### PR TITLE
feat: auto-generate PRD from build design phase

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -179,6 +179,18 @@ After the user approves the design and before starting Phase 2:
 3. If the quality gate requires changes, the Plan Writer updates the design doc and re-commits.
 4. Design doc is now finalized — proceed to acceptance tests.
 
+### Step 2.5: Generate PRD
+
+After the design doc is finalized (Step 2 complete), generate a stakeholder-facing PRD:
+
+1. Dispatch a **PRD Writer** subagent (Sonnet) using `./prd-writer-prompt.md`
+   - Input: finalized design doc
+   - Output: PRD in standard format (problem statement, user stories, requirements, scope, out-of-scope, success metrics, technical notes, dependencies)
+2. Save to `docs/prds/YYYY-MM-DD-<topic>-prd.md`
+3. Commit: `docs: add PRD for [feature]`
+
+This step runs by default. The PRD is a reformatting of the design doc for non-technical stakeholders — it does not introduce new decisions or requirements. Skip only in refactor mode (refactoring has no stakeholder-facing PRD).
+
 ### Step 3: Generate Acceptance Tests (RED)
 
 Before planning, define "done" with executable tests:
@@ -682,6 +694,7 @@ Decision types to capture:
 ## Prompt Templates
 
 - `./acceptance-test-writer-prompt.md` — Phase 1 acceptance test generation
+- `./prd-writer-prompt.md` — Phase 1 PRD generation from design doc
 - `./plan-writer-prompt.md` — Phase 2 plan writer dispatch
 - `./plan-reviewer-prompt.md` — Phase 2 plan reviewer dispatch
 - `./build-implementer-prompt.md` — Phase 3 implementer dispatch

--- a/skills/build/prd-writer-prompt.md
+++ b/skills/build/prd-writer-prompt.md
@@ -1,0 +1,84 @@
+# PRD Writer Prompt Template
+
+Use this template when dispatching a PRD writer subagent in Phase 1, Step 2.5. The PRD reformats the approved design doc for non-technical stakeholders.
+
+```
+Task tool (general-purpose, model: sonnet):
+  description: "Generate PRD for [feature]"
+  prompt: |
+    You are writing a Product Requirements Document (PRD) from a technical
+    design document. Your audience is non-technical stakeholders — product
+    managers, executives, project managers, and QA leads. They need to
+    understand WHAT is being built and WHY, not HOW.
+
+    ## Design Document
+
+    [FULL TEXT of the finalized design doc — paste it here]
+
+    ## Your Job
+
+    Transform the design doc into a PRD using this exact structure:
+
+    ### 1. Problem Statement
+    Extract from the design doc's Overview/Motivation. Write 2-3 sentences
+    a non-technical person can understand. No jargon.
+
+    ### 2. User Stories / Use Cases
+    Derive from acceptance criteria. Format as "As a [role], I want [goal]
+    so that [benefit]." Include the primary happy path and key alternative
+    flows. 3-7 user stories.
+
+    ### 3. Requirements
+    Split into Functional (what the system does) and Non-Functional
+    (performance, security, reliability constraints). Derived from design
+    decisions and invariants. Each requirement should be a single testable
+    statement.
+
+    ### 4. Scope
+    What is included in this feature. Bullet list.
+
+    ### 5. Out of Scope
+    What was explicitly excluded during design. If the design doc doesn't
+    mention exclusions, state "Not specified in design."
+
+    ### 6. Success Metrics
+    Derived from acceptance criteria — reframe as measurable outcomes.
+    "Feature is successful when [observable outcome]."
+
+    ### 7. Technical Notes
+    2-3 sentence summary of key architectural decisions for stakeholders
+    who want context without deep technical detail. Include any external
+    dependencies or integrations.
+
+    ### 8. Dependencies
+    External systems, teams, or services this feature depends on. Derived
+    from the design doc's integration points. If none, state "None."
+
+    ## PRD Format
+
+    Write the PRD as a markdown document with YAML frontmatter:
+
+    ---
+    ticket: "<from design doc frontmatter>"
+    title: "<feature name> — Product Requirements"
+    date: "<today's date>"
+    source: "build"
+    design_doc: "<path to the design doc>"
+    ---
+
+    ## Rules
+
+    - Write for a non-technical audience. No code, no file paths, no
+      architecture diagrams.
+    - Derive everything from the design doc. Do not invent requirements
+      that are not in the design.
+    - Keep it concise. The PRD should be 1-2 pages, not a novel.
+    - If the design doc is thin on a section (e.g., no explicit out-of-scope),
+      say so rather than fabricating content.
+    - User stories should cover the main flows, not every edge case.
+    - Success metrics should be observable by a human, not by a test suite.
+
+    ## Save Location
+
+    Save to: docs/prds/YYYY-MM-DD-<topic>-prd.md
+```

