### PR TITLE
feat: investigated design questions + red-team targeted fixes

### DIFF
--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -7,76 +7,146 @@ description: "You MUST use this before any creative work - creating features, bu
 
 ## Overview
 
-Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
+Turn ideas into fully formed designs through investigated, collaborative dialogue.
 
-Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design in small sections (200-300 words), checking after each section whether it looks right so far.
+Every significant design question is backed by parallel investigation agents that research the codebase, explore approaches, and assess impact BEFORE the question reaches the user. Questions arrive informed, not naive.
 
 ## The Process
 
-**Understanding the idea:**
-- **RECOMMENDED:** Use crucible:forge (feed-forward mode) — consult past lessons before starting
-- **RECOMMENDED:** Use crucible:cartographer (consult mode) — review codebase map for structural awareness
-- Check out the current project state first (files, docs, recent commits)
-- Ask questions one at a time to refine the idea
-- Prefer multiple choice questions when possible, but open-ended is fine too
-- Only one question per message - if a topic needs more exploration, break it into multiple questions
-- Focus on understanding: purpose, constraints, success criteria
+### Phase 1: Context Gathering
 
-**Exploring approaches:**
-- Propose 2-3 different approaches with trade-offs
-- Present options conversationally with your recommendation and reasoning
-- Lead with your recommended option and explain why
+- **RECOMMENDED:** Use crucible:forge (feed-forward mode) — consult past lessons
+- **RECOMMENDED:** Use crucible:cartographer (consult mode) — review codebase map
+- Check current project state (files, docs, recent commits)
+- Understand the user's initial idea through open conversation
 
-**Presenting the design:**
-- Once you believe you understand what you're building, present the design
-- Break it into sections of 200-300 words
-- Ask after each section whether it looks right so far
+### Phase 2: Investigated Questions
+
+For each design dimension that needs a decision, follow this loop:
+
+#### Step 1: Identify the Design Dimension
+
+Before asking anything, name the decision needed (e.g., "persistence strategy," "component communication pattern," "UI architecture").
+
+#### Step 2: State Your Hypothesis
+
+Write down what you EXPECT to find before dispatching agents. After agents return, compare. **Surprises get highlighted** — they're the most valuable insights.
+
+#### Step 3: Triage Depth
+
+| Tier | When | Effort |
+|------|------|--------|
+| **Deep dive** | Architectural decisions, integration points, pattern choices, anything constraining future work | 3 parallel agents + challenger |
+| **Quick scan** | Implementation approach within decided architecture, which existing pattern to follow | Single codebase scout |
+| **Direct ask** | Naming, UI placement, priority ordering — no technical implications | Ask directly |
+
+#### Step 4: Dispatch Investigation
+
+**Deep dive** — spawn three agents in parallel (templates in `investigation-prompts.md`):
+
+1. **Codebase Scout** — What does the codebase already do in this area? Existing patterns, conventions, constraints.
+2. **Domain Researcher** — What are the viable approaches? Trade-offs, best practices, precedents.
+3. **Impact Analyst** — What existing systems does this decision affect? What could break?
+
+Pass the **cascading context** (all prior decisions and rationale) to each agent.
+
+**Quick scan** — dispatch only the Codebase Scout.
+
+#### Step 5: Synthesize
+
+After agents return:
+
+1. **Compare to hypothesis** — note surprises
+2. **Check for auto-resolution** — if only one viable path exists, inform the user rather than asking: "Investigation showed X is the only viable approach because [reasons]. Moving on." User can interrupt if they disagree.
+3. **Check for question redirection** — if agents found the wrong question is being asked, redirect: "Was going to ask about X, but investigation revealed the real decision is Y."
+4. **Synthesize into 2-3 informed options** with a recommended choice
+
+#### Step 6: Challenge (Deep Dive Only)
+
+Dispatch a **Challenger** agent (template in `investigation-prompts.md`):
+- Attacks the recommendation's assumptions
+- Checks for conflicts with prior decisions
+- Identifies blind spots in the investigation
+- Brief output — this is lightweight, not a full red-team
+
+#### Step 7: Present to User
+
+```
+### [Design Dimension]
+
+**Hypothesis:** [what you expected]
+**Surprises:** [anything that contradicted expectations — highlight these]
+
+**Investigation:**
+- **Codebase:** [2-3 sentence summary]
+- **Approaches:** [2-3 sentence summary of viable options]
+- **Impact:** [2-3 sentence summary of affected systems]
+
+**Challenge:** [1-2 sentence summary of what the challenger raised]
+
+**Recommendation:** [your recommended option and why]
+
+**Question:** [the refined question, prefer multiple choice]
+```
+
+For auto-resolved questions:
+
+```
+### [Design Dimension] — Auto-Resolved
+
+[Why only one viable path exists. Decision made.]
+*Speak up if you disagree.*
+```
+
+#### Step 8: Cascade
+
+After the user answers, add the decision and rationale to the running context. All subsequent agents receive this.
+
+### Phase 3: Design Presentation
+
+Once key dimensions are decided:
+- Present design in sections of 200-300 words
+- Ask after each section whether it looks right
 - Cover: architecture, components, data flow, error handling, testing
