### PR TITLE
feat: create test-coverage skill for post-change test suite auditing

### DIFF
--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -372,15 +372,14 @@ Quality-gate handles iteration tracking, stagnation detection, compaction recove
 
 If code review finds Critical or Important issues, fix them and re-review per the standard code review loop.
 
-**Step 2.5: Test suite audit** — Invoke `crucible:test-coverage` (if available) against the changed code and affected test files. This audits whether existing tests need updating, removal, or modification after the fix. Specifically checks for:
-- **Stale tests** — existing tests that assert on the pre-fix (incorrect) behavior
-- **Tests to update** — tests whose assertions are now wrong or misleading given the fix
+**Step 2.5: Test suite audit** — Invoke `crucible:test-coverage` (if available) against the changed code and affected test files. This audits whether existing tests need updating, removal, or modification after the fix. Three categories:
+- **Tests to update** — assertions, descriptions, or setup now wrong or misleading given the fix (includes stale assertions expecting old values)
 - **Tests to delete** — tests for removed code paths
-- **Tests that pass by coincidence** — tests whose assertions are unaffected but whose setup exercises the changed code path
+- **Coincidence tests** — tests whose setup exercises changed code but assertions verify unrelated properties (flagged for judgment, not auto-fixed)
 
 If `crucible:test-coverage` is not available, skip this step. The test gap writer (Step 3) handles missing coverage but NOT stale/misleading existing tests — this step fills that gap.
 
