### PR TITLE
Add test gap writer to debugging Phase 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ln -s ~/repos/crucible/skills/* ~/.claude/skills/
 
 | Skill | Description |
 |-------|-------------|
-| **debugging** | Orchestrated debugging with Phase 3.5 hypothesis red-teaming, domain detection, and strategic context preservation. Includes investigator, pattern analyst, synthesis subagent templates, and post-fix quality gate. |
+| **debugging** | Orchestrated debugging with Phase 3.5 hypothesis red-teaming, domain detection, strategic context preservation, and post-fix quality gate with test gap writer. Includes investigator, pattern analyst, and synthesis subagent templates. |
 
 ### Knowledge & Learning
 

--- a/docs/plans/2026-03-07-quality-gates-and-skill-overhaul-design.md
+++ b/docs/plans/2026-03-07-quality-gates-and-skill-overhaul-design.md
@@ -121,19 +121,25 @@ If the agent can't categorize a removal into one of these buckets, it flags it i
 Implementer builds + tests -> De-sloppify cleanup -> Pass 1: Code Review -> ...
 ```
 
-### Test Gap Writer (Build Phase 3 Addition)
+### Test Gap Writer (Build Phase 3 + Debugging Phase 5)
 
-After the Pass 2 test reviewer identifies coverage gaps, a Test Gap Writer agent writes tests for behaviors discovered during implementation that weren't in the original test plan. This complements de-sloppify — de-sloppify removes unnecessary tests, the test gap writer adds necessary ones the reviewer flagged as missing.
+After reviewers identify coverage gaps, a Test Gap Writer agent writes tests for behaviors discovered during implementation/fixing that weren't in the original test plan. This complements de-sloppify — de-sloppify removes unnecessary tests, the test gap writer adds necessary ones the reviewer flagged as missing.
 
+**In build (Phase 3):**
 ```
 ... -> Pass 2: Test Review -> Implementer fixes -> Test Gap Writer -> Task complete
+```
+
+**In debugging (Phase 5):**
+```
+... -> Red-team fix -> Code review -> Test Gap Writer -> Done
 ```
 
 The test gap writer:
 - Only writes tests for gaps the reviewer specifically identified (no scope creep)
 - Tests should PASS immediately since the behavior already exists
-- If a test fails, it reveals genuinely missing implementation — flagged for the implementer
-- Skipped when the test reviewer reports zero gaps
+- If a test fails, it reveals genuinely missing implementation/fix coverage — flagged for the implementer
+- Skipped when reviewers report zero gaps
 
 ## 4. Skill Stocktake (New)
 

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -82,6 +82,7 @@ All investigation and implementation is delegated to subagents via the Agent too
 | Phase 4 | Implementation | Opus | TDD + root cause fix |
 | Phase 5 | Red-team | Opus | Adversarial analysis |
 | Phase 5 | Code review | Opus or Sonnet | Lead decides by fix complexity |
+| Phase 5 | Test gap writer | Opus | Test authoring requires reasoning |
 
 ### Workflow Overview
 
@@ -125,6 +126,9 @@ Orchestrator: Verify fix -> Success? Phase 5. Failed? Cleanup, log, loop back.
     |
     v
 Phase 5: Red-team the fix (crucible:red-team) + Code review (crucible:code-review)
+    |
+    v
+Test Gap Writer (if reviews flagged missing coverage)
     |
     v
 Done.
@@ -331,7 +335,9 @@ If red-teaming finds Fatal or Significant issues, dispatch a fix agent to addres
 
 If code review finds Critical or Important issues, fix them and re-review per the standard code review loop.
 
-**Only after both gates pass clean is the debugging workflow complete.**
+**Step 3: Test gap writer** — If the code reviewer or red-teamer identified missing test coverage for the fix, dispatch a Test Gap Writer agent (Opus) using `./test-gap-writer-prompt.md`. The agent writes tests only for gaps specifically flagged in the review — no scope creep. Tests should PASS immediately since the behavior already exists from the fix. If a test fails, it reveals genuinely missing fix coverage — flag for the implementer. Skipped when reviews report zero coverage gaps.
+
+**Only after all gates pass clean (and any test gaps are filled) is the debugging workflow complete.**
 
 ### Session Metrics
 
@@ -431,6 +437,7 @@ This is NOT a failed hypothesis -- this is a wrong architecture. Discuss with yo
 | **3.5 Red-Team** | Quality gate (on hypothesis) | Challenge hypothesis completeness | Hypothesis survives or is reformed |
 | **4. Implementation** | 1 subagent (Opus) | TDD fix cycle with evidence log | Bug resolved, tests pass, TDD log |
 | **5. Quality Gate** | Red-team + code review | Adversarial review, quality check | Both pass clean |
+| **5b. Test Gaps** | Test gap writer (Opus, conditional) | Write tests for reviewer-flagged gaps | All gap tests pass |
 
 ---
 
@@ -514,6 +521,7 @@ If systematic investigation reveals issue is truly environmental, timing-depende
 - **`./synthesis-prompt.md`** -- Synthesis agent prompt
 - **`./pattern-analyst-prompt.md`** -- Phase 2 pattern analysis agent prompt
 - **`./implementer-prompt.md`** -- Phase 4 implementation agent prompt
+- **`./test-gap-writer-prompt.md`** -- Phase 5 test gap writer prompt (when reviews flag missing coverage)
 
 **Supporting techniques** (available in this directory):
 - **`root-cause-tracing.md`** -- Trace bugs backward through call stack to find original trigger

--- a/skills/debugging/test-gap-writer-prompt.md
+++ b/skills/debugging/test-gap-writer-prompt.md
@@ -1,0 +1,72 @@
+# Test Gap Writer Prompt Template (Debugging)
+
+Use this template when dispatching a test gap writer after Phase 5 (red-team + code review) identifies missing test coverage for a fix.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Write tests for coverage gaps in debugging fix"
+  prompt: |
+    You are a test writer. Your job is to write tests for behaviors related to the bug fix that aren't covered by the existing test suite.
+
+    ## Review Findings
+
+    [PASTE: The red-team and/or code reviewer's reports, specifically any "Missing coverage", "Edge cases untested", or "Regression risks not covered by test" sections]
+
+    ## Fix Context
+
+    [PASTE: The implementer's changes — git diff from before debugging started to HEAD]
+
+    ## Bug Context
+
+    [PASTE: Original bug description, root cause hypothesis, and hypothesis log]
+
+    ## Project Test Conventions
+
+    [PASTE: Project test conventions from CLAUDE.md or cartographer — naming patterns, test framework, AAA pattern, etc.]
+
+    ## Your Job
+
+    For each coverage gap identified by the reviewers, write a focused test that:
+
+    1. **Tests the behavior, not the implementation** — Assert on observable outcomes, not internal state
+    2. **Follows project conventions** — Match existing test naming, patterns, and framework usage
+    3. **Is independent** — Each test runs in isolation, no shared mutable state
+    4. **Documents the "why"** — Add a brief comment explaining what bug scenario this guards against
+
+    ## Process
+
+    1. Read the reviewer gap analysis (from both red-team and code review)
+    2. For each identified gap:
+       a. Write the test (RED — should fail if the fix didn't exist)
+       b. Run it — verify it PASSES (the fix already exists)
+       c. If it fails: the gap is real but the fix doesn't fully cover it. Flag this for the implementer.
+    3. Group tests logically — add to existing test files where appropriate, create new files only when necessary
+    4. Run the full test suite to ensure no regressions
+
+    ## What You Must NOT Do
+
+    - Write tests for behaviors the reviewers didn't flag (that's scope creep)
+    - Refactor existing tests (that's not your job)
+    - Modify implementation code (only write tests)
+    - Write tests that verify language/framework behavior rather than the fix
+
+    ## Report Format
+
+    ```
+    TEST GAP REPORT (DEBUGGING FIX)
+    ================================
+
+    Bug: [brief description]
+    Root cause: [hypothesis that was confirmed]
+
+    Tests written:
+    - [test_file:test_name] — Covers: [gap description from reviewer]
+    - [test_file:test_name] — Covers: [gap description from reviewer]
+
+    Gaps that revealed incomplete fix:
+    - [gap description] — Test fails because [fix doesn't cover this case]. Flagged for implementer.
+
+    Test suite: PASS (N tests, 0 failures)
+    New tests: X
+    ```
+```


### PR DESCRIPTION
## Summary

- Add **Step 3: Test gap writer** to debugging Phase 5 — after red-team and code review identify missing test coverage for a fix, a test gap writer agent fills those gaps
- Create `skills/debugging/test-gap-writer-prompt.md` — debugging-specific variant that includes bug context and hypothesis log
- Update workflow diagram, model selection table, quick reference table, and prompt templates list
- Update README debugging description
- Update design doc to reflect test gap writer covers both build Phase 3 and debugging Phase 5

Closes #8

## Test plan

- [ ] Verify debugging SKILL.md includes Step 3 test gap writer in Phase 5
- [ ] Verify workflow diagram shows Test Gap Writer step before Done
- [ ] Verify test-gap-writer-prompt.md exists with debugging-specific context (bug context, hypothesis log)
- [ ] Verify README debugging description mentions test gap writer
- [ ] Verify design doc section header updated to "Build Phase 3 + Debugging Phase 5"

🤖 Generated with [Claude Code](https://claude.com/claude-code)