### PR TITLE
feat: live pipeline status file for ambient awareness

### DIFF
--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -44,6 +44,72 @@ Every status update must include:
 
 > "Phase 2 complete. All 4 lenses reported: 14 total findings. Moving to Phase 3 synthesis."
 
+## Pipeline Status
+
+Write a status file to `~/.claude/projects/<hash>/memory/pipeline-status.md` at every narration point. This file is overwritten (not appended) and provides ambient awareness for the user in a second terminal.
+
+### Write Triggers
+
+Write the status file at every point where the Communication Requirement mandates narration: before dispatch, after completion, phase transitions, health changes, escalations, and after compaction recovery.
+
+### Status File Format
+
+The status file uses this structure (overwritten in full each time):
+
+```
+# Pipeline Status
+**Updated:** <current timestamp>
+**Started:** <timestamp from first write — persisted across compaction>
+**Skill:** audit
+**Phase:** <current phase, e.g. "2 — Analysis">
+**Health:** <GREEN|YELLOW|RED>
+**Suggested Action:** <omit when GREEN; concrete one-sentence action when YELLOW/RED>
+**Elapsed:** <computed from Started>
+
+## Recent Events
+- [HH:MM] <most recent event>
+- [HH:MM] <previous event>
+(last 5 events, newest first)
+```
+
+### Skill-Specific Body
+
+Append after the shared header:
+
+```
+## Lenses
+- Correctness: DONE (4 findings)
+- Robustness: DONE (2 findings)
+- Architecture: IN PROGRESS
+- Consistency: PENDING
+- Blind-spots: PENDING
+```
+
+### Health State Machine
+
+Health transitions are one-directional within a phase: GREEN -> YELLOW -> RED. Phase boundaries reset to GREEN.
+
+- **Phase boundaries** (reset to GREEN): Phase 1->2, 2->2.5, 2.5->3, 3->4
+- **YELLOW:** lens agent running longer than 10 minutes, blind-spots agent finds significant gap
+- **RED:** multiple lens agents fail, user gate timeout
+
+When health is YELLOW or RED, include `**Suggested Action:**` with a concrete, context-specific sentence (e.g., "Architecture lens running >10 minutes. May be processing a large subsystem — check if scope needs narrowing.").
+
+### Inline CLI Format
+
+Output concise inline status alongside the status file write:
+- **Minor transitions** (dispatch, completion): one-liner, e.g. `Phase 2 [3/5 lenses] Robustness complete (2 findings) | GREEN | 22m`
+- **Phase changes and escalations**: expanded block with `---` separators
+- **Health transitions**: always expanded with old -> new health
+
+### Compaction Recovery
+
+After compaction, before re-writing the status file:
+1. Read the existing `pipeline-status.md` to recover `Started` timestamp and `Recent Events` buffer
+2. Reconstruct phase, health, and skill-specific body from internal state files
+3. Write the updated status file
+4. Output inline status to CLI
+
 ## Design Decisions
 
 1. **Find and report only** -- no fixing. Audit surfaces issues; user decides what to act on.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -32,6 +32,77 @@ Every status update must include:
 
 **This requirement exists because:** Long-running autonomous pipelines can run for hours. Without narration, the user sees nothing but a spinner. They can't assess progress, can't decide whether to intervene, and can't learn from the pipeline's decisions.
 
+## Pipeline Status
+
+Write a status file to `~/.claude/projects/<hash>/memory/pipeline-status.md` at every narration point. This file is overwritten (not appended) and provides ambient awareness for the user in a second terminal.
+
+### Write Triggers
+
+Write the status file at every point where the Communication Requirement mandates narration: before dispatch, after completion, phase transitions, health changes, escalations, and after compaction recovery.
+
+### Status File Format
+
+The status file uses this structure (overwritten in full each time):
+
+```
+# Pipeline Status
+**Updated:** <current timestamp>
+**Started:** <timestamp from first write — persisted across compaction>
+**Skill:** build
+**Phase:** <current phase, e.g. "3 — Execute (Autonomous)">
+**Health:** <GREEN|YELLOW|RED>
+**Suggested Action:** <omit when GREEN; concrete one-sentence action when YELLOW/RED>
+**Elapsed:** <computed from Started>
+
+## Recent Events
+- [HH:MM] <most recent event>
+- [HH:MM] <previous event>
+(last 5 events, newest first)
+```
+
+### Skill-Specific Body
+
+Append after the shared header:
+
+```
+## Task Progress
+| # | Task | Status | Duration |
+|---|------|--------|----------|
+| 1 | Auth middleware | DONE | 12m |
+| 2 | Route handlers | IN REVIEW (pass 2) | 18m+ |
+| 3 | Database layer | PENDING | — |
+
+## Quality Gates
+- Design: PASSED (2 rounds)
+- Plan: PASSED (1 round)
+- Code: not yet reached
+```
+
+### Health State Machine
+
+Health transitions are one-directional within a phase: GREEN -> YELLOW -> RED. Phase boundaries reset to GREEN.
+
+- **Phase boundaries** (reset to GREEN): Phase 1->2, 2->3, 3->4
+- **YELLOW:** review loop round 3+, quality gate round 5+, retry in progress
+- **RED:** escalation pending, stagnation detected, test suite failure unresolved
+
+When health is YELLOW or RED, include `**Suggested Action:**` with a concrete, context-specific sentence (e.g., "Code review looping on Task 4. Check recent events for recurring patterns.").
+
+### Inline CLI Format
+
+Output concise inline status alongside the status file write:
+- **Minor transitions** (dispatch, completion): one-liner, e.g. `Phase 3 [4/8] Task 4 IN REVIEW (pass 1) | GREEN | 1h 12m`
+- **Phase changes and escalations**: expanded block with `---` separators
+- **Health transitions**: always expanded with old -> new health
+
+### Compaction Recovery
+
+After compaction, before re-writing the status file:
+1. Read the existing `pipeline-status.md` to recover `Started` timestamp and `Recent Events` buffer
+2. Reconstruct phase, health, and skill-specific body from internal state files
+3. Write the updated status file
+4. Output inline status to CLI
+
 ## Mode Detection
 
 Before dispatching the design skill, determine whether this build is:

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -32,6 +32,70 @@ Every status update must include:
 
 **Depth principle:** When in doubt, dispatch MORE investigation agents, not fewer. A bug that looks simple from the surface often has a complex root cause. Spinning up 4-6 focused investigators in parallel costs minutes; missing the root cause costs hours.
 
