### PR TITLE
feat: add Phase 4.5 'Where Else?' blast radius scan to /debugging

### DIFF
--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -43,6 +43,7 @@ The debugging skill writes session state to disk at **every phase transition**, 
 - `hypothesis-log.md`: running hypothesis log (updated at Phase 3, after Phase 4 results)
 - `synthesis-report.md`: latest synthesis report (written after Synthesis completes)
 - `implementation-details.md`: cumulative record of implementation attempts — what was tried, which files changed, regressions encountered, why it failed (appended after each Phase 4)
+- `where-else-state.md`: Phase 4.5 state — pre-Phase-4.5 SHA, generalized pattern, siblings found/fixed/remaining (written during Phase 4.5, read during compaction recovery)
 
 **Context hygiene:** After synthesis completes, raw Phase 1 investigation reports are superseded by the synthesis report. The orchestrator should rely on the synthesis report going forward, not the raw reports. After Phase 4 completes (success or failure), the Phase 2 pattern analysis report is superseded by the implementation results. This keeps the orchestrator lean across long sessions.
 
@@ -51,7 +52,8 @@ The debugging skill writes session state to disk at **every phase transition**, 
 2. Read `hypothesis-log.md` for hypothesis history.
 3. Read `synthesis-report.md` for latest investigation findings.
 4. Read `implementation-details.md` for prior fix attempts.
-5. Output status to user and continue from the current phase.
+5. Read `where-else-state.md` (if exists) for Phase 4.5 progress — which siblings have been fixed, which remain.
+6. Output status to user and continue from the current phase.
 
 **Cleanup:** Delete scratch directory after debugging completes (Phase 5 passes clean or escalation to user).
 
@@ -103,6 +105,7 @@ All investigation and implementation is delegated to subagents via the Agent too
 | Synthesis | Consolidation | Opus | Cross-referencing, contradiction detection, and causal reasoning — not just summarization |
 | Phase 2 | Pattern Analysis | Opus | Exhaustive comparison requires depth |
 | Phase 4 | Implementation | Opus | TDD + root cause fix |
+| Phase 4.5 | "Where Else?" scan | Opus | Cross-codebase pattern matching and sibling fixing |
 | Phase 5 | Red-team | Opus | Adversarial analysis |
 | Phase 5 | Code review | Opus or Sonnet | Lead decides by fix complexity |
 | Phase 5 | Test gap writer | Opus | Test authoring requires reasoning |
@@ -144,8 +147,11 @@ Phase 3.5: Hypothesis Red-Team (crucible:quality-gate on hypothesis)
 Phase 4: Implementation agent (TDD: failing test, fix, verify)
     |
     v
-Orchestrator: Verify fix -> Success? Phase 5. Failed? Cleanup, log, loop back.
+Orchestrator: Verify fix -> Success? Phase 4.5. Failed? Cleanup, log, loop back.
     -> 3 failures? Escalate to user.
+    |
+    v
+Phase 4.5: "Where Else?" scan — find and fix sibling locations
     |
     v
 Phase 5: Quality-gate the fix (crucible:quality-gate) + Code review (crucible:code-review)
@@ -356,9 +362,84 @@ This gives every outcome path a clean revert target (`git revert <sha>`), gives 
 
 On loop-back (failed fix or user-requested revert), `git revert <wip-sha>` cleanly undoes all Phase 4 changes including new files.
 