-If findings exist, dispatch a fix agent to make the changes, then re-run affected tests.
+The test-coverage skill handles its own fix dispatch and revert-on-failure logic internally. It returns a structured report with actions taken.
 
 **Step 3: Test gap writer** — If the code reviewer or red-teamer identified missing test coverage for the fix, dispatch a Test Gap Writer agent (Opus) using `./test-gap-writer-prompt.md`. The agent writes tests only for gaps specifically flagged in the review — no scope creep. Tests should PASS immediately since the behavior already exists from the fix. The agent reports per-test PASS/FAIL results. Skipped when reviews report zero coverage gaps.
 

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: test-coverage
+description: "Audit existing tests for staleness, needed updates, or removal after code changes. Use after any code modification to verify test suite alignment. Triggers on 'audit tests', 'check test alignment', 'stale tests', 'test health', or any task verifying tests match changed code. Technology-agnostic — works with any language and test framework."
+---
+
+# Test Alignment Audit
+
+Audits whether existing tests need updating, removal, or modification after code changes. Distinct from test-gap-writer (which adds NEW tests for missing coverage) — this skill reviews the EXISTING test suite's alignment with changed code.
+
+**Announce at start:** "Running test alignment audit on [scope description]."
+
+**Skill type:** Rigid -- follow exactly, no shortcuts.
+
+**Execution model:** When this skill is running, YOU are the orchestrator. You dispatch the audit and fix agents, handle conditional logic, and return results to the caller. All references to "the orchestrator" in this document refer to you.
+
+**Technology-agnostic:** This skill works with any programming language and test framework. Examples use generic patterns. The audit agent adapts its checks to whatever language and testing conventions are present in the project.
+
+## Why This Exists
+
+Code changes create three categories of test debt that pass silently:
+
+1. **Tests to update** — assertions, descriptions, or setup that are now wrong or misleading given the change. This includes tests that assert on pre-change behavior (stale assertions), tests with outdated descriptions, and tests whose helpers/utilities reference changed interfaces. Severity ranges from "assertion expects wrong value" to "test description is misleading but assertion is technically correct."
+2. **Tests to delete** — test code paths that were removed. They may still pass (testing dead code that wasn't cleaned up) or may have been silently skipped.
+3. **Coincidence tests** — test setup exercises the changed code, but assertions check something unrelated to the change. The test provides false confidence. These are flagged for human judgment, not auto-fixed.
+
+Test-gap-writer handles a fourth category (missing tests for new behavior). This skill handles categories 1-3 (existing tests misaligned with changed behavior).
+
+## When to Use
+
+- **After debugging fixes** (debugging Phase 5 Step 2.5)
+- **After build task implementation** (potential replacement for build Phase 3 Pass 2 staleness checks)
+- **After any code modification** where test suite health matters
+- **Before merging** as a final test alignment check
+- Anytime you want to verify tests still accurately document behavior
+
+## Inputs
+
+The skill receives from the caller:
+
+1. **Code diff** — the changes to audit against (`git diff <base-sha>..<head-sha>` or equivalent)
+2. **Affected test files** — test files in the same subsystem or that import changed modules. The caller identifies these, or the orchestrator discovers them by checking imports and directory proximity.
+3. **Context** (optional) — what the change was for (bug fix hypothesis, feature description, refactoring goal). Helps the auditor understand intent.
+
+## How It Works
+
+1. **Size check:** If the combined diff + test file content exceeds 2,000 lines, split the audit into multiple dispatches by test file grouping. Each dispatch gets the full diff but a subset of test files. When merging, check each dispatch's "Audit Coverage" line — if any dispatch reports unaudited files (context exhaustion), re-dispatch those files in a new batch.
+2. Dispatch a **Test Audit Agent** (Opus) using `./test-audit-prompt.md`
+3. The agent reads the diff and affected test files, then produces a structured report
+4. If findings in categories 1-2 exist (tests to update or delete): dispatch **Test Fix Agent(s)** (Opus) using `./test-fix-prompt.md`. If the audit was split (step 1), dispatch one fix agent per audit batch **sequentially** (not in parallel) to isolate revert scope. Sequential execution prevents file clobber when multiple batches have findings in shared test utilities (helpers, fixtures, conftest). Each fix agent checks `git status` before starting to confirm the tree is in the expected state. A failure in one batch does not discard successful fixes from other batches.
+5. Each fix agent reads the current source files (not just the diff) to determine correct new behavior, makes test changes, and runs affected tests
+6. If modified tests fail: the fix agent reverts its own batch's changes and reports the failure
+7. If modified tests pass: the orchestrator commits the batch's changes (`test: batch N alignment fixes`) before dispatching the next batch. This ensures clean revert targets for subsequent batches and prevents revert clobber of prior successes. The caller may squash these commits per its own protocol.
+8. Return the combined report (audit findings + fix actions across all batches) to the caller
+
+### Test Audit Agent
+
+Dispatch: `Agent tool (subagent_type: "general-purpose", model: opus)`
+
+The audit agent receives the code diff, affected test files (full source), and optional context. It checks three categories:
+
+**Category 1 — Tests to Update:**
+- Assertions that expect values the code no longer produces
+- Test descriptions/names that document behavior that was changed
+- Setup/arrange sections that create scenarios the code no longer supports
+- Test helpers or utilities that reference changed interfaces or signatures
+- Mock setups that no longer match the real implementation
+- Severity: **wrong** (assertion will produce incorrect documentation of behavior) vs **misleading** (technically passes but describes old intent)
+
+**Category 2 — Tests to Delete:**
+- Tests for deleted functions, methods, or classes
+- Tests for removed code branches (e.g., a removed error path)
+- Tests for deprecated behavior that was cleaned up in this change
+- Test files whose entire corresponding source file was deleted
+
+**Category 3 — Coincidence Tests (flag only, do not fix):**
+- Tests whose setup calls into the changed code path but whose assertions verify something unrelated to the change
+- Tests where the assertion checks a property that was NOT modified by the diff, even though the test exercises code that WAS modified
+- These are structurally detectable: does the test's assertion reference any value or behavior that appears in the diff? If not, and the test's setup exercises diff-affected code, it's a coincidence test.
+
+**Evidence requirement:** Every finding must reference specific test file, test name, and the line(s) in the diff that make the test problematic. No speculation.
+
+### Test Fix Agent
+
+If the audit agent reports findings in categories 1-2, dispatch a fix agent (Opus) that receives:
+- The audit report
+- The affected test files (full source)
+- The code diff
+
+The fix agent has tool access to **read current source files** — it needs the actual current behavior (not just the diff) to write correct updated assertions.
+
+The fix agent:
+1. Updates stale assertions to match new behavior
+2. Updates misleading test names/descriptions
+3. Deletes tests for removed code paths
+4. Does NOT modify coincidence tests (category 3) — those are flagged for the caller
+5. Runs all modified test files to verify changes don't break anything
+
+**On success:** Reports changes made (tests updated, tests deleted, all passing).
+
+**On failure:** Reverts its own changes using `git checkout` + `git clean` (see `test-fix-prompt.md`), then verifies clean working tree with `git status`. Reports: "Attempted fix for [finding], reverted because [test failure details]. Manual intervention needed." This prevents broken test modifications from polluting the working tree. The caller decides next steps per its own protocol.
+
+**Precondition:** The working tree must be clean when this skill starts. The caller should commit before invoking test-coverage (debugging's commit strategy handles this). In multi-batch mode, the orchestrator commits each successful batch before dispatching the next, maintaining the clean-tree invariant throughout. If uncommitted changes are detected, the fix agent reports this and does not proceed.
+
+### Output Format
+
+The skill returns a structured report to the caller:
+
+```
+## Test Alignment Audit Report
+
+### Summary
+- Tests audited: N
+- Tests updated: N
+- Tests deleted: N
+- Coincidence tests flagged: N (require caller judgment)
+- All modified tests passing: yes/no
+- Fix agent reverts: N (if any fixes failed)
+
+### Findings
+
+#### Tests Updated
+- `test_file::test_name` — assertion on line N expected OLD_VALUE, updated to NEW_VALUE. Diff ref: [changed line]
+[repeat]
+
+#### Tests Deleted
+- `test_file::test_name` — tested removed code path [description]. Diff ref: [removed lines]
+[repeat]
+
+#### Coincidence Tests (flagged, not modified)
+- `test_file::test_name` — exercises changed code but asserts on [unrelated property]. Consider updating assertion to verify [changed behavior].
+[repeat]
+
+#### Fix Failures (reverted)
+- `test_file::test_name` — attempted [change], reverted because [failure reason]. Manual intervention needed.
+[repeat]
+
+### Test Run Results
+- [PASS/FAIL] per modified test file
+```
+
+## Caller Integration
+
+### From debugging (Phase 5 Step 2.5)
+
+```
+Invoke crucible:test-coverage with:
+- Code diff: git diff <pre-debug-sha>..HEAD
+- Affected test files: test files in subsystem identified during investigation
+- Context: "Debugging fix for [hypothesis summary]"
+```
+
+### From build (Phase 3 — potential future integration)
+
+```
+Invoke crucible:test-coverage with:
+- Code diff: git diff <pre-task-sha>..HEAD
+- Affected test files: test files touched or related to task
+- Context: "Build task N: [task description]"
+```
+
+Build's reviewer Pass 2 currently checks test health inline. A future integration could replace the staleness-detection portion of Pass 2 with this skill, letting the reviewer focus on test quality (independence, determinism, edge cases). This integration is not yet wired — the build skill would need to be updated to dispatch this skill.
+
+### Standalone
+
+```
+Invoke crucible:test-coverage with:
+- Code diff: git diff <base>..HEAD
+- Context: [description of changes]
+```
+
+## Guardrails
+
+**The audit agent must NOT:**
+- Write new tests (that's test-gap-writer's job)
+- Modify source code (only audit test files)
+- Flag style or naming issues unrelated to the change
+- Speculate about test health without evidence from the diff
+- Use counterfactual reasoning ("would this test pass if reverted?") — use structural checks instead
+
+**The fix agent must NOT:**
+- Modify coincidence tests (flag them, don't guess what they should assert)
+- Delete tests that still test valid behavior (even if the test name is slightly misleading)
+- Add new test cases (scope is updating/removing existing tests only)
+- Leave failed modifications in the working tree (revert on failure)
+
+## Red Flags
+
+- Auditing tests without reading the code diff (can't assess staleness without knowing what changed)
+- Deleting tests "to be safe" without evidence they test removed behavior
+- Updating assertions to make tests pass without understanding WHY they should pass
+- Confusing "test passes" with "test is correct" — a passing test can still be stale
+
+## Prompt Templates
+
+- `./test-audit-prompt.md` — Test audit agent dispatch
+- `./test-fix-prompt.md` — Test fix agent dispatch (revert-on-failure, source file access)
+
+## Integration
+
+- **Called by:** `crucible:debugging` (Phase 5 Step 2.5), standalone invocation
+- **Future callers:** `crucible:build` (Phase 3 Pass 2 replacement — not yet wired)
+- **Distinct from:** `crucible:test-driven-development` (writes tests during implementation), test-gap-writer (adds missing coverage for new behavior)
+- **Does NOT use:** `crucible:quality-gate` (this is a single-pass audit, not an iterative loop)

--- a/skills/test-coverage/test-audit-prompt.md
+++ b/skills/test-coverage/test-audit-prompt.md
@@ -1,0 +1,160 @@
+# Test Audit Prompt Template
+
+Use this template when dispatching the test audit agent. The orchestrator fills in the bracketed sections.
+
+```
+Agent tool (subagent_type: "general-purpose", model: opus):
+  description: "Test alignment audit for changed code"
+  prompt: |
+    You are a test auditor. Your job is to review existing tests and determine
+    whether they are still accurate, relevant, and correctly aligned with
+    recent code changes. You are NOT writing new tests — you are auditing
+    existing ones.
+
+    This is technology-agnostic. Adapt your checks to whatever language and
+    test framework is present in the project.
+
+    ## Code Changes
+
+    [PASTE: The code diff (git diff output). This is the source of truth
+    for what changed. Every finding must reference something in this diff.]
+
+    ## Affected Test Files
+
+    [PASTE: Full source of test files in the affected subsystem. Include
+    test files that import or exercise changed modules.]
+
+    ## Context
+
+    [PASTE: What the change was for — bug fix hypothesis, feature
+    description, refactoring goal. This helps you understand intent.
+    If no context provided, write "No context provided — audit based
+    on diff only."]
+
+    ## Your Job
+
+    Review every test in the affected test files against the code diff.
+    For each test, determine whether it falls into one of three categories:
+
+    ### Category 1: Tests to Update
+    Tests whose assertions, descriptions, or setup are now wrong or
+    misleading given the code change.
+
+    Check for:
+    - Assertions that expect values the code no longer produces
+    - Test descriptions/names that document behavior that was changed
+    - Setup/arrange sections that create scenarios the code no longer
+      supports
+    - Test helpers or utilities that reference changed interfaces or
+      method signatures
+    - Mock setups that no longer match the real implementation
+    - Comments that describe old behavior
+
+    For each finding, note severity:
+    - **Wrong:** assertion documents incorrect behavior (e.g., expects
+      old return value)
+    - **Misleading:** technically passes but describes old intent (e.g.,
+      test named "test_returns_null" when function now returns empty list)
+
+    ### Category 2: Tests to Delete
+    Tests for code paths that were removed.
+
+    Check for:
+    - Tests for deleted functions, methods, or classes
+    - Tests for removed code branches (e.g., a removed error path)
+    - Tests for deprecated behavior cleaned up in this change
+    - Test files whose entire corresponding source file was deleted
+
+    ### Category 3: Coincidence Tests (flag only)
+    Tests that exercise the changed code but assert on unrelated
+    properties.
+
+    Detection (structural, not counterfactual):
+    - Does the test's assertion reference any value or behavior that
+      appears in the diff? If NOT, and the test's setup/act exercises
+      code paths that DO appear in the diff, it is a coincidence test.
+    - Look for tests where the "act" step calls into changed code but
+      the "assert" step checks a property that was not modified.
+
+    Do NOT use counterfactual reasoning ("would this test pass if the
+    change were reverted?"). Use structural checks: does the assertion
+    verify something the diff touched?
+
+    ## Evidence Requirement
+
+    Every finding MUST include:
+    - The specific test file and test name
+    - The line(s) in the test that are stale/wrong/deletable
+    - The line(s) in the code diff that make the test problematic
+    - WHY this is a problem (not just that it exists)
+
+    Do NOT speculate. If you cannot point to specific code evidence,
+    do not report the finding.
+
+    ## What You Must NOT Do
+
+    - Do NOT write new tests (that is the test-gap-writer's job)
+    - Do NOT modify source code (audit test files only)
+    - Do NOT flag style or naming issues unrelated to the code change
+    - Do NOT report tests as stale just because they are old
+    - Do NOT exceed the evidence in the diff — if a test might be
+      affected but you cannot trace the connection, skip it
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include findings so far and list
+      unaudited files in the "Audit Coverage" section of the output format.
+    - Do NOT try to rush through remaining files — partial findings
+      with clear status are better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure (plain text, no code fences):
+
+    ## TEST ALIGNMENT AUDIT FINDINGS
+
+    ### Summary
+    - Test files audited: N
+    - Total tests reviewed: N
+    - Tests to update: N (wrong: N, misleading: N)
+    - Tests to delete: N
+    - Coincidence tests flagged: N
+
+    ### Category 1: Tests to Update
+    #### Finding 1: [test name]
+    - **File:** path/to/test_file
+    - **Test:** test_function_name (line N)
+    - **Severity:** Wrong / Misleading
+    - **Problem:** [What the test asserts/describes vs what the code now does]
+    - **Diff reference:** [Which lines in the diff make this wrong/misleading]
+    - **Recommended action:** [Update assertion from X to Y / Update description / Update mock setup]
+
+    [repeat for each finding]
+
+    ### Category 2: Tests to Delete
+    #### Finding N: [test name]
+    - **File:** path/to/test_file
+    - **Test:** test_function_name (line N)
+    - **Problem:** Tests [removed code path/function/behavior]
+    - **Diff reference:** [Where the code was removed]
+    - **Recommended action:** Delete test
+
+    [repeat]
+
+    ### Category 3: Coincidence Tests (flag only)
+    #### Finding N: [test name]
+    - **File:** path/to/test_file
+    - **Test:** test_function_name (line N)
+    - **Problem:** Exercises changed code but asserts on [unrelated thing]
+    - **Suggestion:** Consider updating assertion to verify [changed behavior]
+
+    [repeat]
+
+    ### Audit Coverage
+    - Test files audited: N/M
+    - Fully aligned (no findings): N
+    - Unaudited files (context exhaustion): [list of file paths, or "none"]
+```

--- a/skills/test-coverage/test-fix-prompt.md
+++ b/skills/test-coverage/test-fix-prompt.md
@@ -1,0 +1,126 @@
+# Test Fix Prompt Template
+
+Use this template when dispatching the test fix agent after the audit agent reports findings in categories 1-2 (tests to update, tests to delete). The orchestrator fills in the bracketed sections.
+
+```
+Agent tool (subagent_type: "general-purpose", model: opus):
+  description: "Fix test alignment issues found by audit"
+  prompt: |
+    You are a test fix agent. The test audit agent identified existing tests
+    that are misaligned with recent code changes. Your job is to update or
+    delete those tests so the test suite accurately documents current behavior.
+
+    You are NOT writing new tests. You are fixing existing ones.
+
+    ## Audit Report
+
+    [PASTE: The full audit report from the test audit agent, including
+    all Category 1 (Tests to Update) and Category 2 (Tests to Delete)
+    findings with their evidence and recommended actions.]
+
+    ## Code Diff
+
+    [PASTE: The code diff that triggered the audit. Use this to understand
+    what changed and why tests need updating.]
+
+    ## File Access
+
+    Use your tools to read test files and source files as needed. The audit
+    report references specific files and line numbers — read those files
+    directly rather than relying on pasted content. You need to read
+    current source files to understand the ACTUAL new behavior when
+    updating assertions.
+
+    ## Your Job
+
+    For each finding in the audit report:
+
+    ### Category 1 findings (Tests to Update):
+    1. Read the current source code (use your tools) to understand the
+       ACTUAL current behavior — do not guess from the diff alone
+    2. Update the test assertion to match the new correct behavior
+    3. Update test descriptions/names if they are misleading
+    4. Update mock setups or helpers if they reference changed interfaces
+
+    ### Category 2 findings (Tests to Delete):
+    1. Delete the test function/method
+    2. If the entire test file is for deleted code, delete the file
+    3. Clean up any test utilities that are now unused
+
+    ### Category 3 findings (Coincidence Tests):
+    Do NOT modify these. They are flagged for human judgment. Skip them.
+
+    ## Revert-on-Failure Procedure
+
+    BEFORE making any changes:
+    1. Record the list of files you will modify, create, or delete
+
+    AFTER making changes:
+    2. Run all modified test files to verify your changes pass
+    3. If ALL tests pass: report success
+    4. If ANY test fails: revert ALL your changes:
+       a. Run `git checkout -- <each modified file>` to restore originals
+       b. Run `git clean -f <each new file you created>` to remove them
+       c. Run `git status` to verify the working tree is clean
+       d. Report the failure: which test failed, why, and what you attempted
+
+    Do NOT leave failed modifications in the working tree. The caller
+    depends on a clean state after your dispatch.
+
+    **Precondition:** The working tree should be clean when you start
+    (prior batches are committed by the orchestrator, and the caller
+    commits before invoking test-coverage). If you detect uncommitted
+    changes before starting, report this to the caller and do not
+    proceed.
+
+    ## What You Must NOT Do
+
+    - Do NOT modify coincidence tests (Category 3) — flag them, skip them
+    - Do NOT write new test cases — only update or delete existing ones
+    - Do NOT modify source code — only test files
+    - Do NOT delete tests that still test valid behavior
+    - Do NOT update assertions just to make tests pass — understand WHY
+      the new value is correct by reading the current source code
+    - Do NOT leave uncommitted changes on failure — always revert
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include fixes applied so far and
+      which findings remain unaddressed.
+    - Do NOT try to rush through remaining fixes — partial fixes with
+      clear status are better than degraded output.
+
+    ## Output Format
+
+    Report using this EXACT structure (plain text, no code fences):
+
+    ## TEST FIX REPORT
+
+    ### Summary
+    - Tests updated: N
+    - Tests deleted: N
+    - Coincidence tests skipped: N
+    - All modified tests passing: yes/no
+    - Reverted due to failure: yes/no
+
+    ### Tests Updated
+    - `test_file::test_name` — assertion on line N changed from
+      OLD_VALUE to NEW_VALUE. Verified against current source at
+      [source_file:line].
+    [repeat]
+
+    ### Tests Deleted
+    - `test_file::test_name` — removed (tested [deleted code path])
+    [repeat]
+
+    ### Fix Failures (if any, all reverted)
+    - `test_file::test_name` — attempted [change], test failed with
+      [error]. Reverted. Manual intervention needed because: [reason].
+    [repeat]
+
+    ### Test Run Results
+    - [PASS/FAIL] per modified test file
+```


### PR DESCRIPTION
## Summary

- New **crucible:test-coverage** skill that audits existing tests for staleness, needed updates, or removal after code changes
- Quality-gated through 5 rounds of adversarial review (score 9→2→3→1→1)
- Technology-agnostic — works with any language and test framework
- Updates debugging SKILL.md Step 2.5 to match the skill's 3-category model

## Key design

- **3 categories:** Tests to update (wrong/misleading), tests to delete, coincidence tests (flagged, not auto-fixed)
- **Audit agent** (Opus) reads diff + test files, produces structured evidence-based report
- **Fix agent** (Opus) updates/deletes tests with checkout+clean revert on failure
- **Split audit** for large scopes (>2000 lines) with sequential fix agents and per-batch commits
- **Clean tree precondition** — caller commits before invoking, orchestrator commits between batches
- **Structured output** with unaudited files tracking for context exhaustion recovery

## Quality Gate Scorecard

| Round | Fatal | Significant | Score |
|-------|-------|-------------|-------|
| 1 | 1 | 6 | 9 |
| 2 | 0 | 2 | 2 |
| 3 | 0 | 3 | 3 (regression — fix-prompt was new content) |
| 4 | 0 | 1 | 1 |
| 5 | 0 | 1 | 1 (stagnation) |

## Test plan

- [ ] Invoke test-coverage with a small diff and verify audit agent produces structured report
- [ ] Verify fix agent reverts on test failure (checkout+clean, git status clean)
- [ ] Test split audit path (>2000 lines) — confirm sequential fix dispatch and per-batch commits
- [ ] Verify clean tree precondition check (fix agent refuses on dirty tree)
- [ ] Confirm debugging Phase 5 Step 2.5 correctly invokes with "if available" guard

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)