-- Be ready to go back and clarify if something doesn't make sense
+- Be ready to go back and re-investigate if something doesn't make sense
 
 ## Before Saving the Design
 
-Scan the design for gaps. Not every item applies to every feature — use judgment — but actively check:
+Scan for gaps (use judgment — not every item applies):
 
-- [ ] **Acceptance criteria** — Can someone verify "done" without asking you? Are conditions concrete and testable?
-- [ ] **Testing strategy** — What needs unit tests vs integration tests? What level of testing covers each behavior?
-- [ ] **Integration impact** — What existing systems does this touch? Are those touchpoints addressed in the design?
-- [ ] **Failure modes** — What happens when things go wrong? Invalid data, missing dependencies, unexpected state?
-- [ ] **Edge cases** — What are the boundary conditions? Empty collections, max values, concurrent access?
+- [ ] **Acceptance criteria** — Concrete and testable?
+- [ ] **Testing strategy** — Unit vs integration coverage?
+- [ ] **Integration impact** — Touchpoints addressed?
+- [ ] **Failure modes** — Invalid data, missing dependencies, unexpected state?
+- [ ] **Edge cases** — Boundary conditions?
 
-If a critical item is missing, raise it with the user before saving — don't silently skip it.
+Raise critical gaps with the user before saving.
 
 ## After the Design
 
-**Documentation:**
-- Write the validated design to `docs/plans/YYYY-MM-DD-<topic>-design.md`
-- Use elements-of-style:writing-clearly-and-concisely skill if available
-- Commit the design document to git
+- Write to `docs/plans/YYYY-MM-DD-<topic>-design.md`
+- Commit the design document
 
 **Implementation (if continuing):**
 - Ask: "Ready to set up for implementation?"
-- Use crucible:worktree to create isolated workspace
-- Use crucible:planning to create detailed implementation plan
+- Use crucible:worktree, then crucible:planning
 
 ## Quality Gate
 
 This skill produces **design docs**. When used standalone, invoke `crucible:quality-gate` after the design document is saved and committed. When used as a sub-skill of build, the parent orchestrator handles gating.
 
-**Standalone invocation:**
-1. Design doc is saved and committed
-2. Invoke `crucible:quality-gate` with artifact type "design"
-3. Address any findings, re-commit
-4. Quality gate iterates until clean or escalates after 3 rounds
-
 ## Key Principles
 
-- **One question at a time** - Don't overwhelm with multiple questions
-- **Multiple choice preferred** - Easier to answer than open-ended when possible
-- **YAGNI ruthlessly** - Remove unnecessary features from all designs
-- **Explore alternatives** - Always propose 2-3 approaches before settling
-- **Incremental validation** - Present design in sections, validate each
-- **Be flexible** - Go back and clarify when something doesn't make sense
+- **Investigated questions** — Never ask a significant question without research backing
+- **One question at a time** — Don't overwhelm
+- **Auto-resolve when possible** — Don't waste user attention on decided questions
+- **Hypothesis-first** — State expectations, highlight surprises
+- **Cascading context** — Each decision informs subsequent investigations
+- **YAGNI ruthlessly** — Remove unnecessary features
+- **Depth-appropriate effort** — Not every question needs deep investigation
 
 ## Integration
 
 **Related skills:** crucible:planning, crucible:worktree, crucible:forge, crucible:cartographer, crucible:quality-gate
+
+**Prompt templates:** `design/investigation-prompts.md`

