### PR TITLE
feat: auto-retry failing test-gap-writer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ln -s ~/repos/crucible/skills/* ~/.claude/skills/
 
 | Skill | Description |
 |-------|-------------|
-| **debugging** | Orchestrated debugging with Phase 3.5 hypothesis red-teaming, domain detection, strategic context preservation, and post-fix quality gate with test gap writer. Includes investigator, pattern analyst, and synthesis subagent templates. |
+| **debugging** | Orchestrated debugging with Phase 3.5 hypothesis red-teaming, domain detection, strategic context preservation, and post-fix quality gate with test gap writer (auto-retry on failures). Includes investigator, pattern analyst, and synthesis subagent templates. |
 
 ### Knowledge & Learning
 
@@ -99,7 +99,7 @@ The **build** skill is the main entry point for feature development. It chains t
 
 1. **Phase 1: Design** (interactive) — Refine the idea with the user, produce a design doc. Forge feed-forward and Cartographer consult run at start. Design passes through a quality gate (replaces direct red-team).
 2. **Phase 2: Plan** (autonomous) — Write implementation plan, review, then quality gate on the plan (replaces direct red-team). Innovate proposes enhancements before the gate.
-3. **Phase 3: Execute** (autonomous, team-based) — Dispatch implementers per task, de-sloppify cleanup (removes unnecessary code), code review per task, a test gap writer (fills coverage gaps identified by the test reviewer), and an adversarial tester (writes tests designed to break the implementation). Cartographer loads module context into subagent prompts.
+3. **Phase 3: Execute** (autonomous, team-based) — Dispatch implementers per task, de-sloppify cleanup (removes unnecessary code), code review per task, a test gap writer (fills coverage gaps identified by the test reviewer, with auto-retry if gaps reveal missing implementation), and an adversarial tester (writes tests designed to break the implementation). Cartographer loads module context into subagent prompts.
 4. **Phase 4: Complete** (autonomous) — Code review on full implementation, inquisitor (5 parallel adversarial dimensions against the full feature diff), quality gate (replaces direct red-team), session metrics report, full test suite, Forge retrospective, Cartographer recording, branch completion options.
 
 The **forge** and **cartographer** skills are recommended (not required) knowledge accelerators that integrate across the pipeline. Forge learns about agent behavior (process wisdom), Cartographer learns about the codebase (domain wisdom). Both accumulate across sessions.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -216,8 +216,20 @@ After the implementer addresses Pass 2 findings, dispatch a **Test Gap Writer** 
 1. Input: Pass 2 test reviewer's missing coverage findings + implementer's changes
 2. The test gap writer writes tests ONLY for gaps the reviewer identified — no scope creep
 3. Tests should pass immediately (the behavior already exists from implementation)
-4. If a test fails: the gap reveals genuinely missing implementation — flag for the implementer to fix before task completion
+4. The test gap writer reports per-test PASS/FAIL results (see prompt template for report format)
 5. Commits new tests: `test: fill coverage gaps for task N`
+
+**If all tests PASS:** Continue to adversarial tester.
+
+**If some tests FAIL** (gaps reveal genuinely missing implementation):
+1. Dispatch a fresh implementer (Opus) with the failing test(s), their failure messages, and the gap descriptions from the reviewer
+2. Implementer fixes the missing behavior, then re-runs ALL test gap writer tests (not just the failures — catches regressions from the fix)
+3. If all tests pass after fix: commit (`fix: address test gap failures for task N`), continue to adversarial tester
+4. If tests still fail after one fix attempt: **escalate to user** with:
+   - Which coverage gaps the reviewer identified
+   - Which tests the gap writer wrote (per-test PASS/FAIL)
+   - What the implementer attempted to fix
+   - Which tests still fail and their current failure messages
 
 **Skip this step if** the Pass 2 test reviewer reported zero missing coverage gaps.
 

--- a/skills/build/test-gap-writer-prompt.md
+++ b/skills/build/test-gap-writer-prompt.md
@@ -52,14 +52,17 @@ Task tool (general-purpose, model: opus):
     TEST GAP REPORT
     ===============
 
-    Tests written:
-    - [test_file:test_name] — Covers: [gap description from reviewer]
-    - [test_file:test_name] — Covers: [gap description from reviewer]
+    Tests written (per-test results):
+    - [test_file:test_name] — Covers: [gap description] — Result: PASS
+    - [test_file:test_name] — Covers: [gap description] — Result: FAIL
+      Failure: [assertion error or exception message]
+      Fix guidance: [what behavior is missing and where to implement it]
 
-    Gaps that revealed missing implementation:
-    - [gap description] — Test fails because [behavior not implemented]. Flagged for implementer.
+    Summary:
+    - Total tests written: N
+    - Passing: N
+    - Failing: N
 
-    Test suite: PASS (N tests, 0 failures)
-    New tests: X
+    Test suite (full): PASS/FAIL (N total tests, M failures)
     ```
 ```

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -335,9 +335,22 @@ If red-teaming finds Fatal or Significant issues, dispatch a fix agent to addres
 
 If code review finds Critical or Important issues, fix them and re-review per the standard code review loop.
 
-**Step 3: Test gap writer** — If the code reviewer or red-teamer identified missing test coverage for the fix, dispatch a Test Gap Writer agent (Opus) using `./test-gap-writer-prompt.md`. The agent writes tests only for gaps specifically flagged in the review — no scope creep. Tests should PASS immediately since the behavior already exists from the fix. If a test fails, it reveals genuinely missing fix coverage — flag for the implementer. Skipped when reviews report zero coverage gaps.
+**Step 3: Test gap writer** — If the code reviewer or red-teamer identified missing test coverage for the fix, dispatch a Test Gap Writer agent (Opus) using `./test-gap-writer-prompt.md`. The agent writes tests only for gaps specifically flagged in the review — no scope creep. Tests should PASS immediately since the behavior already exists from the fix. The agent reports per-test PASS/FAIL results. Skipped when reviews report zero coverage gaps.
 
-**Only after all gates pass clean (and any test gaps are filled) is the debugging workflow complete.**
+**If all tests PASS:** Debugging workflow is complete.
+
+**If some tests FAIL** (gaps reveal incomplete fix coverage):
+1. Dispatch a fresh implementer (Opus) with the failing test(s), their failure messages, gap descriptions, and the original bug context (hypothesis, root cause)
+2. Implementer fixes the incomplete coverage, re-runs ALL test gap writer tests (not just failures — catches regressions from the fix)
+3. If all tests pass after fix: commit (`fix: address test gap failures for debugging fix`), debugging workflow is complete
+4. If tests still fail after one fix attempt: **escalate to user** with:
+   - The original bug and confirmed root cause
+   - What was fixed in Phase 4
+   - Which test gaps were detected by reviewers
+   - What the retry implementer attempted
+   - Which tests still fail and their current failure messages
+
+**Only after all gates pass clean (and any test gaps are filled or escalated) is the debugging workflow complete.**
 
 ### Session Metrics
 

--- a/skills/debugging/test-gap-writer-prompt.md
+++ b/skills/debugging/test-gap-writer-prompt.md
@@ -59,14 +59,17 @@ Task tool (general-purpose, model: opus):
     Bug: [brief description]
     Root cause: [hypothesis that was confirmed]
 
-    Tests written:
-    - [test_file:test_name] — Covers: [gap description from reviewer]
-    - [test_file:test_name] — Covers: [gap description from reviewer]
+    Tests written (per-test results):
+    - [test_file:test_name] — Covers: [gap description] — Result: PASS
+    - [test_file:test_name] — Covers: [gap description] — Result: FAIL
+      Failure: [assertion error or exception message]
+      Fix guidance: [what the fix doesn't cover and where to address it]
 
-    Gaps that revealed incomplete fix:
-    - [gap description] — Test fails because [fix doesn't cover this case]. Flagged for implementer.
+    Summary:
+    - Total tests written: N
+    - Passing: N
+    - Failing: N
 
-    Test suite: PASS (N tests, 0 failures)
-    New tests: X
+    Test suite (full): PASS/FAIL (N total tests, M failures)
     ```
 ```


### PR DESCRIPTION
## Summary

- When test gap writer tests fail, the pipeline now dispatches a fresh implementer with failure context + gap descriptions instead of just flagging
- After fix, re-runs ALL test gap writer tests (not just failures) to catch regressions
- Escalates to user with structured report after one failed retry attempt
- Prompt templates now report per-test PASS/FAIL with failure messages and fix guidance
- Applied to both build (Phase 3) and debugging (Phase 5) pipelines

## Design Decision

Issue #10 originally proposed a full debugging cycle with triage gate, disk-based failure files, and recursion prevention. After cost/benefit analysis, we chose a lighter approach: fresh implementer retry instead of full debugging cycle. This captures ~90% of the value (machine-detectable problems no longer get punted) at ~10% of the token cost (~30-60K tokens vs ~200-500K).

## Files

| File | Change |
|------|--------|
| `skills/build/SKILL.md` | Test Gap Writer section: added retry flow with fresh implementer + escalation |
| `skills/debugging/SKILL.md` | Phase 5 Step 3: same retry flow, includes bug context in implementer dispatch |
| `skills/build/test-gap-writer-prompt.md` | Report format: per-test PASS/FAIL with failure messages and fix guidance |
| `skills/debugging/test-gap-writer-prompt.md` | Same report format update |
| `README.md` | Added auto-retry mentions to debugging and Phase 3 descriptions |

## Test plan

- [x] Verify build SKILL.md Test Gap Writer section has clear retry → escalate flow
- [x] Verify debugging SKILL.md Phase 5 Step 3 includes bug context (hypothesis, root cause) in retry dispatch
- [x] Verify both prompt templates have matching per-test PASS/FAIL report format
- [x] Verify README mentions auto-retry in both relevant descriptions
- [x] Verify no new files were created (all changes are inline in existing files)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)