### PR TITLE
feat: feature-level TDD with acceptance tests

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -32,7 +32,21 @@ After the user approves the design and before starting Phase 2:
 1. **Innovate:** Dispatch `crucible:innovate` on the design doc. Plan Writer incorporates the proposal.
 2. **Red-team:** Dispatch `crucible:red-team` on the (potentially updated) design doc. Iterates until clean or stagnation.
 3. If the red team requires changes, the Plan Writer updates the design doc and re-commits.
-4. Design doc is now finalized — proceed to Phase 2.
+4. Design doc is now finalized — proceed to acceptance tests.
+
+### Step 3: Generate Acceptance Tests (RED)
+
+Before planning, define "done" with executable tests:
+
+1. Dispatch an **Acceptance Test Writer** subagent (Opus) using `./acceptance-test-writer-prompt.md`
+   - Input: finalized design doc (especially acceptance criteria)
+   - Output: integration-level test file(s) that verify feature behavior end-to-end
+2. Run the acceptance tests — verify they **FAIL** (the feature doesn't exist yet)
+   - If tests pass: something is wrong — investigate before proceeding
+   - If tests error (won't compile): this is expected in typed languages — note which tests exist and what they verify. They become the first implementation task.
+3. Commit: `test: add acceptance tests for [feature] (RED)`
+
+These tests define the feature-level RED-GREEN cycle that wraps the entire pipeline. The pipeline is done when these tests pass.
 
 ## Phase 2: Plan (Autonomous)
 
@@ -40,8 +54,9 @@ After the user approves the design and before starting Phase 2:
 
 Dispatch a **Plan Writer** subagent (Opus):
 
-- Read the design doc produced in Phase 1
+- Read the design doc produced in Phase 1 and the acceptance tests from Step 3
 - Write an implementation plan following the `crucible:writing-plans` format
+- If acceptance tests couldn't compile (typed language), Task 1 should create the interfaces/stubs needed for them to compile and fail correctly
 - Include per-task metadata: Files (with count), Complexity (Low/Medium/High), Dependencies
 - Save to `docs/plans/YYYY-MM-DD-<topic>-implementation-plan.md`
 - Plan tasks should be scoped to 2-3 per subagent, ~10 files max (context budget awareness)
@@ -173,14 +188,17 @@ For plans with 10+ tasks, at ~50% completion or after a major subsystem:
 ## Phase 4: Completion
 
 After all tasks complete:
-1. Run full test suite
-2. **REQUIRED SUB-SKILL:** Use crucible:requesting-code-review on full implementation (iterative until clean)
-3. **REQUIRED SUB-SKILL:** Use crucible:red-team on full implementation (iterative until clean)
-4. **RECOMMENDED SUB-SKILL:** Use crucible:forge (retrospective mode) — capture what happened vs what was planned
-5. **RECOMMENDED SUB-SKILL:** Use crucible:cartographer (record mode) — persist any new codebase knowledge discovered during build
-6. Compile summary: what was built, tests passing, review findings addressed, concerns
-7. Report to user
-8. **REQUIRED SUB-SKILL:** Use crucible:finishing-a-development-branch
+1. Run acceptance tests from Phase 1 Step 3 — verify they **PASS** (GREEN)
+   - If any fail: implementation is incomplete. Identify what's missing, dispatch implementer to fix, re-run.
+   - If all pass: feature is verifiably done. Proceed.
+2. Run full test suite (unit + integration)
+3. **REQUIRED SUB-SKILL:** Use crucible:requesting-code-review on full implementation (iterative until clean)
+4. **REQUIRED SUB-SKILL:** Use crucible:red-team on full implementation (iterative until clean)
+5. **RECOMMENDED SUB-SKILL:** Use crucible:forge (retrospective mode) — capture what happened vs what was planned
+6. **RECOMMENDED SUB-SKILL:** Use crucible:cartographer (record mode) — persist any new codebase knowledge discovered during build
+7. Compile summary: what was built, acceptance tests passing, review findings addressed, concerns
+8. Report to user
+9. **REQUIRED SUB-SKILL:** Use crucible:finishing-a-development-branch
 
 ## Escalation Triggers (Any Phase)
 
@@ -211,6 +229,7 @@ After all tasks complete:
 
 ## Prompt Templates
 
+- `./acceptance-test-writer-prompt.md` — Phase 1 acceptance test generation
 - `./plan-writer-prompt.md` — Phase 2 plan writer dispatch
 - `./plan-reviewer-prompt.md` — Phase 2 plan reviewer dispatch
 - `./build-implementer-prompt.md` — Phase 3 implementer dispatch

--- a/skills/build/acceptance-test-writer-prompt.md
+++ b/skills/build/acceptance-test-writer-prompt.md
@@ -1,0 +1,56 @@
+# Acceptance Test Writer Prompt Template
+
+Use this template when dispatching an acceptance test writer subagent in Phase 1, Step 3. These tests define "done" at the feature level — the build pipeline starts RED and ends GREEN.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Write acceptance tests for [feature]"
+  prompt: |
+    You are writing acceptance tests for a feature BEFORE it is implemented.
+    These tests define what "done" looks like. They will fail now (the feature
+    doesn't exist) and pass when the build pipeline finishes.
+
+    ## Design Document
+
+    [FULL TEXT of the finalized design doc — paste it here]
+
+    ## Project Conventions
+
+    [Test framework, test location, naming conventions, DI framework, etc.]
+
+    ## Your Job
+
+    Write integration-level tests that verify the feature works end-to-end.
+    These are NOT unit tests — they test feature BEHAVIOR from the outside.
+
+    **What to test:**
+    - Each acceptance criterion from the design doc becomes one or more tests
+    - Multi-system interactions (the seams between components)
+    - User-facing behavior (what the user would observe)
+    - Key failure modes mentioned in the design
+
+    **What NOT to test:**
+    - Internal implementation details (those get unit-tested during implementation)
+    - How the code is structured (that's an implementation decision)
+    - Every edge case (unit tests handle those — acceptance tests verify the feature)
+
+    **Test quality:**
+    - Test names describe the feature behavior, not the implementation
+      - Good: `Player_UsesStealthTalent_BecomesUntargetable`
+      - Bad: `StealthManager_SetStealthFlag_UpdatesTargetingList`
+    - Use real components where possible, not mocks
+    - Each test should be independent and deterministic
+    - Follow project test conventions
+
+    **For typed languages (C#, Java, Go, etc.):**
+    - Tests may not compile because the types don't exist yet — this is expected
+    - Write them as if the interfaces exist, using the names from the design doc
+    - The plan's first task will create stubs so these tests compile and fail
+    - Include a comment at the top: "// These tests will not compile until [types] are created"
+
+    ## Output
+
+    - Test file(s) with all acceptance tests
+    - Brief summary: what each test verifies and which acceptance criterion it maps to
+    - Note any acceptance criteria that can't be tested automatically (need manual verification)
+```

--- a/skills/build/plan-writer-prompt.md
+++ b/skills/build/plan-writer-prompt.md
@@ -12,6 +12,10 @@ Task tool (general-purpose, model: opus):
 
     [FULL TEXT of the design doc — paste it here, don't make the subagent read the file]
 
+    ## Acceptance Tests
+
+    [FULL TEXT or summary of acceptance tests generated from the design. These define "done" at the feature level. If tests couldn't compile (typed language), Task 1 of your plan should create the interfaces/stubs needed for them to compile and fail correctly.]
+
     ## Plan Format Requirements
 
     **REQUIRED SUB-SKILL:** Use crucible:writing-plans — follow its format exactly.


### PR DESCRIPTION
## Summary
- The build pipeline now wraps in a feature-level RED-GREEN cycle: acceptance tests are generated from design criteria before planning (RED), and verified after all tasks complete (GREEN)
- Applies TDD's own iron law to the pipeline itself — no implementation without a failing test first, at both the code AND feature level
- Directly produces the integration tests that were identified as a coverage gap

## Changes
- **build/SKILL.md** — Phase 1 Step 3 (acceptance test generation), Phase 4 Step 1 (acceptance test verification), plan writer awareness, prompt template list, fix step numbering
- **build/acceptance-test-writer-prompt.md** — new prompt template for generating integration-level acceptance tests from design criteria
- **build/plan-writer-prompt.md** — acceptance tests section added, Task 1 stub guidance for typed languages

## How it works
```
Design → Acceptance Tests (RED) → Plan → Implement (unit TDD) → Acceptance Tests (GREEN) → Review → Done
```

For typed languages (C#, Go, etc.) where tests can't compile without the types existing, the tests are noted and the plan's Task 1 creates stubs so they compile and fail correctly.

## Test plan
- [ ] Run a build pipeline and verify acceptance tests are generated after design
- [ ] Verify acceptance tests fail before implementation
- [ ] Verify acceptance tests pass after implementation completes
- [ ] Verify plan writer references acceptance tests and creates stub task for typed languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)