--- a/skills/design/investigation-prompts.md
+++ b/skills/design/investigation-prompts.md
@@ -1,0 +1,217 @@
+# Design Investigation Prompt Templates
+
+Templates for dispatching investigation agents during the design skill's Phase 2 (Investigated Questions).
+
+## Codebase Scout
+
+```
+Agent tool (subagent_type: Explore, thoroughness: "very thorough"):
+  description: "Codebase scout: [design dimension]"
+  prompt: |
+    You are a Codebase Scout investigating how this project handles [DESIGN DIMENSION].
+
+    ## What You're Investigating
+
+    [1-2 sentence description of the design dimension being explored]
+
+    ## Decisions Made So Far
+
+    [CASCADING CONTEXT — all prior design decisions and their rationale]
+
+    ## Your Job
+
+    Search the codebase for:
+
+    1. **Existing patterns** — How does the project currently handle this or similar concerns? What conventions are established?
+    2. **Constraints** — What architectural decisions, dependencies, or framework requirements limit the options?
+    3. **Touchpoints** — What files, systems, or interfaces would a new feature in this area need to interact with?
+    4. **Precedents** — Has this problem been solved elsewhere in the codebase? What approach was used?
+
+    ## Output Format
+
+    ### Existing Patterns
+    [What the codebase already does, with file paths and line references]
+
+    ### Constraints
+    [What limits the options — framework requirements, existing contracts, dependencies]
+
+    ### Key Touchpoints
+    [Files and systems that would be involved]
+
+    ### Precedents
+    [Similar problems already solved in the codebase, if any]
+
+    ### Summary
+    [2-3 sentence synthesis: what does the codebase tell us about how to approach this?]
+```
+
+## Domain Researcher
+
+```
+Agent tool (subagent_type: general-purpose):
+  description: "Domain research: [design dimension]"
+  prompt: |
+    You are a Domain Researcher exploring approaches for [DESIGN DIMENSION] in the context of a [PROJECT DESCRIPTION].
+
+    ## What You're Researching
+
+    [1-2 sentence description of the design dimension]
+
+    ## Project Context
+
+    [Tech stack, architecture style, key constraints]
+
+    ## Decisions Made So Far
+
+    [CASCADING CONTEXT — all prior design decisions and their rationale]
+
+    ## Your Job
+
+    Research and present 2-4 viable approaches for this design dimension:
+
+    1. **For each approach:**
+       - Name and brief description
+       - How it works in this context
+       - Advantages (specific to this project, not generic)
+       - Disadvantages (specific to this project, not generic)
+       - Complexity cost (what it adds to the codebase)
+
+    2. **Compare approaches** on the dimensions that matter most for this decision
+
+    3. **Recommend one** with clear reasoning — lead with your recommendation, don't bury it
+
+    ## Rules
+
+    - Be specific to this project's constraints, not generic
+    - If one approach is clearly dominant, say so — don't manufacture false balance
+    - If the decision depends on information you don't have, say what information is needed
+    - Consider prior decisions — don't recommend approaches that conflict with them
+
+    ## Output Format
+
+    ### Recommended Approach: [Name]
+    [Why this is the best fit — 3-5 sentences]
+
+    ### All Approaches Compared
+
+    | Approach | Fit | Complexity | Risk |
+    |----------|-----|-----------|------|
+    | ... | ... | ... | ... |
+
+    ### Approach Details
+    [Each approach with advantages, disadvantages, complexity cost]
+
+    ### Open Questions
+    [What information would change the recommendation, if any]
+```
+
+## Impact Analyst
+
+```
+Agent tool (subagent_type: Explore, thoroughness: "very thorough"):
+  description: "Impact analysis: [design dimension]"
+  prompt: |
+    You are an Impact Analyst assessing how a decision about [DESIGN DIMENSION] would affect existing systems.
+
+    ## What's Being Decided
+
+    [1-2 sentence description of the design dimension]
+
+    ## Likely Approaches Being Considered
+
+    [Brief summary of the approaches the domain researcher is exploring, if known — otherwise describe the general direction]
+
+    ## Decisions Made So Far
+
+    [CASCADING CONTEXT — all prior design decisions and their rationale]
+
+    ## Your Job
+
+    Assess impact across these dimensions:
+
+    1. **Systems affected** — Which existing systems, scripts, or components would need to change or adapt? Be specific — file paths and class names.
+    2. **Integration risk** — Where are the seams? What could break at the boundaries between new and existing code?
+    3. **Data impact** — Does this affect save data, ScriptableObjects, serialized state, or configuration?
+    4. **Test impact** — Which existing tests would need updating? Are there test gaps this decision would expose?
+    5. **Reversibility** — How hard is it to change this decision later? Is this a one-way door or a two-way door?
+
+    ## Output Format
+
+    ### Systems Affected
+    [List with file paths and brief description of required changes]
+
+    ### Integration Risks
+    [Specific risks at system boundaries]
+
+    ### Data Impact
+    [Changes to serialized state, saves, configs — or "None"]
+
+    ### Test Impact
+    [Tests that need updating, coverage gaps exposed]
+
+    ### Reversibility
+    [One-way door / two-way door / partially reversible — with explanation]
+
+    ### Summary
+    [2-3 sentences: overall impact assessment and what to watch for]
+```
+
+## Challenger
+
+```
+Agent tool (subagent_type: general-purpose):
+  description: "Challenge recommendation: [design dimension]"
+  prompt: |
+    You are a Challenger reviewing a design recommendation BEFORE it is presented to the user.
+
+    ## The Design Dimension
+
+    [What decision is being made]
+
+    ## Investigation Findings
+
+    **Codebase Scout found:**
+    [Summary of codebase investigation]
+
+    **Domain Researcher found:**
+    [Summary of domain research and recommended approach]
+
+    **Impact Analyst found:**
+    [Summary of impact analysis]
+
+    ## The Recommendation
+
+    [The synthesized recommendation and its rationale]
+
+    ## Decisions Made So Far
+
+    [CASCADING CONTEXT — all prior design decisions]
+
+    ## Your Job
+
+    This is a LIGHTWEIGHT challenge, not a full red-team. Check for:
+
+    1. **Assumption gaps** — What is the recommendation assuming that hasn't been verified?
+    2. **Investigation blind spots** — What did the investigators NOT look at that they should have?
+    3. **Prior decision conflicts** — Does this recommendation conflict with or undermine any earlier design decisions?
+    4. **Missing options** — Is there a viable approach the domain researcher didn't consider?
+    5. **Risk underestimation** — Is the impact analyst's assessment too optimistic?
+
+    ## Rules
+
+    - Be brief — this is a sanity check, not an exhaustive review
+    - Only raise issues that would change the recommendation or the question asked
+    - If the recommendation is solid, say so in one sentence and stop
+    - Do NOT manufacture concerns to justify your existence
+
+    ## Output Format
+
+    ### Verdict
+    [Solid / Has blind spots / Recommendation should change]
+
+    ### Concerns (if any)
+    [Each concern in 1-2 sentences with what should change]
+
+    ### Suggested Question Refinement (if any)
+    [How the question to the user should be adjusted based on your findings]
+```

