### PR TITLE
feat: forge + cartographer skills, debugging Phase 5 quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ ln -s ~/repos/crucible/skills/* ~/.claude/skills/
 
 | Skill | Description |
 |-------|-------------|
-| **systematic-debugging** | Structured investigation before proposing fixes. Includes investigator, pattern analyst, and synthesis subagent templates. |
+| **systematic-debugging** | Structured investigation before proposing fixes. Includes investigator, pattern analyst, synthesis subagent templates, and post-fix red-team/code-review quality gate. |
+
+### Knowledge & Learning
+
+| Skill | Description |
+|-------|-------------|
+| **forge** | Self-improving retrospective system. Post-task retrospectives classify deviations and extract lessons. Pre-task feed-forward surfaces relevant warnings. Periodic mutation analysis proposes concrete skill edits for human review. |
+| **cartographer** | Living architectural map that accumulates across sessions. Records codebase structure, conventions, and landmines after exploration. Surfaces structural context before tasks. Loads module-specific knowledge into subagent prompts. |
 
 ### Meta
 
@@ -64,12 +71,14 @@ ln -s ~/repos/crucible/skills/* ~/.claude/skills/
 
 The **build** skill is the main entry point for feature development. It chains through four phases:
 
-1. **Brainstorm** (interactive) — Refine the idea with the user, produce a design doc
+1. **Brainstorm** (interactive) — Refine the idea with the user, produce a design doc. Forge feed-forward and Cartographer consult run at start.
 2. **Innovate + Red-Team Design** (autonomous) — Creative enhancement, then adversarial review of the design (iterative until clean)
 3. **Plan** (autonomous) — Write implementation plan, review iteratively, innovate, then red-team iteratively
-4. **Execute** (autonomous, team-based) — Dispatch implementers per task, iterative code review per task
+4. **Execute** (autonomous, team-based) — Dispatch implementers per task, iterative code review per task. Cartographer loads module context into subagent prompts.
 5. **Red-Team Implementation** (autonomous) — Adversarial review of the complete implementation (iterative until clean)
-6. **Complete** — Full test suite, comprehensive code review, branch completion options
+6. **Complete** — Full test suite, comprehensive code review, Forge retrospective, Cartographer recording, branch completion options
+
+The **forge** and **cartographer** skills are recommended (not required) knowledge accelerators that integrate across the pipeline. Forge learns about agent behavior (process wisdom), Cartographer learns about the codebase (domain wisdom). Both accumulate across sessions.
 
 Individual skills can also be used standalone (e.g., `crucible:test-driven-development` for any implementation work, `crucible:systematic-debugging` for any bug).
 
@@ -86,3 +95,6 @@ Forked from [obra/superpowers](https://github.com/obra/superpowers) with modific
 - Standalone red-team skill with iterative adversarial review
 - Standalone innovate skill for creative enhancement before red-teaming
 - executing-plans skill ported from superpowers with iterative review loops
+- Forge skill for post-task retrospectives, pre-task feed-forward, and skill mutation proposals
+- Cartographer skill for persistent codebase mapping across sessions
+- Systematic debugging Phase 5: post-fix red-team and code review quality gate

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -79,8 +79,14 @@ Phase 3: Orchestrator forms hypothesis (no subagent -- lightweight decision-maki
 Phase 4: Implementation agent (TDD: failing test, fix, verify)
     |
     v
-Orchestrator: Verify fix -> Success? Done. Failed? Cleanup, log, loop back.
+Orchestrator: Verify fix -> Success? Phase 5. Failed? Cleanup, log, loop back.
     -> 3 failures? Escalate to user.
+    |
+    v
+Phase 5: Red-team the fix (crucible:red-team) + Code review (crucible:requesting-code-review)
+    |
+    v
+Done.
 ```
 
 ---
@@ -209,13 +215,34 @@ Dispatch a single Implementation agent that receives:
 
 ---
 
+### Phase 5: Red-Team and Code Review (Post-Fix Quality Gate)
+
+After Phase 4 succeeds (fix works, tests pass, no regressions), the orchestrator runs two quality gates before declaring done:
+
+**Step 1: Red-team the fix** — Invoke `crucible:red-team` against the changed code. The red-team skill dispatches a fresh Devil's Advocate to adversarially review the fix for:
+- Edge cases the fix doesn't handle
+- New failure modes introduced by the fix
+- Assumptions that could break under different conditions
+- Regression risks not covered by the test
+
+If red-teaming finds Fatal or Significant issues, dispatch a fix agent to address them, then re-run red-team per the standard red-team loop. Do NOT skip this — a fix that introduces new risks is not done.
+
+**Step 2: Code review** — After red-teaming passes clean, invoke `crucible:requesting-code-review` against the full diff (from before debugging started to HEAD). The code reviewer checks implementation quality, test coverage, and adherence to project conventions.
+
+If code review finds Critical or Important issues, fix them and re-review per the standard code review loop.
+
+**Only after both gates pass clean is the debugging workflow complete.**
+
+---
+
 ### Loop-back, Cleanup, and Escalation
 
 After the Implementation agent reports back, the orchestrator evaluates:
 
-**Fix works, no regressions** -- Done. Log the result in the hypothesis log. Use `crucible:verification-before-completion` to confirm. Then:
+**Fix works, no regressions** -- Log the result in the hypothesis log. Use `crucible:verification-before-completion` to confirm. Then:
 - **RECOMMENDED:** Use crucible:forge (retrospective mode) — capture the debugging journey and lessons learned
 - **RECOMMENDED:** Use crucible:cartographer (record mode) — persist any new codebase knowledge discovered during investigation
+- Proceed to Phase 5.
 
 **Fix works but introduces regressions** -- Start a new investigation cycle targeting the regressions. The original fix stays; the regressions are a new bug.
 
@@ -252,6 +279,7 @@ This is NOT a failed hypothesis -- this is a wrong architecture. Discuss with yo
 | **2. Pattern** | 1 subagent (skippable) | Find working examples, compare exhaustively | Differences identified |
 | **3. Hypothesis** | Orchestrator (no subagent) | Form hypothesis, check log | Specific testable hypothesis |
 | **4. Implementation** | 1 subagent | TDD fix cycle | Bug resolved, tests pass |
+| **5. Quality Gate** | Red-team + code review | Adversarial review, quality check | Both pass clean |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Forge skill** — Self-improving retrospective system with three modes: post-task retrospective (classifies deviations, extracts lessons), pre-task feed-forward (surfaces relevant warnings), and periodic mutation proposals (concrete skill edits for human review). Includes Sonnet subagent templates for retrospective and feed-forward, Opus template for mutation analysis.
- **Cartographer skill** — Living architectural map that accumulates across sessions. Records codebase structure, conventions, and landmines after exploration. Surfaces structural context before tasks. Loads module-specific knowledge into subagent prompts so they don't re-discover codebase structure.
- **Systematic debugging Phase 5** — Merges local Phase 5 (post-fix red-team + code review quality gate) with upstream forge/cartographer integration points. After a fix passes Phase 4, the orchestrator now runs red-team and code review before declaring done.
- **README updated** — New "Knowledge & Learning" section documenting forge and cartographer. Updated "How It Works" to show where forge/cartographer integrate in the build pipeline. Updated Origin section.

Both forge and cartographer are **recommended, not required** — knowledge accelerators that integrate across the pipeline (build, executing-plans, systematic-debugging, brainstorming, finishing-a-development-branch).

## Test plan

- [x] Verify forge and cartographer SKILL.md files render correctly on GitHub
- [x] Verify systematic-debugging flow diagram shows Phase 5 correctly
- [x] Verify Quick Reference table includes Phase 5 row
- [x] Verify README skill table, How It Works, and Origin sections are accurate
- [x] Symlink new skills and confirm they appear in Claude Code skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)