+## Pipeline Status
+
+Write a status file to `~/.claude/projects/<hash>/memory/pipeline-status.md` at every narration point. This file is overwritten (not appended) and provides ambient awareness for the user in a second terminal.
+
+### Write Triggers
+
+Write the status file at every point where the Communication Requirement mandates narration: before dispatch, after completion, phase transitions, health changes, escalations, and after compaction recovery.
+
+### Status File Format
+
+The status file uses this structure (overwritten in full each time):
+
+```
+# Pipeline Status
+**Updated:** <current timestamp>
+**Started:** <timestamp from first write — persisted across compaction>
+**Skill:** debugging
+**Phase:** <current phase, e.g. "Synthesis", "4 — Implementation">
+**Health:** <GREEN|YELLOW|RED>
+**Suggested Action:** <omit when GREEN; concrete one-sentence action when YELLOW/RED>
+**Elapsed:** <computed from Started>
+
+## Recent Events
+- [HH:MM] <most recent event>
+- [HH:MM] <previous event>
+(last 5 events, newest first)
+```
+
+### Skill-Specific Body
+
+Append after the shared header:
+
+```
+## Investigation
+- Hypothesis: "Missing null check in event handler dispatch chain"
+- Cycle: 2 of 4 max
+- Phase 4 fix attempts: 1 (WIP commit pending verification)
+```
+
+### Health State Machine
+
+Health transitions are one-directional within a phase: GREEN -> YELLOW -> RED. Phase boundaries reset to GREEN.
+
+- **Phase boundaries** (reset to GREEN): Phase 0->1, 1->Synthesis, Synthesis->2, 2->3, 3->4, 4->4.5, 4.5->5. Sub-phases (3.5, within Phase 3) do NOT reset.
+- **YELLOW:** hypothesis cycle 3+, quality gate round 5+, fix retry in progress
+- **RED:** escalation pending, stagnation detected, 3 fix failures reached
+
+When health is YELLOW or RED, include `**Suggested Action:**` with a concrete, context-specific sentence (e.g., "Third hypothesis attempted. Consider narrowing the search space or providing additional context.").
+
+### Inline CLI Format
+
+Output concise inline status alongside the status file write:
+- **Minor transitions** (dispatch, completion): one-liner, e.g. `Phase 1 [cycle 2] Investigating: null check hypothesis | GREEN | 34m`
+- **Phase changes and escalations**: expanded block with `---` separators
+- **Health transitions**: always expanded with old -> new health
+
+### Compaction Recovery
+
+After compaction, before re-writing the status file:
+1. Read the existing `pipeline-status.md` to recover `Started` timestamp and `Recent Events` buffer
+2. Reconstruct phase, health, and skill-specific body from internal state files
+3. Write the updated status file
+4. Output inline status to CLI
+
 ## Session State and Compaction Recovery
 
 The debugging skill writes session state to disk at **every phase transition**, not just on failure. This ensures compaction recovery works regardless of when it occurs.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -34,6 +34,70 @@ Every status update must include:
 **Example of GOOD narration:**
 > "Wave 2 complete. 3/3 tickets committed. 1 medium-confidence alert on #45 (chose Redis over Postgres for session store). #67 re-queued to Wave 3 (new dependency on #45 discovered). Overall: 7/12 tickets done, 5 remaining across 2 waves."
 
