### PR TITLE
feat: add inquisitor skill for cross-component adversarial testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ln -s ~/repos/crucible/skills/* ~/.claude/skills/
 | **worktree** | Create isolated git worktrees for feature work with smart directory selection and safety verification. |
 | **parallel** | Dispatch independent tasks to parallel subagents to work without shared state or sequential dependencies. |
 | **adversarial-tester** | Reads completed implementation and writes up to 5 tests designed to expose unknown failure modes. Targets edge cases, boundary conditions, and runtime behavior the implementer didn't anticipate. |
+| **inquisitor** | Full-feature cross-component adversarial testing. Dispatches 5 parallel dimensions (wiring, integration, edge cases, state/lifecycle, regression) against the complete implementation diff to find bugs that per-task testing misses. |
 
 ### Quality
 
@@ -99,7 +100,7 @@ The **build** skill is the main entry point for feature development. It chains t
 1. **Phase 1: Design** (interactive) — Refine the idea with the user, produce a design doc. Forge feed-forward and Cartographer consult run at start. Design passes through a quality gate (replaces direct red-team).
 2. **Phase 2: Plan** (autonomous) — Write implementation plan, review, then quality gate on the plan (replaces direct red-team). Innovate proposes enhancements before the gate.
 3. **Phase 3: Execute** (autonomous, team-based) — Dispatch implementers per task, de-sloppify cleanup (removes unnecessary code), code review per task, a test gap writer (fills coverage gaps identified by the test reviewer), and an adversarial tester (writes tests designed to break the implementation). Cartographer loads module context into subagent prompts.
-4. **Phase 4: Complete** (autonomous) — Quality gate on the full implementation (replaces direct red-team), session metrics report, full test suite, Forge retrospective, Cartographer recording, branch completion options.
+4. **Phase 4: Complete** (autonomous) — Code review on full implementation, inquisitor (5 parallel adversarial dimensions against the full feature diff), quality gate (replaces direct red-team), session metrics report, full test suite, Forge retrospective, Cartographer recording, branch completion options.
 
 The **forge** and **cartographer** skills are recommended (not required) knowledge accelerators that integrate across the pipeline. Forge learns about agent behavior (process wisdom), Cartographer learns about the codebase (domain wisdom). Both accumulate across sessions.
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -272,18 +272,27 @@ After all tasks complete:
    - If all pass: feature is verifiably done. Proceed.
 2. Run full test suite (unit + integration)
 3. **REQUIRED SUB-SKILL:** Use crucible:code-review on full implementation (iterative until clean)
-4. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on full implementation (artifact type: "code", iterative until clean)
-5. **RECOMMENDED SUB-SKILL:** Use crucible:forge (retrospective mode) — capture what happened vs what was planned
-6. **RECOMMENDED SUB-SKILL:** Use crucible:cartographer (record mode) — persist any new codebase knowledge discovered during build
-7. Compile summary: what was built, acceptance tests passing, review findings addressed, concerns
-8. Report to user
-9. **REQUIRED SUB-SKILL:** Use crucible:finish
+4. **REQUIRED SUB-SKILL:** Use crucible:inquisitor on full implementation (dispatches 5 parallel dimensions against full feature diff)
+   - Input: `git diff <base-sha>..HEAD` where base-sha is the commit before Phase 3 execution began
+   - Runs after code review (obvious issues already fixed) and before quality gate (gate reviews final state)
+   - The inquisitor manages its own fix cycle internally — do not intervene unless it escalates
+   - See `crucible:inquisitor` for full process
+5. **Conditional:** If the inquisitor's fix cycle produced any code changes, re-run crucible:code-review scoped to the inquisitor fix commits only (`git diff <pre-inquisitor-sha>..HEAD`)
+   - This is NOT a full implementation re-review — scope it to only the fixer's changes
+   - Iterative until clean, same as step 3
+   - Skip if the inquisitor reported all PASS (no fixes were needed)
+6. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on full implementation (artifact type: "code", iterative until clean)
+7. **RECOMMENDED SUB-SKILL:** Use crucible:forge (retrospective mode) — capture what happened vs what was planned
+8. **RECOMMENDED SUB-SKILL:** Use crucible:cartographer (record mode) — persist any new codebase knowledge discovered during build
+9. Compile summary: what was built, acceptance tests passing, review findings addressed, inquisitor findings, concerns
+10. Report to user
+11. **REQUIRED SUB-SKILL:** Use crucible:finish
 
 ### Session Metrics
 
 Throughout the pipeline, the orchestrator appends timestamped entries to `/tmp/crucible-metrics-<session-id>.log` on each subagent dispatch and completion.
 
-At completion (before reporting to user, i.e. step 8), read the metrics log and compute:
+At completion (before reporting to user, i.e. step 9), read the metrics log and compute:
 
 ```
 -- Pipeline Complete ----------------------------------------
@@ -354,10 +363,11 @@ Decision types to capture:
 - `./test-gap-writer-prompt.md` — Phase 3 test gap writer dispatch
 - `./architecture-reviewer-prompt.md` — Mid-plan checkpoint
 
-Red-team, innovate, and adversarial tester prompts live in their respective skills:
+Red-team, innovate, adversarial tester, and inquisitor prompts live in their respective skills:
 - `crucible:red-team` — `skills/red-team/red-team-prompt.md`
 - `crucible:innovate` — `skills/innovate/innovate-prompt.md`
 - `crucible:adversarial-tester` — `skills/adversarial-tester/break-it-prompt.md`
+- `crucible:inquisitor` — `skills/inquisitor/inquisitor-prompt.md`
 
 ## Quality Gate Orchestration
 
@@ -369,9 +379,9 @@ Build is the outermost orchestrator and controls all quality gates via `crucible
 |---------------|---------------|----------|
 | Phase 1, Step 2 (after design) | design | Existing `crucible:red-team` on design |
 | Phase 2, Step 3 (after plan review) | plan | Existing `crucible:red-team` on plan |
-| Phase 4, Step 4 (after implementation) | code | Existing `crucible:red-team` on implementation |
+| Phase 4, Step 6 (after inquisitor + conditional re-review) | code | Existing `crucible:red-team` on implementation |
 
-Code review (`crucible:code-review`) remains separate — it serves a different purpose (structured quality check vs. adversarial attack).
+Code review (`crucible:code-review`) and inquisitor (`crucible:inquisitor`) remain separate from the quality gate — code-review does structured quality checks, inquisitor writes cross-component adversarial tests, and the quality gate does adversarial artifact review. All three serve distinct purposes.
 
 ## Integration
 
@@ -381,6 +391,7 @@ Code review (`crucible:code-review`) remains separate — it serves a different 
 - **crucible:quality-gate** — Iterative red-teaming at each quality gate point
 - **crucible:red-team** — Adversarial review engine (invoked by quality-gate)
 - **crucible:innovate** — Creative enhancement before quality gates
+- **crucible:inquisitor** — Full-feature cross-component adversarial testing (Phase 4, after code-review, before quality-gate)
 
 **Recommended sub-skills:**
 - **crucible:forge** — Feed-forward at Phase 1 start, retrospective at Phase 4 completion

--- a/skills/inquisitor/SKILL.md
+++ b/skills/inquisitor/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: inquisitor
+description: "Use when a full feature is assembled and you want to hunt cross-component bugs before final quality gate. Dispatches 5 parallel adversarial dimensions against the complete implementation diff. Triggers on 'inquisitor', 'hunt bugs', 'cross-component test', 'find integration issues', or automatically in build pipeline Phase 4."
+---
+
+# Inquisitor
+
+Hunt cross-component bugs by dispatching 5 parallel adversarial dimensions against the full feature diff. Each dimension writes and runs tests targeting a different class of failure mode that per-task testing misses.
+
+**Announce at start:** "I'm using the inquisitor skill to hunt cross-component bugs across the full implementation."
+
+**Skill type:** Rigid -- follow exactly, no shortcuts.
+
+**Model:** Opus (orchestrating parallel adversarial subagents requires precise coordination)
+
+## Why This Exists
+
+Per-task adversarial testing (Phase 3) sees one task's diff. It catches bugs within each task's scope. But the bugs you find instantly after a big feature lands live in the **seams** -- wiring that's almost right, state that initializes in one task but gets consumed in another, edge cases that only appear when the whole feature is assembled.
+
+The inquisitor sees the FULL diff and attacks the interactions.
+
+## Distinction from Related Skills
+
+| Agent | Question | Output | Scope |
+|-------|----------|--------|-------|
+| Red-team | "What's wrong with this artifact?" | Written findings (Fatal/Significant/Minor) | Attacks designs, plans, code quality |
+| Adversarial Tester | "What runtime behavior breaks?" | Executable tests (per-task) | Single task's changes |
+| **Inquisitor** | "What breaks between components?" | Executable tests (full feature) | Cross-component interactions across all tasks |
+
+## The 5 Dimensions
+
+Each dimension is a parallel subagent with a specific attack lens. All 5 are dispatched simultaneously.
+
+### Dimension 1: Wiring
+
+**Question:** "Is everything actually connected?"
+
+**Looks for:**
+- New classes/components that exist but are never instantiated or registered
+- Missing service registrations (DI container bindings)
+- Missing event subscriptions (published but nobody listens, or listener never subscribed)
+- Interface implementations that aren't bound
+- New entry points (menu items, buttons, routes, commands) that don't trigger the new code
+- Factory methods or builders that don't include new types
+
+**Test style:** Instantiate the system and verify new components are reachable and callable through their intended entry points.
+
+### Dimension 2: Integration
+
+**Question:** "Do the new pieces talk to each other correctly?"
+
+**Looks for:**
+- Data format mismatches between producer and consumer components
+- Type assumption mismatches (producer sends int, consumer expects float)
+- Ordering assumptions (A must happen before B, but nothing enforces it)
+- Missing data transformations between components
+- API contracts that don't match between caller and callee
+- Events published with wrong payload shape or missing fields
+
+**Test style:** Set up 2+ new components and verify data flows correctly end-to-end through the interaction chain.
+
+### Dimension 3: Edge Cases
+
+**Question:** "What happens at the boundaries?"
+
+**Looks for:**
+- Null/empty inputs at every new public API surface
+- Zero and negative values where only positives are expected
+- Maximum values and overflow conditions
+- Empty collections passed to methods expecting non-empty
+- Strings with special characters (empty, whitespace-only, extremely long)
+- Boundary conditions at state transition thresholds
+
+**Test style:** Call new APIs with boundary inputs and verify graceful handling (no crash, correct error, or documented behavior).
+
+### Dimension 4: State & Lifecycle
+
+**Question:** "Is state managed correctly across the feature?"
+
+**Looks for:**
+- Initialization order dependencies (A must init before B, but nothing enforces it)
+- Missing disposal/cleanup (IDisposable, Unsubscribe, RemoveListener, event detachment)
+- Stale references after disposal (use-after-dispose)
+- State mutations that aren't thread-safe when they should be
+- Singleton assumptions that don't hold in the actual runtime
+- State not reset between uses (pooling, recycling, scene transitions)
+
+**Test style:** Exercise lifecycle sequences (create, use, dispose, re-create) and verify correct behavior at each stage.
+
+### Dimension 5: Regression
+
+**Question:** "Did we break anything that used to work?"
+
+**Looks for:**
+- Existing methods whose return values or side effects changed subtly
+- Modified base classes affecting derived class behavior
+- Changed default values, constructor signatures, or parameter ordering
+- Modified event handling order or priority
+- Changed error handling (swallowing exceptions that used to propagate, or vice versa)
+- Moved or renamed things that other code depends on
+
+**Test style:** Exercise existing functionality through paths that touch newly modified code, verifying prior behavior is preserved.
+
+## Process
+
+### Step 1: Determine the Full Feature Diff
+
+Compute the diff covering ALL implementation changes:
+
+- **Pipeline mode:** The build orchestrator provides the base commit SHA. Use `git diff <base-sha>..HEAD`.
+- **Standalone mode:** Use `git merge-base HEAD main` (or the user-specified base branch) to find the diverge point. Use `git diff <merge-base>..HEAD`.
+
+If the diff is empty or contains only non-behavioral files (`.md`, `.json`, `.yaml`, `.uss`, `.uxml`), report "No behavioral changes to investigate" and stop.
+
+### Step 2: Dispatch 5 Parallel Inquisitor Subagents
+
+For each dimension, dispatch a fresh subagent (Opus) using `./inquisitor-prompt.md`:
+
+- Pass the full diff
+- Pass the dimension name and its focus areas (from the dimension definitions above)
+- Pass project test conventions (from CLAUDE.md or cartographer)
+- Pass cartographer module context if available
+- Each subagent identifies 3-5 attack vectors, writes one test per vector, runs them, and reports
+
+**All 5 dimensions are dispatched in parallel.** Do not wait for one to finish before starting another.
+
+Status update format while dispatching:
+> "Inquisitor: dispatching 5 dimensions in parallel — Wiring, Integration, Edge Cases, State & Lifecycle, Regression."
+
+### Step 3: Collect and Aggregate Reports
+
+When all 5 subagents complete, aggregate their reports into a single INQUISITOR REPORT (see Report Format below).
+
+Classify overall results:
+- **All PASS across all dimensions:** Feature is robust. Report results and proceed.
+- **Some FAIL in one or more dimensions:** Weaknesses found. Proceed to fix cycle (Step 4).
+- **All ERROR in a dimension:** Discard that dimension's broken tests. Note in report. Proceed with remaining dimensions.
+
+Status update format:
+> "Inquisitor complete: Wiring 3/3 PASS, Integration 4/4 PASS, Edge Cases 3/5 PASS (2 FAIL), State 4/4 PASS, Regression 3/3 PASS. Dispatching fixes for 2 edge case failures."
+
+### Step 4: Fix Cycle (Only if FAILs Exist)
+
+For each dimension with FAIL results:
+
+1. Dispatch a **Fixer** subagent (Opus) with:
+   - The failing test(s) and their attack vector descriptions
+   - The relevant source files identified in the failure
+   - Fix guidance from the inquisitor's report
+2. Fixer implements the fix and runs ALL tests (including the previously-failing adversarial tests)
+3. If the fix touches **3+ files:** dispatch a lightweight code review before accepting
+4. After fix, re-run ONLY the dimension that had failures to verify
+5. **Max 2 fix attempts per dimension.** If a dimension still has FAILs after 2 attempts, escalate to user with full context.
+
+**Cascading fix detection:** If fixes for one dimension cause failures in another dimension's tests, escalate to user immediately -- this indicates a deeper design issue that automated fixes can't resolve.
+
+Commit passing fixes: `fix: inquisitor [dimension] findings`
+
+### Step 5: Final Report
+
+Output the aggregated INQUISITOR REPORT including fix outcomes. The report must include:
+- Whether any fixes were made (so the build orchestrator knows whether to re-run code review)
+- The pre-inquisitor commit SHA (so the build orchestrator can scope the re-review diff)
+
+## Report Format
+
+```
+## INQUISITOR REPORT
+
+### Summary
+- Dimensions dispatched: 5
+- Total attack vectors tested: N
+- Tests PASSING (robust): N
+- Tests FAILING (weaknesses found): N
+- Tests ERROR (discarded): N
+- Dimensions clean: N/5
+- Fix cycles required: N
+
+### Dimension: Wiring
+#### Attack Vector 1: [Title]
+- **What was tested:** [specific wiring concern]
+- **Likelihood:** High/Medium/Low
+- **Impact:** High/Medium/Low
+- **Test:** `TestClassName.TestMethodName`
+- **Result:** PASS/FAIL
+- **If FAIL -- fix guidance:** [what to change]
+
+[repeat for each attack vector]
+
+### Dimension: Integration
+[same structure]
+
+### Dimension: Edge Cases
+[same structure]
+
+### Dimension: State & Lifecycle
+[same structure]
+
+### Dimension: Regression
+[same structure]
+
+### Fix Outcomes (if applicable)
+- [Dimension]: [N] failures fixed in [N] attempts
+- [Dimension]: [N] failures escalated to user
+
+### Fix Footprint
+- Pre-inquisitor SHA: [commit SHA before any fixes]
+- Files changed by fixes: [N]
+- Code review re-run recommended: YES/NO
+```
+
+## Guardrails
+
+**Inquisitor subagents must NOT:**
+- Modify production code (only the Fixer modifies code)
+- Write more than 5 tests per dimension (25 total max across all dimensions)
+- Refactor or "improve" existing tests
+- Test implementation details -- only observable behavior
+- Duplicate coverage already provided by per-task adversarial tests or test gap writer
+- Attack the same vector from multiple dimensions (if overlap, the more specific dimension owns it)
+
+**The orchestrator must NOT:**
+- Skip dimensions without justification
+- Accept a "no issues found" report without verifying the subagent actually wrote and ran tests
+- Continue past a FAIL without either fixing or escalating
+- Run more than 2 fix attempts per dimension
+
+## Pipeline Integration
+
+When used within the build pipeline (Phase 4):
+
+- **Runs after:** code-review on full implementation (obvious issues already fixed)
+- **Runs before:** quality-gate on full implementation (gate reviews final state including inquisitor fixes)
+- **Input:** `git diff <base-sha>..HEAD` where base-sha is the commit before Phase 3 execution began
+- **Orchestrator provides:** base SHA, project test conventions, cartographer module context
+
+The build orchestrator handles the inquisitor as a single step. It does NOT invoke the inquisitor's fix cycle independently -- the inquisitor skill manages its own fix cycle internally and reports the final outcome.
+
+## Standalone Usage
+
+Invoke directly with `/inquisitor` when you want to assault a feature branch:
+
+1. Determine base branch (default: `main`, or user-specified)
+2. Compute merge-base: `git merge-base HEAD <base-branch>`
+3. Run the full inquisitor process against `git diff <merge-base>..HEAD`
+4. Report results
+5. If FAILs found: ask user whether to fix automatically or just report
+
+## Skip Condition
+
+The **orchestrator** (not this skill) decides whether to skip. When used standalone, use your judgment:
+- Skip if the diff contains only non-behavioral files (docs, config, assets)
+- If borderline, run the process -- a dimension can report "No attack surface for this dimension" if the diff genuinely has nothing relevant
+
+## Quality Gate
+
+This skill produces **adversarial tests across 5 dimensions**. The tests themselves are the quality mechanism. When used in the build pipeline, the quality-gate that follows reviews the final state including any inquisitor fixes. No additional quality gate is needed on the inquisitor's own output.
+
+## Integration
+
+- **Called by:** `crucible:build` (Phase 4, after code-review, before quality-gate)
+- **Dispatches:** 5 parallel subagents (one per dimension) using `./inquisitor-prompt.md`
+- **May dispatch:** Fixer subagents for FAIL results, lightweight code-review if fix touches 3+ files
+- **Uses:** `crucible:cartographer` context (when available) for module-aware attack surface analysis
+- **Pairs with:** `crucible:adversarial-tester` (per-task, Phase 3) -- inquisitor is the full-feature complement
+- **Prompt template:** `inquisitor-prompt.md` (for dimension subagent dispatch)

--- a/skills/inquisitor/inquisitor-prompt.md
+++ b/skills/inquisitor/inquisitor-prompt.md
@@ -1,0 +1,181 @@
+# Inquisitor Dimension Prompt Template
+
+Use this template when dispatching each of the 5 inquisitor dimension subagents. The orchestrator fills in the dimension-specific sections.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Inquisitor [DIMENSION_NAME] dimension"
+  prompt: |
+    You are an inquisitor — a relentless hunter of cross-component bugs. Your
+    assigned dimension is **[DIMENSION_NAME]**. You are NOT reviewing code
+    quality. You are hunting for runtime failures that emerge from the
+    interaction of multiple components across the full feature.
+
+    ## Your Dimension: [DIMENSION_NAME]
+
+    **Core question:** [DIMENSION_QUESTION]
+
+    **What you're looking for:**
+    [DIMENSION_FOCUS_AREAS]
+
+    **Test style:** [DIMENSION_TEST_STYLE]
+
+    ## Full Feature Diff
+
+    This is the complete diff of ALL implementation changes — every task
+    combined. This is NOT a single task's diff. Look for interactions
+    BETWEEN components that per-task testing would miss.
+
+    [PASTE: git diff <base-sha>..HEAD — the full feature diff]
+
+    ## Project Test Conventions
+
+    [PASTE: Project test conventions from CLAUDE.md or cartographer — naming
+    patterns, test framework, AAA pattern, file locations, etc.]
+
+    ## Module Context
+
+    [PASTE: Cartographer module context, if available. Otherwise omit this
+    section.]
+
+    ## Your Job
+
+    1. **Read the full diff.** Understand what was built across ALL tasks.
+       Map the new components and how they interact.
+
+    2. **Identify 3-5 attack vectors** specific to your dimension.
+       Think like an attacker. Where would [DIMENSION_NAME] problems hide
+       in the seams between these components?
+
+    3. **Rank by likelihood x impact.**
+       - Likelihood: how easily triggered in normal use (High/Medium/Low)
+       - Impact: severity of consequence if triggered (High/Medium/Low)
+       Select your top 3-5. If fewer than 3 are meaningful, write fewer —
+       don't pad with trivial tests.
+
+    4. **Write one test per attack vector.**
+       - Test observable behavior, not implementation details
+       - Follow project test conventions (naming, framework, AAA pattern)
+       - Each test is independent — no shared mutable state
+       - Include a brief comment explaining the attack vector and why
+         cross-component interaction makes it dangerous
+       - Focus on interactions the per-task adversarial tester COULD NOT
+         have caught (it only saw individual task diffs)
+
+    5. **Run each test and record the result.**
+       - PASS: the implementation handles this correctly
+       - FAIL: weakness found — the feature breaks under this condition
+       - ERROR: your test is broken (compilation error, setup failure)
+
+    6. **Report** using the exact format below.
+
+    ## What You Must NOT Do
+
+    - Do NOT modify production code
+    - Do NOT write more than 5 tests
+    - Do NOT refactor or improve existing tests
+    - Do NOT test internal implementation details — only observable behavior
+    - Do NOT duplicate coverage from per-task adversarial tests or test gap
+      writer (your job is cross-component interactions they missed)
+    - Do NOT attack vectors that belong to a different dimension — stay in
+      your lane
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include attack vectors identified,
+      tests written so far, and what remains.
+    - Do NOT try to rush through remaining work — partial work with clear
+      status is better than degraded output.
+
+    ## Report Format
+
+    When done, report using this EXACT structure:
+
+    ```
+    ## INQUISITOR DIMENSION REPORT: [DIMENSION_NAME]
+
+    ### Summary
+    - Attack vectors identified: N
+    - Tests written: N
+    - Tests PASSING (robust): N
+    - Tests FAILING (weaknesses found): N
+    - Tests ERROR (discarded): N
+
+    ### Attack Vector 1: [Title]
+    - **What was tested:** [specific cross-component concern]
+    - **Likelihood:** High/Medium/Low
+    - **Impact:** High/Medium/Low
+    - **Test:** `TestClassName.TestMethodName`
+    - **Result:** PASS/FAIL/ERROR
+    - **If FAIL — fix guidance:** [what to change and in which component]
+
+    [repeat for each attack vector]
+    ```
+```
+
+## Dimension Reference
+
+The orchestrator copies the relevant dimension block into the template above.
+
+### Wiring
+
+- **Core question:** "Is everything actually connected?"
+- **Focus areas:**
+  - New classes/components that exist but are never instantiated or registered
+  - Missing service registrations (DI container bindings)
+  - Missing event subscriptions (published but nobody listens, or listener never subscribed)
+  - Interface implementations that aren't bound
+  - New entry points (menu items, buttons, routes, commands) that don't trigger the new code
+  - Factory methods or builders that don't include new types
+- **Test style:** Instantiate the system and verify new components are reachable and callable through their intended entry points.
+
+### Integration
+
+- **Core question:** "Do the new pieces talk to each other correctly?"
+- **Focus areas:**
+  - Data format mismatches between producer and consumer components
+  - Type assumption mismatches (producer sends int, consumer expects float)
+  - Ordering assumptions (A must happen before B, but nothing enforces it)
+  - Missing data transformations between components
+  - API contracts that don't match between caller and callee
+  - Events published with wrong payload shape or missing fields
+- **Test style:** Set up 2+ new components and verify data flows correctly end-to-end through the interaction chain.
+
+### Edge Cases
+
+- **Core question:** "What happens at the boundaries?"
+- **Focus areas:**
+  - Null/empty inputs at every new public API surface
+  - Zero and negative values where only positives are expected
+  - Maximum values and overflow conditions
+  - Empty collections passed to methods expecting non-empty
+  - Strings with special characters (empty, whitespace-only, extremely long)
+  - Boundary conditions at state transition thresholds
+- **Test style:** Call new APIs with boundary inputs and verify graceful handling (no crash, correct error, or documented behavior).
+
+### State & Lifecycle
+
+- **Core question:** "Is state managed correctly across the feature?"
+- **Focus areas:**
+  - Initialization order dependencies (A must init before B, but nothing enforces it)
+  - Missing disposal/cleanup (IDisposable, Unsubscribe, RemoveListener, event detachment)
+  - Stale references after disposal (use-after-dispose)
+  - State mutations that aren't thread-safe when they should be
+  - Singleton assumptions that don't hold in the actual runtime
+  - State not reset between uses (pooling, recycling, scene transitions)
+- **Test style:** Exercise lifecycle sequences (create, use, dispose, re-create) and verify correct behavior at each stage.
+
+### Regression
+
+- **Core question:** "Did we break anything that used to work?"
+- **Focus areas:**
+  - Existing methods whose return values or side effects changed subtly
+  - Modified base classes affecting derived class behavior
+  - Changed default values, constructor signatures, or parameter ordering
+  - Modified event handling order or priority
+  - Changed error handling (swallowing exceptions that used to propagate, or vice versa)
+  - Moved or renamed things that other code depends on
+- **Test style:** Exercise existing functionality through paths that touch newly modified code, verifying prior behavior is preserved.


### PR DESCRIPTION
## Summary

- Adds `crucible:inquisitor` skill that dispatches 5 parallel adversarial dimensions (wiring, integration, edge cases, state/lifecycle, regression) against the full feature diff to catch bugs that per-task testing misses
- Integrates into build pipeline Phase 4 between code-review and quality-gate, with conditional code review re-run if inquisitor fixes change code
- Includes parameterized dispatch template (`inquisitor-prompt.md`) with dimension-specific focus areas and report format

## Motivation

Per-task adversarial testing (Phase 3) only sees individual task diffs. Bugs in the seams between components slip through — e.g., riftlock's debug menu polish where new item types were implemented correctly but never associated with the item creation UI. Each task passed its own tests; the user found the bug instantly.

## Files

| File | Change |
|------|--------|
| `skills/inquisitor/SKILL.md` | New — main orchestrator (5 dimensions, fix cycle, pipeline + standalone modes) |
| `skills/inquisitor/inquisitor-prompt.md` | New — parameterized dimension dispatch template |
| `skills/build/SKILL.md` | Phase 4 steps 4-5 added (inquisitor + conditional re-review), renumbered 6-11 |
| `README.md` | Added inquisitor to Implementation table and Phase 4 description |

## Test plan

- [ ] Verify SKILL.md follows crucible skill conventions (YAML frontmatter, CSO-optimized description, Integration section)
- [ ] Verify prompt template has all 5 dimension reference blocks matching SKILL.md definitions
- [ ] Verify build pipeline Phase 4 numbering is consistent (steps 1-11, metrics reference step 9)
- [ ] Verify README skill table and How It Works are updated
- [ ] Verify quality gate table in build/SKILL.md references correct step number

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)