### PR TITLE
Replace 3-round quality gate cap with weighted stagnation detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ln -s ~/repos/crucible/skills/* ~/.claude/skills/
 
 | Skill | Description |
 |-------|-------------|
-| **quality-gate** | Iterative red-teaming of any artifact (design, plan, code, hypothesis, mockup). Default 3-round cap. Invoked by artifact-producing skills. |
+| **quality-gate** | Iterative red-teaming of any artifact (design, plan, code, hypothesis, mockup). Loops until clean or stagnation (weighted scoring: Fatal=3, Significant=1). 15-round safety limit. Invoked by artifact-producing skills. |
 | **red-team** | Adversarial review engine. Dispatches fresh Devil's Advocate subagents per round with stagnation detection. Used by quality-gate internally. |
 | **code-review** | Dispatch code review with shared canonical review checklist. |
 | **review-feedback** | Process code review feedback with technical rigor. Requires verification, not blind implementation. |

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -49,7 +49,7 @@ Every status update must include:
 After the user approves the design and before starting Phase 2:
 
 1. **Innovate:** Dispatch `crucible:innovate` on the design doc. Plan Writer incorporates the proposal.
-2. **Quality gate:** Dispatch `crucible:quality-gate` on the (potentially updated) design doc with artifact type "design". Iterates until clean, stagnation, or 3-round cap.
+2. **Quality gate:** Dispatch `crucible:quality-gate` on the (potentially updated) design doc with artifact type "design". Iterates until clean or stagnation.
 3. If the quality gate requires changes, the Plan Writer updates the design doc and re-commits.
 4. Design doc is now finalized — proceed to acceptance tests.
 
@@ -110,7 +110,7 @@ Use `./plan-reviewer-prompt.md` template for the dispatch prompt.
 1. **Innovate:** Dispatch `crucible:innovate` on the approved plan. Plan Writer incorporates the proposal into the plan.
 2. **Quality gate:** Dispatch `crucible:quality-gate` on the (potentially updated) plan with artifact type "plan". Provides the plan and design doc as context.
 
-The quality gate handles the iterative red-team loop — fresh review each round, stagnation detection, 3-round cap, escalation. See `crucible:quality-gate` for details.
+The quality gate handles the iterative red-team loop — fresh review each round, weighted stagnation detection, 15-round safety limit, escalation. See `crucible:quality-gate` for details.
 
 ## Phase 3: Execute (Autonomous, Team-Based)
 

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -95,7 +95,7 @@ This skill produces **implementation plans**. When used standalone, invoke `cruc
 1. Plan is saved
 2. Invoke `crucible:quality-gate` with artifact type "plan"
 3. Address any findings, revise plan
-4. Quality gate iterates until clean or escalates after 3 rounds
+4. Quality gate iterates until clean or stagnation is detected
 
 ## Remember
 - Exact file paths always

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-gate
-description: Iterative red-teaming of any artifact (design docs, plans, code, hypotheses, mockups). Default 3-round cap. Invoked by artifact-producing skills or their parent orchestrator.
+description: Iterative red-teaming of any artifact (design docs, plans, code, hypotheses, mockups). Loops until clean or stagnation. Invoked by artifact-producing skills or their parent orchestrator.
 origin: crucible
 ---
 
@@ -15,10 +15,10 @@ Shared iterative red-teaming mechanism invoked at the end of artifact-producing 
 1. Receives: artifact content, artifact type, project context
 2. Invokes `crucible:red-team` on the artifact
 3. If red-team finds issues: revise the artifact, invoke a FRESH red-team (no anchoring)
-4. Track issue count between rounds:
-   - **Strictly fewer issues** → progress, loop again
-   - **Same or more issues** → stagnation, escalate to user
-5. **Default 3-round cap.** If still finding Fatal issues after 3 rounds, escalate to user with findings. User can override with "keep going" but the default is capped.
+4. Track weighted score between rounds (Fatal=3, Significant=1):
+   - **Strictly lower score** → progress, loop again
+   - **Same or higher score** → stagnation, escalate to user
+5. **Global safety limit: 15 rounds.** Loop continues as long as progress is being made, up to a maximum of 15 rounds. This is a runaway protection circuit-breaker, not a quality target — if you hit 15, something has gone wrong. Escalate to user with full round history.
 
 ### Artifact Types
 
@@ -59,17 +59,18 @@ Each artifact-producing skill's SKILL.md documents:
 
 ## Escalation
 
-- After 3 rounds with remaining Fatal issues → escalate to user
-- Stagnation (same or more issues) → escalate immediately
-- User can say "keep going" to extend beyond 3 rounds
+- Stagnation (weighted score same or higher) → escalate to user with findings from both rounds
+- Global safety limit reached (15 rounds) → escalate to user with full round history
+- Architectural concerns → escalate immediately (bypass loop)
 - User can interrupt at any time to skip the gate
 
 ## Red Flags
 
 - Rationalizing away red-team findings instead of addressing them
 - Skipping the gate without user approval
-- Running more than 3 rounds without escalating
+- Exceeding the 15-round safety limit without escalating
 - Using the same red-team agent across rounds (always dispatch fresh)
+- Declaring stagnation on raw issue count without using weighted score (Fatal=3, Significant=1)
 
 ## Integration
 

--- a/skills/red-team/SKILL.md
+++ b/skills/red-team/SKILL.md
@@ -30,10 +30,10 @@ digraph red_team_loop {
   "No Fatal/Significant issues" -> "Artifact approved -- proceed";
   "Reviewer returns findings" -> "Fatal/Significant issues found";
   "Fatal/Significant issues found" -> "Dispatch fix agent";
-  "Dispatch fix agent" -> "Count issues (Fatal + Significant)";
-  "Count issues (Fatal + Significant)" -> "Compare to prior round";
-  "Compare to prior round" -> "Dispatch FRESH Devil's Advocate" [label="strictly fewer = progress"];
-  "Compare to prior round" -> "Escalate to user" [label="same or more = stagnation"];
+  "Dispatch fix agent" -> "Score issues (Fatal=3, Significant=1)";
+  "Score issues (Fatal=3, Significant=1)" -> "Compare weighted score to prior round";
+  "Compare weighted score to prior round" -> "Dispatch FRESH Devil's Advocate" [label="strictly lower score = progress"];
+  "Compare weighted score to prior round" -> "Escalate to user" [label="same or higher score = stagnation"];
   "Reviewer returns findings" -> "Escalate to user" [label="architectural concern"];
 }
 ```
@@ -41,10 +41,20 @@ digraph red_team_loop {
 ### Rules
 
 1. **Fresh reviewer every round** — dispatch a NEW subagent each time. Never pass prior findings to the next reviewer. Each reviewer sees the artifact cold.
-2. **Stagnation = escalation** — if Round N+1 finds >= the number of Fatal+Significant issues as Round N, stop and escalate to user with full findings from both rounds.
+2. **Stagnation = escalation** — use weighted scoring to detect stagnation (see below). If the weighted score does not strictly decrease, stop and escalate to user with full findings from both rounds.
 3. **Architectural concerns bypass the loop** — immediate escalation regardless of round or progress.
-4. **No round cap** — loop as long as each round makes progress.
+4. **No round cap** — loop as long as each round makes progress. The caller (e.g., `crucible:quality-gate`) may impose a global safety limit.
 5. **Only Fatal and Significant count** — Minor observations are logged but don't count toward stagnation and don't trigger fix rounds.
+
+### Stagnation Detection
+
+Stagnation uses **weighted scoring**, not raw issue counts. This prevents false stagnation when Fatal issues are converted to Significant ones (which is genuine progress).
+
+**Weights:** Fatal = 3 points, Significant = 1 point.
+
+**Example:** Round 1 finds 2 Fatal + 1 Significant = score 7. Fixer eliminates both Fatals but surfaces 3 new Significants. Round 2 finds 0 Fatal + 3 Significant = score 3. That is progress (3 < 7), not stagnation.
+
+**If the weighted score is the same or higher than the prior round, that is stagnation.** Escalate to user with findings from both rounds.
 
 ### Issue Classification
 
@@ -77,14 +87,14 @@ Model: **Opus** (adversarial analysis needs the best model)
 ### 3. Process findings
 
 - **No Fatal/Significant issues:** Artifact is approved. Proceed.
-- **Fatal/Significant issues found:** Record the issue count. Dispatch fix mechanism. Then go to step 4.
+- **Fatal/Significant issues found:** Compute the weighted score (Fatal=3, Significant=1). Dispatch fix mechanism. Then go to step 4.
 - **Architectural concerns:** Escalate to user immediately. Do not attempt to fix.
 
 ### 4. Re-review after fixes
 
-Dispatch a NEW Devil's Advocate subagent (fresh, no prior context). Compare issue count:
-- **Strictly fewer Fatal+Significant issues:** Progress. Loop back to step 3.
-- **Same or more Fatal+Significant issues:** Stagnation. Escalate to user with findings from both rounds.
+Dispatch a NEW Devil's Advocate subagent (fresh, no prior context). Compute weighted score and compare:
+- **Strictly lower weighted score:** Progress. Loop back to step 3.
+- **Same or higher weighted score:** Stagnation. Escalate to user with findings from both rounds.
 
 ## What the Devil's Advocate is NOT
 


### PR DESCRIPTION
## Summary

- **Remove the hard 3-round cap** from quality-gate — it was cutting short productive red-team iterations
- **Add weighted stagnation detection** to red-team (Fatal=3pts, Significant=1pt) — prevents false stagnation when Fatals are converted to Significants (genuine progress that raw counts miss)
- **Add 15-round global safety limit** as a circuit-breaker for unattended pipelines
- **Update all downstream references** in build, planning, and README

Three clean termination conditions:
1. No Fatal/Significant issues → clean pass
2. Weighted score same or higher → stagnation, escalate
3. 15 rounds → safety limit, escalate

## Test plan

- [x] Verify quality-gate SKILL.md has no 3-round cap references
- [x] Verify red-team SKILL.md uses weighted scoring in rules, diagram, and procedural steps
- [x] Verify build/SKILL.md references weighted stagnation detection
- [x] Verify planning/SKILL.md references stagnation-based termination
- [x] Verify README.md description matches new behavior
- [x] Grep for "3-round" or "3 round" outside docs/plans/ — should be zero hits

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)