--- a/skills/red-team/red-team-prompt.md
+++ b/skills/red-team/red-team-prompt.md
@@ -74,6 +74,7 @@ Task tool (general-purpose, model: opus):
 
     - Every challenge must be SPECIFIC and ACTIONABLE. "This might have issues" is not a challenge. "Task 3 creates MapDefinition but Task 5 assumes it has a field called TransitionPoints which isn't added until Task 7" is a challenge.
     - You must propose what should change, not just what's wrong.
+    - For every Fatal or Significant challenge, propose a **targeted fix** — the smallest concrete change to the artifact that addresses the issue. This grounds criticism in actionable remediation, not just identification.
     - If you can't find Fatal or Significant issues, say so honestly. Don't manufacture problems to justify your existence.
     - You are attacking the PLAN, not the design. The design was approved by the user. If you think the design itself is flawed, flag it as an architectural escalation.
 


### PR DESCRIPTION
## Summary

- **Design skill rewrite:** Every significant design question is now backed by parallel investigation agents (Codebase Scout, Domain Researcher, Impact Analyst) that research the codebase, explore approaches, and assess impact BEFORE the question reaches the user
- **Six new capabilities:** depth triage (deep dive / quick scan / direct ask), hypothesis-first investigation, auto-resolution for decided questions, question redirection when agents find the wrong question, cascading context across decisions, and a lightweight Challenger agent for recommendation validation
- **Red-team improvement:** Devil's Advocate prompt now requires a targeted fix for every Fatal/Significant finding, grounding criticism in actionable remediation

## Context

Emerged from a deep investigation into whether to replace the Devil's Advocate model with a "Rival Architect" model. Four parallel agents (Strengths Advocate, Devil's Advocate, Rival Architect, Implementation Analyst) evaluated the proposal. The investigation revealed that the current Devil's Advocate + Innovate separation is sound, but the design skill's question-asking process was naive. The targeted fix requirement was the single highest-value change to the red-team prompt identified by all four agents.

## Files Changed

- `skills/design/SKILL.md` — Full rewrite with investigated questions framework (Phase 1: Context, Phase 2: Investigated Questions, Phase 3: Design Presentation)
- `skills/design/investigation-prompts.md` — New file with four agent dispatch templates (Codebase Scout, Domain Researcher, Impact Analyst, Challenger)
- `skills/red-team/red-team-prompt.md` — Added targeted fix requirement to Rules of Engagement

## Test plan

- [ ] Run design skill on a real feature to verify investigated questions flow
- [ ] Verify depth triage correctly categorizes architectural vs. simple questions
- [ ] Verify auto-resolution fires when only one viable path exists
- [ ] Verify cascading context passes prior decisions to subsequent agents
- [ ] Verify red-team agents now include targeted fixes in Fatal/Significant findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)