+## Pipeline Status
+
+Write a status file to `~/.claude/projects/<hash>/memory/pipeline-status.md` at every narration point. This file is overwritten (not appended) and provides ambient awareness for the user in a second terminal.
+
+### Write Triggers
+
+Write the status file at every point where the Communication Requirement mandates narration: before dispatch, after completion, phase transitions, health changes, escalations, and after compaction recovery.
+
+### Status File Format
+
+The status file uses this structure (overwritten in full each time):
+
+```
+# Pipeline Status
+**Updated:** <current timestamp>
+**Started:** <timestamp from first write — persisted across compaction>
+**Skill:** spec
+**Phase:** <current phase, e.g. "Wave 2 (3/4 tickets in progress)">
+**Health:** <GREEN|YELLOW|RED>
+**Suggested Action:** <omit when GREEN; concrete one-sentence action when YELLOW/RED>
+**Elapsed:** <computed from Started>
+
+## Recent Events
+- [HH:MM] <most recent event>
+- [HH:MM] <previous event>
+(last 5 events, newest first)
+```
+
+### Skill-Specific Body
+
+Append after the shared header:
+
+```
+## Tickets
+- Wave 1: 3/3 complete
+- Wave 2: 2/4 in progress (#45 writing, #67 investigating)
+- Alerts: 1 medium-confidence on #45
+```
+
+### Health State Machine
+
+Health transitions are one-directional within a phase: GREEN -> YELLOW -> RED. Phase boundaries reset to GREEN.
+
+- **Phase boundaries** (reset to GREEN): each new wave
+- **YELLOW:** ticket re-queued more than once, teammate failure on a ticket, medium-confidence alert
+- **RED:** 2+ tickets failed in same wave, unresolvable dependency cycle, block-confidence alert
+
+When health is YELLOW or RED, include `**Suggested Action:**` with a concrete, context-specific sentence (e.g., "Ticket #45 re-queued twice — may have an unresolvable dependency. Check dependency graph.").
+
+### Inline CLI Format
+
+Output concise inline status alongside the status file write:
+- **Minor transitions** (dispatch, completion): one-liner, e.g. `Wave 2 [7/12] #45 spec committed | GREEN | 45m`
+- **Phase changes and escalations**: expanded block with `---` separators
+- **Health transitions**: always expanded with old -> new health
+
+### Compaction Recovery
+
+After compaction, before re-writing the status file:
+1. Read the existing `pipeline-status.md` to recover `Started` timestamp and `Recent Events` buffer
+2. Reconstruct phase, health, and skill-specific body from internal state files
+3. Write the updated status file
+4. Output inline status to CLI
+
 ## Epic Extraction
 
 GitHub has no first-class "epic with child tickets" API. Use a fallback chain to extract scope units from the provided issue:


### PR DESCRIPTION
## Summary

- All 4 orchestrating skills (build, debugging, spec, audit) now write `pipeline-status.md` at every state transition
- Shared header: skill, phase, health (GREEN/YELLOW/RED), suggested action, elapsed time, last 5 events
- Skill-specific body: task progress table (build), hypothesis/cycles (debug), wave/ticket counts (spec), lens progress (audit)
- Hybrid inline CLI: one-liners for minor transitions, expanded blocks for phase changes/escalations/health transitions
- Per-skill health triggers and phase boundary definitions
- Compaction recovery: reads Started timestamp and Recent Events from existing status file

### Health state machine
- **GREEN**: normal progression
- **YELLOW**: per-skill triggers (review loop 3+, gate round 5+, hypothesis cycle 3+, ticket re-queued, lens timeout)
- **RED**: per-skill triggers (escalation, stagnation, test failure, multiple agent failures)
- Health resets to GREEN on phase boundaries (defined per-skill)

### Files changed (4 files, +265 lines)
- `skills/build/SKILL.md` — Pipeline Status section with task progress + quality gates
- `skills/debugging/SKILL.md` — Pipeline Status section with hypothesis/cycle tracking
- `skills/spec/SKILL.md` — Pipeline Status section with wave/ticket progress
- `skills/audit/SKILL.md` — Pipeline Status section with lens progress

## Test plan

- [ ] Run /build on a feature — verify pipeline-status.md is written at state transitions
- [ ] Verify status file has correct shared header fields (Updated, Started, Skill, Phase, Health, Elapsed, Recent Events)
- [ ] Verify health transitions to YELLOW on review loop round 3+
- [ ] Verify health resets to GREEN on phase boundary
- [ ] Verify Suggested Action appears when YELLOW/RED
- [ ] Verify Recent Events holds last 5 (newest first)
- [ ] Verify inline CLI uses hybrid format (one-liner + expanded blocks)
- [ ] Verify compaction recovery reads Started and Recent Events from status file
- [ ] Run /debugging — verify debugging-specific body (hypothesis, cycle, fix attempts)
- [ ] Run /audit — verify audit-specific body (lens progress)

Closes #61

Generated with [Claude Code](https://claude.com/claude-code)