+If Phase 4.5 ran (sibling commits exist): use `git revert <pre-4.5-sha>..HEAD` instead of `git revert <wip-sha>`. This reverts all sibling commits plus the original WIP commit in one operation. See Phase 4.5 below.
+
+**Phase 4.5 sibling commits:** Each sibling fix uses the prefix `fix(sibling):` with a descriptive message. Example: `fix(sibling): add icon initialization to StashScreen.OnEnable`
+
+---
+
+### Phase 4.5: "Where Else?" Blast Radius Scan
+
+After Phase 4 succeeds and the WIP commit is created, dispatch the "Where Else?" scan agent to find and fix analogous locations in the codebase that have the same bug pattern. Phase 4.5 does NOT run on loop-back paths (fix failed, regressions found).
+
+**Prompt template:** `./where-else-prompt.md`
+
+**Pre-Phase-4.5 SHA:** Immediately after the Phase 4 WIP commit succeeds, record its SHA. This is the last commit before any sibling work begins. Store it in `where-else-state.md` in the scratch directory.
+
+#### Three Input Signals
+
+The scan agent receives three sources of information:
+
+1. **The fix diff** — `git diff <pre-fix-sha>..HEAD`. The structural pattern of what changed: what was missing, what was added, and what makes a location "analogous."
+2. **Cartographer module context** — If cartographer data is available from Phase 0, structurally similar modules (other screens, panels, managers, handlers that follow the same architectural pattern as the fixed code).
+3. **Implementer's "Analogous Locations" report** — The Phase 4 implementer's observations about locations they noticed during the fix that may have the same pattern. This is the highest-quality signal — the implementer was already reading the code.
+
+#### Scan Agent Behavior
+
+1. **Analyze the fix pattern.** Read the diff. Extract the structural pattern. Produce a 2-3 sentence generalized pattern description.
+2. **Build candidate list.** Combine all three input signals, deduplicate candidates.
+3. **Evaluate each candidate.** Read the code at that location. Determine if the same pattern/omission exists. If yes: write a justification explaining WHY this location matches semantically (not just structurally). If no: record as skipped with reason.
+4. **Fix confirmed siblings.** For each confirmed sibling:
+   - Apply the same fix pattern
+   - Run tests
+   - If tests pass: commit with `fix(sibling): <description>`
+   - If tests fail: revert that single commit, record as "reverted — test failure", continue with remaining candidates
+   - After each fix (or revert), update `where-else-state.md` in the scratch directory
+5. **Report back.** Structured report:
+
+```
+## Where Else? Scan Report
+
+### Generalized Pattern
+[2-3 sentence pattern description]
+
+### Candidates Evaluated: N
+
+### Siblings Fixed: N
+- [file:path] — [commit SHA] — Justification: [why this matches]
+- ...
+
+### Siblings Skipped: N
+- [file:path] — Reason: [why this doesn't match]
+- ...
+
+### Siblings Reverted: N
+- [file:path] — Test failure: [summary of what failed]
+- ...
+```
+
+#### Compaction Recovery
+
+Phase 4.5 maintains state in `<scratch-dir>/where-else-state.md` to survive session compaction. The file is updated after each sibling fix. On compaction recovery, the agent reads this file to:
+- Skip siblings already fixed
+- Resume from where it left off with remaining siblings
+- Recover the pre-Phase-4.5 SHA (needed for revert mechanics)
+- Recover the generalized pattern (avoids re-deriving from the diff)
+
+#### Rules
+
+- Apply the SAME fix pattern — do not invent new approaches for siblings
+- One commit per sibling — clean revert granularity
+- If tests fail for a sibling, revert and continue — do not debug the sibling
+- Do not modify the original fix
+- If no candidates are found, report "No analogous locations found" and proceed to Phase 5
+- No cap on sibling count — fix all confirmed siblings
+
+---
+
 ### Phase 5: Red-Team and Code Review (Post-Fix Quality Gate)
 
-After Phase 4 succeeds and the WIP commit is created, the orchestrator runs quality gates before declaring done:
+After Phase 4.5 completes (or Phase 4 succeeds if no Phase 4.5 ran), the orchestrator runs quality gates before declaring done:
 
 **Step 1: Quality-gate the fix** — Invoke `crucible:quality-gate` with artifact type "code" against the changed code. Quality-gate dispatches fresh red-team reviewers to adversarially review the fix for:
 - Edge cases the fix doesn't handle
@@ -398,7 +479,7 @@ The test-coverage skill handles its own fix dispatch and revert-on-failure logic
 
 **If Phase 5 quality-gate escalates** (stagnation or round limit): Present the quality-gate findings to the user alongside the fix. The user decides:
 - **(a) Accept the fix** with known issues noted
-- **(b) Revert and loop back** — revert the WIP commit and loop back to Phase 1 with the quality-gate findings as new investigation context
+- **(b) Revert and loop back** — revert the WIP commit (or range revert `<pre-4.5-sha>..HEAD` if Phase 4.5 ran) and loop back to Phase 1 with the quality-gate findings as new investigation context
 - **(c) Stop debugging** — end the session with the current state
 
 This is user-gated, not automatic. The orchestrator does not decide whether to loop back from Phase 5 on its own.
