### PR TITLE
feat: add audit skill for subsystem code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ These settings are specific to Claude Code. Other platforms have equivalent conf
 | **adversarial-tester** | Reads completed implementation and writes up to 5 tests designed to expose unknown failure modes. Targets edge cases, boundary conditions, and runtime behavior the implementer didn't anticipate. |
 | **inquisitor** | Full-feature cross-component adversarial testing. Runs 5 parallel adversarial dimensions (wiring, integration, edge cases, state/lifecycle, regression) against the complete implementation diff to find bugs that per-task testing misses. |
 
-### Quality
+### Quality & Audit
 
 | Skill | Description |
 |-------|-------------|
+| **audit** | Adversarial review of existing subsystems on demand. Dispatches 4 parallel analysis lenses (correctness, robustness, consistency, architecture), synthesizes findings, cross-references existing issues, and offers to file in the user's tracker (GitHub, Jira, Linear, etc.). Find-and-report only. |
 | **quality-gate** | Iterative red-teaming of any artifact (design, plan, code, hypothesis, mockup). Loops until clean or stagnation (weighted scoring: Fatal=3, Significant=1). 15-round safety limit. Invoked by artifact-producing skills. |
 | **red-team** | Adversarial review engine. Dispatches fresh Devil's Advocate reviewers per round with stagnation detection. Used by quality-gate internally. |
 | **code-review** | Dispatch code review with shared canonical review checklist. |
@@ -156,7 +157,7 @@ The **forge** and **cartographer** skills are recommended (not required) knowled
 
 The **project-init** skill accelerates onboarding — run `/project-init` on an unfamiliar repo to get full structural context before the first `/build` or `/design`. It produces the same cartographer files that would accumulate over multiple sessions, tagged as structural scaffolding that gets replaced by task-verified content over time.
 