--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: prd
+description: "Generate a stakeholder-facing PRD from a design doc. Use when you have a finalized design doc and need a non-technical product requirements document for archival or sharing. Triggers on /prd, 'generate PRD', 'write a PRD', 'product requirements'."
+---
+
+# PRD Generator
+
+## Overview
+
+Generates a Product Requirements Document (PRD) from a finalized design doc. The PRD reformats technical design decisions into stakeholder-friendly language — problem statement, user stories, requirements, scope, success metrics.
+
+**Announce at start:** "I'm using the PRD skill to generate a product requirements document."
+
+**Core principle:** The PRD derives everything from the design doc. It does not introduce new decisions or requirements — it translates existing technical decisions for a non-technical audience.
+
+## When to Use
+
+- After `/design` or `/build` Phase 1 completes — you have a finalized design doc
+- When a stakeholder asks for a PRD, product spec, or requirements document
+- When archiving a feature's requirements in Confluence, Jira, Notion, or similar
+
+## Input
+
+The skill needs a design doc path. If not provided, it searches:
+1. Check if the user specified a path: `/prd docs/plans/2026-03-23-my-feature-design.md`
+2. If no path: scan `docs/plans/` for the most recently modified `*-design.md` file
+3. If no design docs found: inform user and stop
+
+## The Process
+
+1. **Read the design doc** — verify it exists and has the expected structure (Overview, acceptance criteria, etc.)
+2. **Dispatch a Sonnet PRD Writer** using the prompt template at `skills/build/prd-writer-prompt.md`
+   - Input: full design doc text
+   - Output: PRD in standard format
+3. **Save** to `docs/prds/YYYY-MM-DD-<topic>-prd.md`
+4. **Commit:** `docs: add PRD for [feature]`
+5. **Report** the file path to the user
+
+## PRD Structure
+
+The generated PRD follows a fixed structure:
+
+1. **Problem Statement** — what problem this solves, in plain language
+2. **User Stories / Use Cases** — "As a [role], I want [goal] so that [benefit]"
+3. **Requirements** — functional and non-functional, each a testable statement
+4. **Scope** — what's included
+5. **Out of Scope** — what was explicitly excluded
+6. **Success Metrics** — measurable outcomes
+7. **Technical Notes** — brief architectural context for stakeholders who want it
+8. **Dependencies** — external systems, teams, or services
+
+## Integration
+
+**Called by:**
+- **crucible:build** — Phase 1 Step 2.5 (after design finalized, before acceptance tests). Runs by default in feature mode, skipped in refactor mode.
+
+**Standalone usage:**
+- `/prd <design-doc-path>` — generate PRD from any design doc
+- `/prd` (no args) — auto-detect most recent design doc
+
+**Prompt template:** `skills/build/prd-writer-prompt.md` (shared with build pipeline)
+
+## Red Flags
+
+- Inventing requirements not in the design doc
+- Including code, file paths, or architecture diagrams in the PRD
+- Writing more than 2 pages — PRDs should be concise
+- Skipping sections rather than stating "Not specified in design"


### PR DESCRIPTION
## Summary

- Build Phase 1 now generates a stakeholder-facing PRD after design approval (Step 2.5)
- Sonnet subagent transforms the technical design doc into standard PRD format
- New standalone `/prd` skill for on-demand PRD generation from any design doc
- Default on in feature mode, skipped in refactor mode

### PRD Structure
1. Problem Statement
2. User Stories / Use Cases
3. Requirements (functional + non-functional)
4. Scope / Out of Scope
5. Success Metrics
6. Technical Notes (brief, non-technical)
7. Dependencies

### Files changed (3 files, +165 lines)
- `skills/build/SKILL.md` — Step 2.5 + prompt template reference
- `skills/build/prd-writer-prompt.md` — Sonnet PRD writer template
- `skills/prd/SKILL.md` — standalone /prd skill

## Test plan

- [ ] Run /build on a feature — verify PRD is generated after design approval
- [ ] Verify PRD saved to docs/prds/ with correct frontmatter
- [ ] Verify PRD contains all 8 sections
- [ ] Verify PRD is non-technical (no code, no file paths)
- [ ] Run /prd standalone with a design doc path — verify PRD generated
- [ ] Run /prd with no args — verify auto-detection of most recent design doc
- [ ] Verify PRD step is skipped in refactor mode

Closes #66

Generated with [Claude Code](https://claude.com/claude-code)