@@ -444,7 +525,7 @@ Decision types:
 
 After the Implementation agent reports back, the orchestrator evaluates four possible outcomes:
 
-**Fix works, no regressions** -- Log the result in the hypothesis log. Proceed to Phase 5. After Phase 5 passes clean:
+**Fix works, no regressions** -- Log the result in the hypothesis log. Proceed to Phase 4.5 ("Where Else?" blast radius scan). After Phase 4.5 completes, proceed to Phase 5. After Phase 5 passes clean:
 - **RECOMMENDED:** Use crucible:forge (retrospective mode) — capture the debugging journey and lessons learned
 - **RECOMMENDED:** Use crucible:cartographer (record mode) — persist any new codebase knowledge discovered during investigation
 
@@ -457,7 +538,7 @@ After the Implementation agent reports back, the orchestrator evaluates four pos
 **Fix does not resolve the issue** -- Before looping back:
 1. Log the failure in the hypothesis log with metrics (see Stagnation Detection below)
 2. **Test triage:** Dispatch a quick Opus subagent to read the test and the hypothesis log, then decide: keep the test (if it validly reproduces the bug regardless of the failed fix) or remove it (if it was hypothesis-specific and doesn't reproduce the actual bug). The orchestrator does not make this judgment directly — it requires reading code.
-3. **Revert the WIP commit** using `git revert <wip-sha>` (see Commit Strategy above). This cleanly undoes all Phase 4 changes including any new files created during refactoring.
+3. **Revert the WIP commit** using `git revert <wip-sha>` (see Commit Strategy above). This cleanly undoes all Phase 4 changes including any new files created during refactoring. If Phase 4.5 ran (sibling commits exist): use `git revert <pre-4.5-sha>..HEAD` instead of `git revert <wip-sha>` to revert all sibling commits plus the original WIP commit.
    - If triage decided **"keep the test"**: dispatch a subagent to recover the test file from the reverted commit (`git checkout <wip-sha> -- <test-file-path>`) and commit it separately (`test: preserve reproduction test from cycle N`).
    - If triage decided **"remove the test"**: no further action — the revert already removed it.
 4. Verify the working tree is clean: dispatch the cleanup agent to run `git status` and report any remaining modifications or untracked files. If any remain, clean them up before proceeding.
@@ -511,6 +592,7 @@ This is NOT a failed hypothesis -- this is a wrong architecture. Discuss with yo
 | **3. Hypothesis** | Orchestrator (no subagent) | Form hypothesis, check log | Specific testable hypothesis |
 | **3.5 Red-Team** | Quality gate (on hypothesis) | Challenge hypothesis completeness | Hypothesis survives or is reformed |
 | **4. Implementation** | 1 subagent (Opus) | TDD fix cycle with evidence log | Bug resolved, tests pass, TDD log |
+| **4.5. Where Else?** | 1 subagent (Opus) | Find and fix sibling locations | Siblings fixed or confirmed none exist |
 | **5. Quality Gate** | Red-team + code review | Adversarial review, quality check | Both pass clean |
 | **5b. Test Audit** | Test coverage skill (conditional) | Audit existing tests for staleness after fix | Stale tests updated/removed |
 | **5c. Test Gaps** | Test gap writer (Opus, conditional) | Write tests for reviewer-flagged gaps | All gap tests pass |
@@ -597,6 +679,7 @@ If systematic investigation reveals issue is truly environmental, timing-depende
 - **`./synthesis-prompt.md`** -- Synthesis agent prompt
 - **`./pattern-analyst-prompt.md`** -- Phase 2 pattern analysis agent prompt
 - **`./implementer-prompt.md`** -- Phase 4 implementation agent prompt
+- **`./where-else-prompt.md`** -- Phase 4.5 "Where Else?" scan agent prompt
 - **`./test-gap-writer-prompt.md`** -- Phase 5 test gap writer prompt (when reviews flag missing coverage)
 
 **Supporting techniques** (available in this directory):

--- a/skills/debugging/implementer-prompt.md
+++ b/skills/debugging/implementer-prompt.md
@@ -217,6 +217,21 @@ Agent tool (subagent_type: "general-purpose", model: opus):
     - [TestName] — RED: "[exact failure message]" → GREEN: pass
     ```
 
+    ### Analogous Locations
+
+    While fixing this bug, report any locations you noticed that may have the same pattern/omission:
+
+    ```
+    Analogous Locations:
+    - [file:path] — [brief description of why this might be a sibling]
+    - [file:path] — [brief description]
+    - (If none observed: "No analogous locations observed during the fix.")
+    ```
+
+    This information feeds Phase 4.5's "Where Else?" scan. You are NOT expected
+    to fix these locations — just note them if you happen to see them while
+    working on the fix.
+
     ## What NOT To Do
 
     - Do NOT investigate the bug — that was done in earlier phases

--- a/skills/debugging/where-else-prompt.md
+++ b/skills/debugging/where-else-prompt.md
@@ -1,0 +1,266 @@
+# "Where Else?" Scan Agent Prompt Template
+
+Use this template when the orchestrator dispatches the Phase 4.5 "Where Else?" scan agent. This agent runs ONLY after Phase 4 succeeds (fix works, no regressions). It receives the fix diff, cartographer context, and implementer observations, then finds and fixes analogous locations in the codebase that have the same bug pattern.
+
+Fill in the placeholders before dispatching.
+
+```
+Agent tool (subagent_type: "general-purpose", model: opus):
+  description: "Where Else? scan: find and fix sibling locations for [one-line summary of the fix]"
+  prompt: |
+    You are the "Where Else?" scan agent for a systematic debugging session.
+    Your job is to find analogous locations in the codebase that have the same
+    bug pattern as the one just fixed, and apply the same fix to each.
+
+    You do NOT investigate. You do NOT invent new fixes. You find siblings of
+    a known fix and apply the same pattern — nothing more.
+
+    ## Fix Diff
+
+    The Phase 4 implementation agent just fixed a bug. Here is the diff of
+    what changed:
+
+    [FIX_DIFF]
+
+    ## Cartographer Context
+
+    Structurally similar modules from cartographer (may be empty if no
+    cartographer data is available):
+
+    [CARTOGRAPHER_CONTEXT]
+
+    ## Implementer Observations
+
+    The Phase 4 implementer reported these analogous locations they noticed
+    while working on the fix (may be "No analogous locations observed"):
+
+    [IMPLEMENTER_OBSERVATIONS]
+
+    ## Session Info
+
+    - Scratch directory: [SCRATCH_DIR]
+    - Pre-Phase-4.5 SHA (the WIP commit): [PRE_PHASE_45_SHA]
+
+    ## Compaction Recovery
+
+    Before starting work, check if `[SCRATCH_DIR]/where-else-state.md` already
+    exists. If it does, a previous scan was interrupted by compaction. Read the
+    file to determine:
+    - Which siblings have already been fixed (skip them)
+    - Which siblings remain (continue from here)
+    - The generalized pattern (avoids re-deriving it from the diff)
+    - The pre-Phase-4.5 SHA (needed for revert mechanics)
+
+    Resume from where the previous scan left off. Do NOT re-fix completed siblings.
+
+    ## Your Job
+
+    Follow these steps exactly, in order.
+
+    ### Step 1: Analyze the Fix Pattern
+
+    Read the fix diff carefully. Extract the structural pattern:
+    - What was missing or wrong in the original code?
+    - What was added or changed to fix it?
+    - What makes a location "analogous" — what structural and semantic
+      properties must a location have for this same fix to apply?
+
+    Produce a **generalized pattern description** in 2-3 sentences. This
+    description must be abstract enough to match other locations, but specific
+    enough to avoid false positives.
+
+    Example: "Screen classes that override `OnEnable` without calling
+    `InitializeIcons()`. The pattern applies to any screen that displays items
+    with visual indicators and inherits from `BaseScreen`."
+
+    ### Step 2: Build Candidate List
+
+    Combine three signals to build a deduplicated list of candidate locations:
+
+    **Signal 1 — Fix diff (structural search):**
+    Search the codebase for code that follows the same structural pattern as
+    the buggy code before the fix. Look for:
+    - Other classes/methods with similar structure (e.g., other screens with
+      similar initialization, other handlers with similar setup)
+    - Code that uses the same base class, interface, or pattern
+    - Files in the same directory or sibling directories that follow the same
+      convention
+
+    **Signal 2 — Cartographer context:**
+    If cartographer data is available, check every structurally similar module
+    listed. These are architecturally similar components that are likely to
+    follow the same patterns.
+
+    **Signal 3 — Implementer observations:**
+    Add any locations the Phase 4 implementer flagged. These are the highest-
+    quality signal — the implementer was already reading the code and is best
+    positioned to spot siblings.
+
+    Deduplicate candidates across all three signals. If a location appears in
+    multiple signals, note that — it increases confidence.
+
+    If no candidates are found from any signal, skip to Step 5 and report
+    "No analogous locations found."
+
+    ### Step 3: Evaluate Each Candidate
+
+    For each candidate location:
+
+    1. **Read the code** at that location. Do not guess from file names alone.
+    2. **Determine if the same pattern/omission exists.** Does this location
+       have the same structural defect that was fixed in the original bug?
+    3. **If yes — confirmed sibling:** Write a justification explaining WHY
+       this location matches semantically, not just structurally. The
+       justification must explain what makes this location's context equivalent
+       to the original bug. Example: "StashScreen.OnEnable has the same
+       structure as VendorScreen.OnEnable — it displays items with icons but
+       never calls InitializeIcons(), so icons will be missing here too."
+    4. **If no — skip:** Record the candidate as skipped with a brief reason
+       explaining why it does NOT match. Example: "SettingsScreen.OnEnable
+       does not display items with icons — the OnEnable override is for audio
+       setup only."
+
+    Do not force matches. A structurally similar location that does not have
+    the same semantic context is NOT a sibling.
+
+    ### Step 4: Fix Confirmed Siblings
+
+    For each confirmed sibling, in order:
+
+    1. **Apply the fix pattern.** Make the same kind of change that was made
+       in the original fix. Adapt it to the local context (variable names,
+       method signatures) but do NOT invent a new approach.
+
+    2. **Run tests.** Run the relevant test suite to verify the fix does not
+       break anything.
+
+    3. **If tests pass:** Commit the fix with the message format:
+       ```
+       fix(sibling): <description of what was fixed and where>
+       ```
+       Example: `fix(sibling): add icon initialization to StashScreen.OnEnable`
+
+    4. **If tests fail:** Revert the change for this sibling immediately.
+       Record it as "reverted — test failure" with a summary of what failed.
+       Do NOT debug the sibling. Do NOT attempt alternative fixes. Move on
+       to the next candidate.
+
+    5. **Update state file.** After each fix (whether committed or reverted),
+       update `[SCRATCH_DIR]/where-else-state.md` with current progress.
+       This protects against session compaction. See the state file format
+       at the end of this prompt.
+
+    ### Step 5: Report Back
+
+    When all candidates have been evaluated and all confirmed siblings have
+    been fixed (or reverted), produce this EXACT report structure:
+
+    ```
+    ## Where Else? Scan Report
+
+    ### Generalized Pattern
+    [2-3 sentence pattern description from Step 1]
+
+    ### Candidates Evaluated: N
+
+    ### Siblings Fixed: N
+    - [file:path] — [commit SHA] — Justification: [why this matches]
+    - ...
+
+    ### Siblings Skipped: N
+    - [file:path] — Reason: [why this doesn't match]
+    - ...
+
+    ### Siblings Reverted: N
+    - [file:path] — Test failure: [summary of what failed]
+    - ...
+    ```
+
+    If no candidates were found at all:
+
+    ```
+    ## Where Else? Scan Report
+
+    ### Generalized Pattern
+    [2-3 sentence pattern description from Step 1]
+
+    ### Candidates Evaluated: 0
+
+    No analogous locations found.
+    ```
+
+    ## Rules
+
+    - **Apply the SAME fix pattern** — do not invent new approaches for
+      siblings. If the original fix added a method call, add the same method
+      call. If it added a null check, add the same null check. Adapt to
+      local context (names, signatures) but the approach must be identical.
+    - **One commit per sibling** — each sibling gets its own commit for
+      clean revert granularity. Never batch multiple siblings into one commit.
+    - **If tests fail for a sibling, revert and continue** — do not debug
+      the sibling, do not attempt alternative fixes, do not abort the scan.
+      Record the failure and move to the next candidate.
+    - **Do not modify the original fix** — the Phase 4 fix is complete.
+      You are only working on sibling locations.
+    - **If no candidates are found, report and stop** — "No analogous
+      locations found" is a valid and expected outcome. Do not manufacture
+      candidates to justify your existence.
+    - **No cap on sibling count** — if you find 15 siblings, fix all 15.
+      The quality gate in Phase 5 handles review.
+    - **Update state after every sibling** — the state file is your
+      crash-recovery mechanism. Never skip the update.
+    - **Justify every match semantically** — "same base class" or "similar
+      file name" is not sufficient justification. Explain WHY the context at
+      that location means the same bug exists there.
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: ensure
+      `where-else-state.md` is fully up to date, then report partial
+      progress immediately. Include what you've completed, what remains,
+      and the current state file contents.
+    - Do NOT try to rush through remaining siblings — partial work with
+      accurate state is better than degraded fixes.
+
+    ## where-else-state.md Format
+
+    Maintain this file at `[SCRATCH_DIR]/where-else-state.md`. Create it
+    at the start of the scan. Update it after every sibling fix or revert.
+
+    ```
+    ### Where-Else State
+
+    **Phase status:** scanning | fixing | complete
+    **Pre-Phase-4.5 SHA:** <sha>
+    **Generalized pattern:** <2-3 sentence pattern description>
+
+    **Siblings found:**
+    - <file:line> — <brief description>
+    - ...
+
+    **Siblings fixed:**
+    - <file:line> — <commit SHA> — <status: committed | reverted-test-failure>
+    - ...
+
+    **Siblings remaining:**
+    - <file:line> — <brief description>
+    - ...
+    ```
+
+    Field definitions:
+    - **Phase status:** `scanning` while building the candidate list and
+      evaluating, `fixing` while applying fixes to confirmed siblings,
+      `complete` when all siblings are processed.
+    - **Pre-Phase-4.5 SHA:** The WIP commit SHA provided as [PRE_PHASE_45_SHA].
+      Needed for revert mechanics if Phase 5 rejects.
+    - **Generalized pattern:** The pattern description from Step 1. Persisted
+      so compaction recovery does not need to re-derive it from the diff.
+    - **Siblings found:** All confirmed siblings from Step 3 evaluation.
+    - **Siblings fixed:** Siblings that have been processed — includes both
+      successfully committed and reverted-on-test-failure entries.
+    - **Siblings remaining:** Siblings not yet processed. Entries move from
+      "remaining" to "fixed" as work progresses. On compaction recovery,
+      resume from the first entry in "remaining."
+```


### PR DESCRIPTION
## Summary

Adds a post-fix investigation step to the /debugging skill that scans for analogous locations with the same bug pattern and fixes them automatically.

**Problem:** /debugging finds and fixes a bug in one location but never asks "where else does this same pattern exist?" — leading to manual re-testing to catch siblings.

**Solution:** Phase 4.5 runs after the fix succeeds, dispatches a scan agent with three signals (fix diff, cartographer, implementer observations), and fixes all sibling locations automatically.

## Key Design Decisions

- **Three input signals** for rich candidate discovery
- **One commit per sibling** (`fix(sibling):` prefix) for clean revert granularity
- **No scope limit** — fix everything found; quality gate reviews all
- **Per-sibling justification** — scan agent explains WHY each location matches semantically
- **Revert-and-continue** — if a sibling fix fails tests, revert it and continue with remaining
- **Compaction recovery** — `where-else-state.md` persisted after each sibling fix

## Files Changed

- `skills/debugging/SKILL.md` — Phase 4.5 section, compaction recovery, commit strategy, workflow diagram, quick reference, loop-back paths
- `skills/debugging/where-else-prompt.md` — New scan agent prompt template
- `skills/debugging/implementer-prompt.md` — "Analogous Locations" added to report format

Closes #52

## Test plan

- [ ] Run /debugging on a bug that exists in multiple analogous locations
- [ ] Verify Phase 4.5 fires after Phase 4 succeeds
- [ ] Verify sibling locations are found and fixed with individual commits
- [ ] Verify Phase 5 reviews original + siblings together
- [ ] Test revert mechanics: `git revert <pre-4.5-sha>..HEAD` covers all commits
- [ ] Test compaction recovery mid-Phase-4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)