-Individual skills can also be used standalone (e.g., `test-driven-development` for any implementation work, `debugging` for any bug).
+Individual skills can also be used standalone (e.g., `test-driven-development` for any implementation work, `debugging` for any bug, `audit` for adversarial review of any existing subsystem).
 
 ## Eval Results
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: audit
+description: "Review existing subsystems for bugs, robustness gaps, inconsistencies, and architecture issues. Triggers on 'audit', 'review subsystem', 'check the save system', 'examine the UI code', or any task requesting adversarial review of existing (not newly written) code."
+---
+
+# Audit
+
+Adversarial review of existing subsystems. Dispatches parallel analysis agents across four lenses, synthesizes findings, and offers to file them in the user's issue tracker.
+
+**Announce at start:** "Running audit on [subsystem name]."
+
+**Skill type:** Rigid -- follow exactly, no shortcuts.
+
+**Purpose:** Review existing subsystems in a repo and report findings. Distinct from quality-gate (which fixes artifacts in a loop) -- audit is find-and-report only.
+
+**Model:** Opus (orchestrator and analysis agents). Sonnet (scoping exploration). If the orchestrator session is not running Opus, warn: "Audit requires Opus-level reasoning for synthesis. Results may be degraded."
+
+## Why This Exists
+
+Per-task quality gates (red-team, inquisitor) review artifacts produced during development. But the bugs that accumulate in stable code -- the ones nobody's looked at critically in months -- live in subsystems that passed their original review but have drifted, accrued inconsistencies, or developed subtle failure modes. The audit skill performs a focused adversarial review of any existing subsystem on demand.
+
+## Distinction from Related Skills
+
+| Skill | Reviews | When | Fixes? | Scope |
+|-------|---------|------|--------|-------|
+| red-team | A single artifact just produced | During creation | Yes (loop) | One doc/plan/impl |
+| inquisitor | A complete implementation diff | During build phase 4 | Yes (automated fix cycle) | Changes only (diffs) |
+| **audit** | Existing code in a subsystem | On demand | No (reports only) | Existing codebase |
+
+## Communication Requirement (Non-Negotiable)
+
+**Between every agent dispatch and every agent completion, output a status update to the user.** This is NOT optional -- the user cannot see agent activity without your narration.
+
+Every status update must include:
+1. **Current phase** -- Which phase you're in
+2. **What just completed** -- What the last agent reported
+3. **What's being dispatched next** -- What you're about to do and why
+4. **Lens status** -- Which lenses have reported vs. still in flight, finding counts so far
+
+**After compaction:** Re-read the scratch directory and current state before continuing. See Compaction Recovery below.
+
+**Examples of GOOD narration:**
+> "Phase 2: Correctness and Robustness lenses complete (4 findings, 2 findings). Architecture still in flight. Consistency Agent A returned -- flagged 6 files, dispatching Agent B."
+
+> "Phase 2 complete. All 4 lenses reported: 14 total findings. Moving to Phase 3 synthesis."
+
+## Design Decisions
+
+1. **Find and report only** -- no fixing. Audit surfaces issues; user decides what to act on.
+2. **Cross-reference existing open issues** -- avoid filing duplicates, using whatever tools are available in the environment.
+3. **Issue filing format is user's choice** -- offer individual issues per finding OR one umbrella issue with checklist. Let user pick.
+4. **Tracker-agnostic** -- the skill stores which tracker and project the user uses, not how to use it. The agent uses whatever tools are available in the environment (MCP servers, CLIs, APIs) to interact with the tracker. If the agent can't figure out how to file, it asks the user. If the user mentions a different tracker or project during an invocation, update the stored preference.
+
+## Preferences Storage
+
+Stored in `~/.claude/projects/<project-hash>/memory/audit/preferences.md`:
+
+```markdown
+## Issue Tracker
+- Tracker: github
+- Project: owner/repo
+```
+
+First audit run: ask the user which tracker and project. Persist for future runs. Update if user indicates a change.
+
+## Scratch Directory
+
+**Canonical path:** `~/.claude/projects/<project-hash>/memory/audit/scratch/<run-id>/`
+
+The `<run-id>` is a timestamp generated at the start of Phase 1 (e.g., `2026-03-15T14-30-00`). This same identifier is used for all scratch files and session logs throughout the run.
+
+All relative paths in this document (e.g., `scratch/<run-id>/manifest.md`) are relative to `~/.claude/projects/<project-hash>/memory/audit/`.
+
+**Stale cleanup:** At the start of each audit run, delete scratch directories whose timestamps are older than 1 hour. Do not delete recent directories (could belong to concurrent sessions).
+
+## Session Tracking
+
+- **Metrics:** Log agent dispatches, completion times, finding counts to `/tmp/crucible-audit-metrics-<run-id>.log`
+- **Decision journal:** Log scoping decisions, chunking rationale, dedup merges to `/tmp/crucible-audit-decisions-<run-id>.log`
+
+The `<run-id>` is the same timestamp used for the scratch directory.
+
+## Compaction Recovery
+
+After context compaction, the orchestrator must:
+1. Read `scratch/<run-id>/` to determine current state:
+   - `manifest.md` exists → Phase 1 scoping is complete
+   - `gate-approved.md` exists → user confirmed scope, Phase 2 can proceed
+   - `<lens>-findings.md` files → those lenses have reported
+   - `consistency-a-findings.md` without `consistency-b-findings.md` → Agent B still needed
+   - `report.md` exists → Phase 3 synthesis is complete, proceed to Phase 4
+2. Re-read relevant files from disk based on current phase
+3. Output current status to user before continuing
+4. Continue with the appropriate phase
+
+**Phase-specific recovery:**
+- **Phase 1:** If `manifest.md` exists but `gate-approved.md` does not, re-present the manifest to the user for confirmation.
+- **Phase 2:** Check which lenses have findings files. Dispatch any remaining lenses.
+- **Phase 3:** If compaction occurs during synthesis, re-read all findings files and re-run synthesis. This is safe — synthesis is idempotent.
+- **Phase 4:** If `report.md` exists, re-read it and continue with cross-referencing/filing.
+
+## Phase 1: Scoping
+
+Dispatch: `Agent tool (subagent_type: Explore, model: sonnet)` using `audit-scoping-prompt.md`
+
+1. User names a subsystem ("save/load", "UI", "networking")
+2. Consult cartographer data if it exists for subsystem boundaries
+3. If no cartographer data: dispatch a Sonnet exploration agent to identify the subsystem boundary using the scoping prompt template.
+4. If the subsystem cannot be cleanly scoped (files share no common dependency chain, naming convention, or functional cohesion), report the scoping difficulty to the user and ask for clarification or a file list.
+5. **Output:** A manifest of files belonging to the subsystem (paths + brief role descriptions). Write to `scratch/<run-id>/manifest.md`.
+
+**USER GATE:** Present the manifest to the user. Do not proceed to Phase 2 until the user confirms the scope is correct. User may add/remove files or refine the boundary. When the user approves, write `scratch/<run-id>/gate-approved.md` (contents: timestamp + user confirmation) as a compaction recovery marker.
+
+If the user removes all files or the manifest is empty: abort cleanly with "No files in scope -- audit cancelled."
+
+## Phase 2: Analysis
+
+Dispatch: `Task tool (general-purpose, model: opus)` per lens, in parallel (matching inquisitor pattern). Fallback if parallel dispatch fails: dispatch sequentially via `Task tool (general-purpose, model: opus)`, with a one-time note to user: "Parallel dispatch unavailable -- running analysis lenses sequentially."
+
+**Write-on-complete:** As each agent completes, immediately write its findings to `scratch/<run-id>/<lens>-findings.md`. Do not wait for Phase 3. For the Consistency lens, use distinct filenames: `consistency-a-findings.md` for Agent A's triage output, `consistency-b-findings.md` for Agent B's confirmed findings.
+
+### Context Management
+
+**Tier 1 -- Overview:** The orchestrator builds a condensed summary of the subsystem: file manifest with role descriptions, key public interfaces/contracts, dependency graph. **Target: 500 lines. Flexible up to 800 lines for subsystems with complex API surfaces.** If the subsystem exceeds what can be summarized in 800 lines, chunk the subsystem (see Chunking below).
+
+**Tier 2 -- Deep dive:** The orchestrator partitions source files across agents by relevance to their lens. **Hard cap: 1500 lines of total prompt content per agent** (Tier 1 overview + Tier 2 source + prompt template). If a lens requires more files than fit, the orchestrator generates brief summaries of overflow files (2-3 lines per file: path, responsibility, key interfaces) and includes those instead of full source. If an agent's findings reference a summarized file, the orchestrator may dispatch a **follow-up agent** for that lens with the flagged files at full source.
+
+### Chunking (Large Subsystems)
+
+If the subsystem is too large to summarize within the 800-line Tier 1 cap:
+
+- Split by dependency subgraph -- files that call each other stay together. Prefer natural boundaries (directories, modules, namespaces).
+- **Soft cap: 4 chunks maximum.** If more than 4 chunks would be needed, advise the user to narrow the subsystem scope instead.
+- Present the chunking plan at the Phase 1 user gate: "This subsystem is large. I'll audit it in N chunks (~5N analysis agents including Consistency two-phase). Chunk descriptions: [list]. Approve?"
+- Each chunk gets its own set of analysis agents.
+- Synthesis (Phase 3) merges findings across all chunks.
+- Cross-chunk concerns: the Tier 1 overview for each chunk includes a "cross-chunk interface" section describing how this chunk interacts with others. All lenses receive this section and should consider cross-chunk issues within their domain.
+
+### The 4 Lenses
+
+Each lens is dispatched as a parallel agent using its prompt template.
+
+All lenses output structured findings with these common fields: `{severity, file, line_range, evidence, description}`. Individual lenses add lens-specific fields (e.g., Correctness adds `scenario`, Robustness adds `failure_scenario`, Architecture adds `impact`, Consistency adds `convention_violated`). The orchestrator's Phase 3 deduplication uses the common fields for matching; lens-specific fields are preserved in the final report.
+
+#### Correctness
+
+**Prompt:** `audit-correctness-prompt.md`
+**Question:** "What's actually broken or will break?"
+**Looks for:** Bugs, race conditions, edge cases, logic errors, off-by-one, null dereferences, unreachable code paths.
+**Gets:** Files with core logic, state management, data flow.
+**Dispatch:** Single agent.
+
+#### Robustness
+
+**Prompt:** `audit-robustness-prompt.md`
+**Question:** "What happens when things go wrong?"
+**Looks for:** Missing error handling at boundaries, unhandled failure modes, missing validation, silent data corruption, resource leaks.
+**Gets:** Files at system boundaries, I/O, serialization.
+**Dispatch:** Single agent.
+
+#### Consistency
+
+**Prompt:** `audit-consistency-prompt.md`
+**Question:** "Does this code follow its own patterns?"
+**Looks for:** Pattern violations, naming drift, convention breaks, inconsistent error handling styles, mixed paradigms.
+**Dispatch:** Two sequential agents (orchestrator dispatches Agent A, reads results, then dispatches a separate Agent B).
+
+- **Agent A:** Receives the Tier 1 overview (which includes the file manifest with role descriptions) + conventions.md from cartographer if available. The overview IS the summary -- do not add additional file-level summaries. Returns: list of files flagged for suspected inconsistencies with rationale. Subject to the 1500-line hard cap.
+- **Agent B:** Receives full source for Agent A's flagged files only. Subject to the same 1500-line hard cap. If Agent A flags more files than fit, the orchestrator applies the same overflow-summary mechanism (summarize overflow files, include full source for highest-priority flags, dispatch follow-up if needed). Returns: confirmed findings with evidence.
+- **Timing:** Agent A dispatches in parallel with the other three lenses. Agent B dispatches after Agent A completes. The orchestrator proceeds to Phase 3 once all lenses (including Consistency Agent B) have reported. The other three lenses may finish earlier -- this is expected and acceptable.
+
+#### Architecture
+
+**Prompt:** `audit-architecture-prompt.md`
+**Question:** "Is this well-structured?"
+**Looks for:** Coupling issues, abstraction leaks, missing contracts, dependency direction violations, god objects, circular dependencies.
+**Gets:** Tier 1 overview + public API surfaces.
+**Dispatch:** Single agent.
+
+## Phase 3: Synthesis
+
+Orchestrator reads all confirmed findings from `scratch/<run-id>/` on disk. Read `correctness-findings.md`, `robustness-findings.md`, `consistency-b-findings.md`, and `architecture-findings.md`. Do NOT read `consistency-a-findings.md` (triage data, not confirmed findings).
+
+1. **Deduplicate:** When two findings reference overlapping file + line_range and describe the same underlying concern (using common fields: severity, file, line_range, evidence, description), merge into one finding noting both lenses. Preserve lens-specific fields from both. **Tie-breaking rule:** When in doubt, keep both findings as separate items but note they may be related. Err on the side of presenting more findings rather than silently merging.
+2. **Severity-rank:** Fatal first, then Significant, then Minor.
+3. **Group by theme** (e.g., "Error Handling," "State Management," "API Contracts").
+4. **Write report** to `scratch/<run-id>/report.md`.
+
+## Phase 4: Reporting
+
+1. Present the ranked, grouped findings to user.
+
+2. **Cross-reference existing issues:** Using whatever tools are available in the environment (MCP servers, CLIs, etc.), search for existing open issues using specific file paths and error descriptions from findings as search terms.
+   - **Budget:** Cross-reference the top 10 findings by severity (Fatal first, then Significant). Check at most 2-3 search queries per finding.
+   - If the tracker is slow or unresponsive after 3+ failed/timed-out queries, skip remaining cross-references.
+   - Present at most 2-3 candidate matches per finding.
+   - Flag likely duplicates with "Possible existing issue: [reference]" -- never silently drop a finding; let user decide.
+   - If cross-referencing isn't possible (no tools available, tracker not configured), skip it and just present findings.
+
+3. Ask user: **"File as individual issues, one umbrella issue with checklist, or skip filing?"**
+   - If filing: use available environment tools to create issues with structured body (severity tag, file references, evidence snippet).
+
+4. **Record to cartographer:** After completion, dispatch cartographer recorder (Mode 1) with the Phase 1 manifest only. The manifest was deliberately scoped during exploration and is reliable structural data. Do NOT feed incidental observations from Phase 2 bug-hunting agents to cartographer -- those are unverified structural inferences.
+
+5. **Cleanup:** Delete the `scratch/<run-id>/` directory only after ALL Phase 4 actions are complete (issue filing, cartographer recording). Do not clean up prematurely -- the report on disk is needed for compaction recovery during Phase 4.
+
+## Prompt Templates
+
+- `audit-scoping-prompt.md` -- Phase 1 subsystem scoping dispatch (`Agent tool, subagent_type: Explore, model: sonnet`)
+
+Analysis lens templates (all use `Task tool, general-purpose, model: opus`):
+- `audit-correctness-prompt.md` -- Correctness lens dispatch
+- `audit-robustness-prompt.md` -- Robustness lens dispatch
+- `audit-consistency-prompt.md` -- Consistency lens dispatch (documents two-agent protocol)
+- `audit-architecture-prompt.md` -- Architecture lens dispatch
+
+Each analysis template includes:
+- Dispatch metadata (for orchestrator reference): `Task tool (general-purpose, model: opus)`
+- The lens definition and what to look for
+- Placeholders for: Tier 1 overview, Tier 2 source partition
+- Output format with common fields (`severity, file, line_range, evidence, description`) plus lens-specific fields
+- Instruction: "Only flag issues you can point to specific code evidence for. No speculative findings."
+- Context self-monitoring (report partial progress at 50%+ utilization)
+
+## Guardrails
+
+**Analysis agents must NOT:**
+- Modify any code (audit is read-only)
+- Flag issues without specific code evidence (no speculation)
+- Overlap with another lens's findings (if borderline, the more specific lens owns it)
+- Exceed 5 findings per lens without strong justification (focus on highest-impact issues)
+
+**The orchestrator must NOT:**
+- Proceed to Phase 2 without user-confirmed scoping manifest
+- File issues without explicit user approval
+- Silently drop findings that match existing issues (always show, let user decide)
+- Exceed 1500 lines of total prompt content in any agent dispatch
+- Feed Phase 2 structural inferences to cartographer (Phase 1 manifest only)
+- Skip narration between agent dispatches (Communication Requirement)
+- Dispatch more than ~20 agents without user awareness (chunking approval includes agent count)
+
+## Red Flags
+
+- Treating this as a fix loop (audit reports, it does not fix)
+- Hardcoding tracker-specific commands (use available environment tools)
+- Losing agent results to context compaction (write to disk immediately)
+- Skipping session metrics or decision journal
+- Cleaning up scratch directory before Phase 4 is fully complete
+
+## Integration
+
+- **Dispatches:** Audit-specific prompt templates (scoping, correctness, robustness, consistency [2 agents], architecture)
+- **Consults:** `crucible:cartographer` (Mode 2: consult map) for subsystem scoping and conventions
+- **Records to:** `crucible:cartographer` (Mode 1: record discovery) -- Phase 1 manifest only
+- **Pairs with:** `crucible:forge` -- audit findings could inform retrospective if they reveal systemic patterns
+- **Called by:** Standalone only (user invokes directly). Not part of any pipeline.
+- **Does NOT use:** `crucible:quality-gate` (audit is not a fix loop), `crucible:red-team` (designed for single artifacts)

--- a/skills/audit/audit-architecture-prompt.md
+++ b/skills/audit/audit-architecture-prompt.md
@@ -1,0 +1,126 @@
+# Audit Architecture Prompt Template
+
+Use this template when dispatching the Architecture lens agent. The orchestrator fills in the bracketed sections.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Audit architecture lens"
+  prompt: |
+    You are an auditor evaluating the structural health of an existing
+    subsystem. You are NOT hunting for bugs or style issues. You are
+    assessing whether the architecture supports maintainability,
+    extensibility, and correctness as the system evolves.
+
+    ## Your Lens: Architecture
+
+    **Core question:** "Is this well-structured?"
+
+    **What you're looking for:**
+    - Tight coupling between components that should be independent
+    - Abstraction leaks (internal details exposed through public APIs)
+    - Missing contracts (implicit agreements between components that
+      should be explicit interfaces)
+    - Dependency direction violations (high-level depending on low-level,
+      circular dependencies)
+    - God objects or god files (single components with too many
+      responsibilities)
+    - Layer violations (bypassing established architectural boundaries)
+    - Missing or incorrect separation of concerns
+
+    **What you are NOT looking for:**
+    - Logic bugs (that's the Correctness lens)
+    - Missing error handling (that's the Robustness lens)
+    - Naming or style issues (that's the Consistency lens)
+    - Speculative issues you can't point to specific code for
+
+    ## Subsystem Overview
+
+    [PASTE: Tier 1 overview -- file manifest, key interfaces, dependency
+    graph]
+
+    [IF CHUNKED: Include the cross-chunk interface section. Pay special
+    attention to issues at chunk boundaries -- coupling, contracts, and
+    dependency direction between chunks.]
+
+    ## Source Files
+
+    [PASTE: Tier 2 partition -- public API surfaces, interface
+    definitions, key abstractions. For files that didn't fit within the
+    1500-line budget, include 2-3 line summaries.]
+
+    ## Your Job
+
+    1. **Read the overview and source files.** Build a mental model of the
+       subsystem's architecture: what depends on what, where are the
+       boundaries, what are the contracts.
+
+    2. **Identify architectural issues.** For each issue, you must have
+       specific code evidence -- concrete dependency chains, specific API
+       surfaces that leak, actual circular references. No speculation.
+
+    3. **Prioritize by severity:**
+       - **Fatal** -- Architectural issue that will force a rewrite or
+         causes active bugs (e.g., circular dependency causing init
+         failures)
+       - **Significant** -- Architectural issue that will cause increasing
+         maintenance burden or make the next feature significantly harder
+       - **Minor** -- Suboptimal structure that works but could be cleaner
+
+    4. **Report** using the exact format below.
+
+    ## What You Must NOT Do
+
+    - Do NOT suggest fixes (audit is report-only)
+    - Do NOT flag logic bugs (Correctness lens handles that)
+    - Do NOT flag missing error handling (Robustness lens handles that)
+    - Do NOT flag style issues (Consistency lens handles that)
+    - Do NOT speculate -- every finding must have code evidence
+    - Do NOT exceed 5 findings unless you have strong justification
+    - Do NOT flag architectural patterns that are intentional and working
+      (pragmatic trade-offs are valid)
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include issues identified so far and
+      what areas remain unexamined.
+    - Do NOT try to rush through remaining work -- partial findings with
+      clear status are better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure (plain text, no code fences):
+
+    ## AUDIT ARCHITECTURE FINDINGS
+
+    ### Summary
+    - Files examined: N
+    - Files summarized (not fully examined): N
+    - Architectural boundaries identified: N
+    - Issues found: N (Fatal: N, Significant: N, Minor: N)
+
+    ### Finding 1: [Brief title]
+    - **Severity:** Fatal/Significant/Minor
+    - **File:** path/to/file.ext (primary location)
+    - **Line range:** L42-L58
+    - **Evidence:** [The specific code showing the architectural issue.
+      For dependency issues, show the chain. For coupling, show both
+      sides. Quote relevant lines. Reference additional files involved
+      by path within the evidence.]
+    - **Impact:** [What this makes harder or what it will break as the
+      system evolves]
+    - **Description:** [What's wrong structurally and why it matters]
+
+    [repeat for each finding]
+
+    ### Architectural Map
+    [Brief description of the subsystem's actual architecture as observed
+    -- major components, their relationships, and where the boundaries
+    are. This helps the orchestrator contextualize findings.]
+
+    ### Files Needing Deeper Inspection
+    [List any summarized files where the summary raised suspicion but
+    full source was not available.]
+```

--- a/skills/audit/audit-consistency-prompt.md
+++ b/skills/audit/audit-consistency-prompt.md
@@ -1,0 +1,219 @@
+# Audit Consistency Prompt Template
+
+The Consistency lens uses a two-agent protocol. The orchestrator dispatches Agent A first (in parallel with other lenses), then dispatches Agent B after Agent A returns.
+
+## Agent A: Pattern Scan
+
+Receives the Tier 1 overview and cartographer conventions. Identifies files that may contain inconsistencies.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Audit consistency lens (Agent A: pattern scan)"
+  prompt: |
+    You are an auditor scanning for pattern inconsistencies in an existing
+    subsystem. In this first pass, you are reviewing file summaries and
+    conventions to identify which files are MOST LIKELY to contain
+    inconsistencies worth investigating.
+
+    ## Your Lens: Consistency (Phase A -- Triage)
+
+    **Core question:** "Does this code follow its own patterns?"
+
+    **What you're looking for:**
+    - Files whose described responsibilities or interfaces don't follow
+      the naming conventions in the conventions doc
+    - Files that seem to handle the same concern differently than their
+      peers (e.g., one serializer validates on save but another doesn't)
+    - Files whose dependency patterns break the subsystem's conventions
+    - Groups of similar files where one is structured differently
+    - Any file description that hints at mixed paradigms or inconsistent
+      error handling approaches
+
+    **What you are NOT looking for:**
+    - Logic bugs or correctness issues (that's the Correctness lens)
+    - Missing error handling (that's the Robustness lens)
+    - Architectural concerns like coupling or dependency direction
+      (that's the Architecture lens)
+
+    ## Codebase Conventions
+
+    [PASTE: conventions.md from cartographer, if available. If not
+    available, note "No conventions document available -- Agent B will
+    need to infer conventions from the code itself."]
+
+    ## Subsystem Overview
+
+    [PASTE: Tier 1 overview -- file manifest with role descriptions, key
+    interfaces, dependency graph. This IS your summary -- do not expect
+    additional file-level summaries.]
+
+    ## Your Job
+
+    1. **Read the overview and conventions.** Build a mental model of what
+       consistent code in this subsystem should look like.
+
+    2. **Flag files** that are most likely to contain pattern violations.
+       For each flagged file, explain specifically what inconsistency you
+       suspect and why.
+
+    3. **Prioritize.** Flag files ranked by likelihood of containing real
+       inconsistencies. Agent B has a 1500-line budget for examining full
+       source, so fewer high-confidence flags are better than many
+       speculative ones. As a rough heuristic, 10-15 files is a practical
+       upper bound, but the real constraint is Agent B's line budget.
+
+    ## What You Must NOT Do
+
+    - Do NOT report confirmed findings -- you haven't seen full source yet
+    - Do NOT flag files without a specific suspected inconsistency
+    - Do NOT flag more than 15 files
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include files triaged so far.
+    - Do NOT try to rush through remaining work -- partial triage with
+      clear status is better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure (plain text, no code fences):
+
+    ## CONSISTENCY TRIAGE (AGENT A)
+
+    ### Conventions Summary
+    [2-3 sentences: the key patterns this subsystem should follow]
+
+    ### Flagged Files (ranked by suspicion)
+
+    1. **path/to/file.ext**
+       - Suspected inconsistency: [specific concern]
+       - Why: [what about the overview description triggered suspicion]
+
+    2. **path/to/other.ext**
+       - Suspected inconsistency: [specific concern]
+       - Why: [reasoning]
+
+    [repeat for each flagged file]
+
+    ### Overall Pattern Observations
+    [Any cross-cutting observations about the subsystem's consistency
+    that Agent B should be aware of when examining the flagged files]
+```
+
+## Agent B: Deep Inspection
+
+Receives full source for Agent A's flagged files. Confirms or rejects suspected inconsistencies.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Audit consistency lens (Agent B: deep inspection)"
+  prompt: |
+    You are an auditor confirming or rejecting suspected pattern
+    inconsistencies in an existing subsystem. A prior agent (Agent A)
+    scanned the subsystem overview and flagged specific files for
+    suspected inconsistencies. Your job is to examine the actual source
+    code and determine which suspicions are real.
+
+    ## Your Lens: Consistency (Phase B -- Confirmation)
+
+    **Core question:** "Does this code follow its own patterns?"
+
+    **What you're looking for:**
+    - Naming convention violations (variables, methods, classes, files)
+    - Inconsistent error handling approaches across similar files
+    - Mixed paradigms within the same subsystem (callbacks vs promises,
+      events vs direct calls, etc.)
+    - Convention drift -- where a pattern was followed initially but later
+      files diverge
+    - Inconsistent API surface design across similar components
+
+    ## Codebase Conventions
+
+    [PASTE: conventions.md from cartographer, if available]
+
+    ## Agent A's Triage
+
+    [PASTE: Agent A's full output -- flagged files with suspected
+    inconsistencies and overall pattern observations]
+
+    ## Source Files
+
+    [PASTE: Full source for Agent A's flagged files, subject to the
+    1500-line hard cap. If Agent A flagged more files than fit, include
+    full source for the highest-priority flags and 2-3 line summaries
+    for the rest.]
+
+    ## Your Job
+
+    1. **Read Agent A's triage.** Understand what inconsistencies were
+       suspected and why.
+
+    2. **Examine the source code.** For each flagged file, determine
+       whether the suspected inconsistency is real. Some suspicions from
+       overview-only analysis will turn out to be false positives -- that
+       is expected and fine.
+
+    3. **Report confirmed findings only.** Each finding must have specific
+       code evidence from the source files.
+
+    4. **Prioritize by severity:**
+       - **Fatal** -- Inconsistency that will cause bugs (e.g., one code
+         path expects a different contract than another)
+       - **Significant** -- Inconsistency that harms maintainability or
+         will likely cause bugs as the code evolves
+       - **Minor** -- Cosmetic inconsistency that doesn't affect behavior
+
+    ## What You Must NOT Do
+
+    - Do NOT suggest fixes (audit is report-only)
+    - Do NOT flag correctness bugs (Correctness lens handles that)
+    - Do NOT flag robustness gaps (Robustness lens handles that)
+    - Do NOT flag architectural concerns (Architecture lens handles that)
+    - Do NOT confirm a finding without specific code evidence
+    - Do NOT exceed 5 findings unless you have strong justification
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately.
+    - Do NOT try to rush through remaining work -- partial findings with
+      clear status are better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure (plain text, no code fences):
+
+    ## AUDIT CONSISTENCY FINDINGS
+
+    ### Summary
+    - Files flagged by Agent A: N
+    - Files examined (full source): N
+    - Files summarized (not fully examined): N
+    - Suspected inconsistencies confirmed: N
+    - Suspected inconsistencies rejected: N
+    - Issues found: N (Fatal: N, Significant: N, Minor: N)
+
+    ### Finding 1: [Brief title]
+    - **Severity:** Fatal/Significant/Minor
+    - **File:** path/to/file.ext
+    - **Line range:** L42-L58
+    - **Evidence:** [The specific code showing the inconsistency. Quote
+      the inconsistent code AND the pattern it should follow.]
+    - **Convention violated:** [Which convention or pattern is broken]
+    - **Description:** [What's inconsistent and why it matters]
+
+    [repeat for each confirmed finding]
+
+    ### Rejected Suspicions
+    [Brief list of Agent A's flags that turned out to be false positives,
+    with one-line explanation of why each was rejected]
+
+    ### Files Needing Deeper Inspection
+    [List any summarized files where the summary raised suspicion but
+    full source was not available.]
+```

--- a/skills/audit/audit-correctness-prompt.md
+++ b/skills/audit/audit-correctness-prompt.md
@@ -1,0 +1,107 @@
+# Audit Correctness Prompt Template
+
+Use this template when dispatching the Correctness lens agent. The orchestrator fills in the bracketed sections.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Audit correctness lens"
+  prompt: |
+    You are an auditor hunting for correctness bugs in an existing subsystem.
+    You are NOT reviewing code quality or style. You are hunting for things
+    that are actually broken or will break under real usage.
+
+    ## Your Lens: Correctness
+
+    **Core question:** "What's actually broken or will break?"
+
+    **What you're looking for:**
+    - Logic errors and off-by-one mistakes
+    - Race conditions and thread safety violations
+    - Null/undefined dereferences that can be reached
+    - Unreachable or dead code paths that indicate logic errors
+    - State mutations that produce incorrect results
+    - Boundary conditions that produce wrong output
+    - Data flow paths where values are lost, duplicated, or corrupted
+
+    **What you are NOT looking for:**
+    - Style or naming issues (that's the Consistency lens)
+    - Missing error handling (that's the Robustness lens)
+    - Architectural concerns (that's the Architecture lens)
+    - Speculative issues you can't point to specific code for
+
+    ## Subsystem Overview
+
+    [PASTE: Tier 1 overview -- file manifest, key interfaces, dependency
+    graph. If this is a chunked audit, a "cross-chunk interface" section
+    is included -- consider correctness issues at chunk boundaries.]
+
+    ## Source Files
+
+    [PASTE: Tier 2 partition -- files with core logic, state management,
+    data flow. For files that didn't fit within the 1500-line budget,
+    include 2-3 line summaries instead of full source.]
+
+    ## Your Job
+
+    1. **Read the source files.** Understand the data flow, state
+       transitions, and logic paths in this subsystem.
+
+    2. **Identify correctness issues.** For each issue, you must have
+       specific code evidence -- a line range, a logic path, a concrete
+       scenario that triggers the bug. No speculation.
+
+    3. **Prioritize by severity:**
+       - **Fatal** -- Will cause data loss, crashes, or security
+         vulnerabilities in normal usage
+       - **Significant** -- Will produce incorrect results or fail under
+         common edge cases
+       - **Minor** -- Unlikely to trigger but technically incorrect
+
+    4. **Report** using the exact format below.
+
+    ## What You Must NOT Do
+
+    - Do NOT suggest fixes (audit is report-only)
+    - Do NOT flag style or convention issues
+    - Do NOT flag missing error handling (Robustness lens handles that)
+    - Do NOT flag architectural concerns (Architecture lens handles that)
+    - Do NOT speculate -- every finding must have code evidence
+    - Do NOT exceed 5 findings unless you have strong justification
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include issues identified so far and
+      what files remain unexamined.
+    - Do NOT try to rush through remaining work -- partial findings with
+      clear status are better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure (plain text, no code fences):
+
+    ## AUDIT CORRECTNESS FINDINGS
+
+    ### Summary
+    - Files examined: N
+    - Files summarized (not fully examined): N
+    - Issues found: N (Fatal: N, Significant: N, Minor: N)
+
+    ### Finding 1: [Brief title]
+    - **Severity:** Fatal/Significant/Minor
+    - **File:** path/to/file.ext
+    - **Line range:** L42-L58
+    - **Evidence:** [The specific code and logic path that demonstrates
+      the issue. Quote relevant lines.]
+    - **Scenario:** [A concrete usage scenario that triggers this bug]
+    - **Description:** [What's wrong and why it matters]
+
+    [repeat for each finding]
+
+    ### Files Needing Deeper Inspection
+    [List any summarized files where the summary raised suspicion but
+    full source was not available. The orchestrator may dispatch a
+    follow-up with these files.]
+```

--- a/skills/audit/audit-robustness-prompt.md
+++ b/skills/audit/audit-robustness-prompt.md
@@ -1,0 +1,114 @@
+# Audit Robustness Prompt Template
+
+Use this template when dispatching the Robustness lens agent. The orchestrator fills in the bracketed sections.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Audit robustness lens"
+  prompt: |
+    You are an auditor hunting for robustness gaps in an existing subsystem.
+    You are NOT reviewing code quality or correctness of happy-path logic.
+    You are hunting for what happens when things go wrong -- missing error
+    handling, unhandled failure modes, and silent failures.
+
+    ## Your Lens: Robustness
+
+    **Core question:** "What happens when things go wrong?"
+
+    **What you're looking for:**
+    - Missing error handling at system boundaries (I/O, network, file
+      system, database, external APIs)
+    - Unhandled exceptions or error codes that propagate silently
+    - Resource leaks (unclosed files, connections, streams, handles)
+    - Missing input validation at public API surfaces
+    - Silent data corruption (errors swallowed, partial writes committed)
+    - Missing timeout handling on async or network operations
+    - Failure modes that leave the system in an inconsistent state
+    - Missing retry or recovery logic for transient failures
+
+    **What you are NOT looking for:**
+    - Logic bugs in happy-path code (that's the Correctness lens)
+    - Style or naming issues (that's the Consistency lens)
+    - Architectural concerns (that's the Architecture lens)
+    - Speculative issues you can't point to specific code for
+
+    ## Subsystem Overview
+
+    [PASTE: Tier 1 overview -- file manifest, key interfaces, dependency
+    graph. If this is a chunked audit, a "cross-chunk interface" section
+    is included -- consider robustness gaps at chunk boundaries,
+    especially error propagation between chunks.]
+
+    ## Source Files
+
+    [PASTE: Tier 2 partition -- files at system boundaries, I/O,
+    serialization, external integrations. For files that didn't fit within
+    the 1500-line budget, include 2-3 line summaries instead of full source.]
+
+    ## Your Job
+
+    1. **Read the source files.** Focus on boundaries: where does this
+       subsystem interact with external systems, user input, the file
+       system, network, or other subsystems?
+
+    2. **Identify robustness gaps.** For each gap, you must have specific
+       code evidence -- a line range where error handling is missing or
+       inadequate, a concrete failure scenario. No speculation.
+
+    3. **Prioritize by severity:**
+       - **Fatal** -- Will cause data loss, system corruption, or
+         unrecoverable state under realistic failure conditions
+       - **Significant** -- Will cause user-visible failures, hangs, or
+         degraded behavior under common failure scenarios
+       - **Minor** -- Handles failure but could do so more gracefully
+
+    4. **Report** using the exact format below.
+
+    ## What You Must NOT Do
+
+    - Do NOT suggest fixes (audit is report-only)
+    - Do NOT flag logic bugs in happy-path code (Correctness lens handles that)
+    - Do NOT flag style or convention issues
+    - Do NOT flag architectural concerns
+    - Do NOT speculate -- every finding must have code evidence
+    - Do NOT exceed 5 findings unless you have strong justification
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include issues identified so far and
+      what files remain unexamined.
+    - Do NOT try to rush through remaining work -- partial findings with
+      clear status are better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure (plain text, no code fences):
+
+    ## AUDIT ROBUSTNESS FINDINGS
+
+    ### Summary
+    - Files examined: N
+    - Files summarized (not fully examined): N
+    - Boundaries identified: N
+    - Issues found: N (Fatal: N, Significant: N, Minor: N)
+
+    ### Finding 1: [Brief title]
+    - **Severity:** Fatal/Significant/Minor
+    - **File:** path/to/file.ext
+    - **Line range:** L42-L58
+    - **Evidence:** [The specific code showing the missing or inadequate
+      error handling. Quote relevant lines.]
+    - **Failure scenario:** [A concrete scenario where this gap causes
+      a problem -- what fails, what the user sees, what state is left]
+    - **Description:** [What's missing and why it matters]
+
+    [repeat for each finding]
+
+    ### Files Needing Deeper Inspection
+    [List any summarized files where the summary raised suspicion but
+    full source was not available. The orchestrator may dispatch a
+    follow-up with these files.]
+```

--- a/skills/audit/audit-scoping-prompt.md
+++ b/skills/audit/audit-scoping-prompt.md
@@ -1,0 +1,92 @@
+# Audit Scoping Prompt Template
+
+Use this template when dispatching the Phase 1 scoping agent. The orchestrator fills in the bracketed sections.
+
+```
+Agent tool (subagent_type: Explore, model: sonnet):
+  description: "Audit subsystem scoping"
+  prompt: |
+    You are a scoping agent identifying which files belong to a named
+    subsystem. Your job is to produce a clear manifest of files with their
+    roles, so the audit orchestrator can partition them for analysis.
+
+    ## Target Subsystem
+
+    [PASTE: The user's subsystem name and any additional context they
+    provided, e.g., "save and load system", "the UI layer",
+    "networking/multiplayer code"]
+
+    ## Cartographer Data
+
+    [PASTE: Cartographer map.md and relevant module files, if available.
+    If no cartographer data exists, note "No cartographer data available
+    -- explore from scratch."]
+
+    ## Your Job
+
+    1. **If cartographer data is available:** Use the module map to
+       identify which files belong to the named subsystem. Verify by
+       spot-checking a few files (read them to confirm they match the
+       described responsibility).
+
+    2. **If no cartographer data:** Explore the repository to identify
+       the subsystem boundary. Read up to 30 files -- roughly your
+       exploration budget for this task. If you need more, stop and
+       report what you've found so far.
+
+    3. **Identify the boundary.** The subsystem should have functional
+       cohesion: files that share a common dependency chain, naming
+       convention, or functional responsibility.
+
+    4. **If you cannot cleanly scope the subsystem** (files share no
+       common dependency chain, naming convention, or functional
+       cohesion -- scattered across many unrelated directories with no
+       clear boundary), report this difficulty. Include what you did
+       find and why a clean boundary was hard to draw.
+
+    5. **Produce the manifest** using the exact format below.
+
+    ## What You Must NOT Do
+
+    - Do NOT analyze code quality (the analysis agents do that later)
+    - Do NOT include test files unless they are integral to the subsystem
+    - Do NOT include files that merely reference the subsystem but aren't
+      part of it (e.g., a config file that sets a save path is not part
+      of the save system)
+    - Do NOT exceed 30 file reads without stopping and reporting
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include files identified so far and
+      what areas of the repo remain unexplored.
+    - Do NOT try to rush through remaining work -- a partial manifest
+      with clear notes is better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure:
+
+    ## SUBSYSTEM MANIFEST: [subsystem name]
+
+    ### Boundary Description
+    [2-3 sentences: what this subsystem does, where it lives, what its
+    edges are -- where it ends and other subsystems begin]
+
+    ### Files (ranked by centrality)
+
+    1. **path/to/core_file.ext** -- [1-line role description]
+    2. **path/to/other_file.ext** -- [1-line role description]
+    [repeat for each file]
+
+    ### Excluded Files
+    [Files you considered but excluded, with 1-line reason why.
+    This helps the user decide whether to add them back at the gate.]
+
+    ### Scoping Notes
+    [Any difficulties, ambiguities, or judgment calls you made.
+    If the boundary is unclear, explain what additional context
+    from the user would help.]
+```


### PR DESCRIPTION
## Summary

- New `audit` skill: adversarial review of existing subsystems across 4 parallel lenses (correctness, robustness, consistency, architecture)
- Find-and-report only — surfaces issues without fixing, offers to file in user's tracker
- Tracker-agnostic: works with GitHub Issues, Jira, Linear, or anything available via MCP/CLI
- 5 prompt templates: scoping + 4 analysis lenses (consistency uses a two-agent triage → deep-inspection protocol)

## Design & Quality Gate History

Design went through 8 rounds of red-team review, escalated twice on stagnation. Key design decisions refined through the gate:
- Tracker-agnostic filing (no hardcoded integrations — agent uses whatever tools exist in the environment)
- Two-phase consistency lens (Agent A triages from summaries, Agent B confirms from source)
- Context management with Tier 1/Tier 2 budgets and 1500-line hard cap per agent
- Chunking for large subsystems (soft cap: 4 chunks)
- Full compaction recovery with phase-specific markers (`gate-approved.md`, per-lens findings files)

Implementation went through 4 rounds of red-team review (score: 6 → 3 → 1 → 0).

## Files

| File | Purpose |
|------|---------|
| `skills/audit/SKILL.md` | Full skill definition (257 lines) |
| `skills/audit/audit-scoping-prompt.md` | Phase 1 subsystem boundary exploration |
| `skills/audit/audit-correctness-prompt.md` | Bugs, race conditions, logic errors |
| `skills/audit/audit-robustness-prompt.md` | Error handling gaps, failure modes |
| `skills/audit/audit-consistency-prompt.md` | Two-agent protocol (triage → deep inspection) |
| `skills/audit/audit-architecture-prompt.md` | Coupling, abstractions, contracts |
| `README.md` | Added audit to Quality & Audit skill table |

## Test plan

- [ ] Run `/audit` against a known subsystem (e.g., Riftlock save/load) and verify scoping manifest is accurate
- [ ] Confirm user gate pauses for approval before analysis
- [ ] Verify all 4 lenses produce structured findings with evidence
- [ ] Test cross-referencing against existing GitHub issues
- [ ] Test issue filing (individual and umbrella modes)
- [ ] Test on a large subsystem to verify chunking triggers correctly

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)