### PR TITLE
feat: add pipeline checkpoint system with shadow git rollback (#70)

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -77,6 +77,11 @@ Append after the shared header:
 - Plan: PASSED (1 round)
 - Task tiers: 1x T1, 1x T2, 1x T3
 - Code: not yet reached
+
+## Checkpoints
+- Last checkpoint: pre-wave-3 (12:45:30)
+- Total checkpoints: 7
+- Shadow repo: healthy
 ```
 
 ### Health State Machine
@@ -101,8 +106,9 @@ Output concise inline status alongside the status file write:
 After compaction, before re-writing the status file:
 1. Read the existing `pipeline-status.md` to recover `Started` timestamp and `Recent Events` buffer
 2. Reconstruct phase, health, and skill-specific body from internal state files
-3. Write the updated status file
-4. Output inline status to CLI
+3. If crucible:checkpoint was used: verify checkpoint availability by checking for the shadow repo at the computed path. Log available checkpoint count. Do not restore — just confirm checkpoints are recoverable.
+4. Write the updated status file
+5. Output inline status to CLI
 
 ## Mode Detection
 
@@ -174,6 +180,8 @@ Before running interactive design, check whether `/spec` (or a prior `/build` ru
 ### Step 2: Innovate and Red-Team the Design
 
 After the user approves the design and before starting Phase 2:
+
+**RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-design-gate" before dispatching innovate and quality-gate on the design doc.
 
 1. **Innovate:** Dispatch `crucible:innovate` on the design doc. Plan Writer incorporates the proposal.
 2. **Quality gate:** Dispatch `crucible:quality-gate` on the (potentially updated) design doc with artifact type "design". Iterates until clean or stagnation.
@@ -314,6 +322,8 @@ Use `./plan-reviewer-prompt.md` template for the dispatch prompt.
 
 **After the plan passes review:**
 
+**RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-plan-gate" before dispatching innovate and quality-gate on the plan.
+
 1. **Innovate:** Dispatch `crucible:innovate` on the approved plan. Plan Writer incorporates the proposal into the plan.
 2. **Quality gate:** Dispatch `crucible:quality-gate` on the (potentially updated) plan with artifact type "plan". Provides the plan and design doc as context.
 
@@ -380,6 +390,8 @@ Before dispatching:
 
 For each task (or wave of parallel tasks):
 
+**RECOMMENDED SUB-SKILL:** Before dispatching each execution wave, use crucible:checkpoint — create checkpoint with reason "pre-wave-N" (where N is the wave number). This captures the working directory state after the prior wave's verification gate passed.
+
 1. Mark task `in_progress` via `TaskUpdate`
 2. Spawn **Implementer** teammate (Opus) via Task tool with `team_name` and `subagent_type="general-purpose"`
    - Use `./build-implementer-prompt.md` template
@@ -409,6 +421,8 @@ When a contract YAML exists for the current ticket (detected during Step 0 or pr
 #### De-Sloppify Cleanup
 
 After the implementer reports completion and before dispatching the reviewer:
+
+**RECOMMENDED:** Use crucible:checkpoint — create checkpoint with reason "pre-cleanup-task-N" before dispatching the cleanup agent. If cleanup removes something needed, restore to this checkpoint.
 
 1. Record the pre-cleanup commit SHA
 2. Dispatch a fresh **Cleanup Agent** (Opus) using `./cleanup-prompt.md`
@@ -651,7 +665,9 @@ After all tasks complete:
    - If any fail: implementation is incomplete. Identify what's missing, dispatch implementer to fix, re-run.
    - If all pass: feature is verifiably done. Proceed.
 2. Run full test suite (unit + integration)
+3. **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-code-review" before dispatching code review. If the iterative review fix cycle introduces regressions, this is the rollback target.
 3. **REQUIRED SUB-SKILL:** Use crucible:code-review on full implementation (iterative until clean)
+4. **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-inquisitor" before dispatching inquisitor. If the inquisitor's fix cycle produces regressions, this is the rollback target.
 4. **REQUIRED SUB-SKILL:** Use crucible:inquisitor on full implementation (dispatches 5 parallel dimensions against full feature diff)
    - Input: `git diff <base-sha>..HEAD` where base-sha is the commit before Phase 3 execution began
    - Runs after code review (obvious issues already fixed) and before quality gate (gate reviews final state)
@@ -661,6 +677,7 @@ After all tasks complete:
    - This is NOT a full implementation re-review — scope it to only the fixer's changes
    - Iterative until clean, same as step 3
    - Skip if the inquisitor reported all PASS (no fixes were needed)
+6. **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-impl-gate" before dispatching the implementation quality gate. If gate fix rounds degrade the code, this is the rollback target.
 6. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on full implementation (artifact type: "code", iterative until clean)
 7. **RECOMMENDED SUB-SKILL:** Use crucible:forge (retrospective mode) — capture what happened vs what was planned
 8. **RECOMMENDED SUB-SKILL:** Use crucible:cartographer (record mode) — persist any new codebase knowledge discovered during build
@@ -715,6 +732,7 @@ Decision types to capture:
 - Test suite failures not obviously fixable
 - Multiple teammates fail on different tasks
 - Teammate reports context pressure at 50%+ with significant work remaining
+- When escalating for regression or stagnation AND a checkpoint exists for the current phase boundary: include "A checkpoint from [reason] is available. Restore to pre-regression state?" in the escalation message.
 
 **Minor issues:** Log, work around, include in final report.
 
@@ -800,6 +818,7 @@ When a contract YAML exists for the current ticket, the quality gate adds contra
 **Recommended sub-skills:**
 - **crucible:forge** — Feed-forward at Phase 1 start, retrospective at Phase 4 completion
 - **crucible:cartographer** — Consult at Phase 1 start, load at Phase 3 dispatches, record at Phase 4
+- **crucible:checkpoint** — Shadow git checkpoints at pipeline boundaries (pre-design-gate, pre-plan-gate, pre-wave-N, pre-cleanup-task-N, pre-code-review, pre-inquisitor, pre-impl-gate)
 
 **Phase 3 sub-skills (dispatched per-task):**
 - **crucible:test-coverage** — Test alignment audit after each task's test quality review (staleness, dead tests, coincidence tests)

--- a/skills/checkpoint/SKILL.md
+++ b/skills/checkpoint/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: checkpoint
+description: Shadow git checkpoint system for pipeline rollback. Creates working directory snapshots without modifying the project's git history. Invoked by build, quality-gate, and debugging orchestrators at pipeline boundaries.
+origin: crucible
+---
+
+# Checkpoint
+
+Shadow git checkpoint system that snapshots and restores working directory state using an isolated git repository. The project's `.git` history is never touched.
+
+**Skill type:** Rigid — follow exactly, no shortcuts.
+
+**Execution model:** No modes, no subagent dispatch. The consuming orchestrator (build, quality-gate, debugging) follows these instructions directly when taking or restoring checkpoints.
+
+## Shadow Repository Setup
+
+Initialize once per session, on first checkpoint request:
+
+1. **Compute directory hash:** SHA-256 of the absolute working directory path, truncated to 16 characters.
+   ```
+   echo -n "/absolute/path/to/project" | sha256sum | cut -c1-16
+   ```
+
+2. **Shadow repo path:** `~/.claude/projects/<project-hash>/checkpoints/<dir-hash>/`
+
+3. **Initialize:** If the shadow repo does not exist:
+   ```bash
+   GIT_DIR=<shadow-path> GIT_WORK_TREE=<working-dir> git init
+   ```
+
+4. **Write `.gitignore`** in the shadow repo (not the project):
+   ```
+   node_modules/
+   .env
+   .env.*
+   __pycache__/
+   .git/
+   venv/
+   .venv/
+   dist/
+   build/
+   .next/
+   *.pyc
+   .DS_Store
+   ```
+
+5. **Health check:** Before every operation, verify:
+   ```bash
+   GIT_DIR=<shadow-path> git rev-parse --git-dir
+   ```
+   If this fails, reinitialize the shadow repo and warn: "Shadow repo was corrupt — reinitialized. Prior checkpoints are lost."
+
+**Tool constraint:** All shadow repo operations MUST use the Bash tool with explicit `GIT_DIR` and `GIT_WORK_TREE` environment variables. Never use Write/Read/Glob for shadow repo git operations. Never run git commands without these env vars — bare `git` commands would affect the project repo.
+
+## Pre-Check: Directory Size
+
+Before the first checkpoint in a session, count files in the working directory (excluding ignored paths):
+
+```bash
+find <working-dir> -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/__pycache__/*' -not -path '*/venv/*' -not -path '*/.venv/*' -type f | wc -l
+```
+
+If count exceeds 50,000: skip all checkpoints for this directory with warning "Directory has >50,000 files — checkpoints disabled for performance." Cache this decision for the session (do not re-count).
+
+## Create Checkpoint
+
+1. **Deduplication:** Read the latest commit timestamp from the shadow repo:
+   ```bash
+   GIT_DIR=<shadow-path> git log -1 --format=%ct 2>/dev/null
+   ```
+   If the current time minus the commit timestamp is less than 1 second, skip this checkpoint (deduplication).
+
+2. **Stage all files:**
+   ```bash
+   GIT_DIR=<shadow-path> GIT_WORK_TREE=<working-dir> git add -A
+   ```
+
+3. **Commit:**
+   ```bash
+   GIT_DIR=<shadow-path> GIT_WORK_TREE=<working-dir> git commit -m "<reason> | <timestamp> | <source-skill>" --allow-empty-message
+   ```
+   The `<reason>` is a structured string (e.g., `pre-design-gate`, `pre-wave-3`, `pre-qg-fix-round-2`). The `<source-skill>` is the consuming skill name (build, quality-gate, debugging).
+
+4. **Record the commit hash** as the checkpoint ID.
+
+5. **Update manifest:** Append an entry to `checkpoint-manifest.md` in the shadow repo directory (outside the git tree):
+   ```
+   | <hash-8-chars> | <timestamp> | <reason> | <source-skill> |
+   ```
+
+6. **Eviction:** After commit, count entries in `checkpoint-manifest.md`. If count exceeds 50 (configurable — orchestrators may override), remove the oldest entries from the manifest. Git objects for evicted commits are cleaned up by the Prune step.
+
+## List Checkpoints
+
+Read `checkpoint-manifest.md` from the shadow repo directory. Display in most-recent-first order:
+
+```
+| Hash     | Timestamp           | Reason              | Source       |
+|----------|---------------------|----------------------|--------------|
+| a1b2c3d4 | 2026-03-24 12:45:30 | pre-wave-3           | build        |
+| e5f6g7h8 | 2026-03-24 12:30:15 | pre-plan-gate        | build        |
+```
+
+## Restore (Full Directory)
+
+1. **Create a pre-restore safety checkpoint** with reason `pre-restore-safety` and source `checkpoint`. This enables "undo the undo."
+
+2. **Restore:**
+   ```bash
+   GIT_DIR=<shadow-path> GIT_WORK_TREE=<working-dir> git checkout <hash> -- .
+   ```
+
+3. **Verify:** Run the project's test suite or relevant subset to confirm the restored state is healthy.
+
+4. **Report:** "Restored to checkpoint `<hash>` (`<reason>`). Safety checkpoint created at `<safety-hash>` — use this to undo the restore."
+
+## Restore (Single File)
+
+1. **Create a pre-restore safety checkpoint** with reason `pre-restore-safety-file` and source `checkpoint`.
+
+2. **Restore:**
+   ```bash
+   GIT_DIR=<shadow-path> GIT_WORK_TREE=<working-dir> git checkout <hash> -- <file-path>
+   ```
+
+3. **Report:** "Restored `<file-path>` from checkpoint `<hash>` (`<reason>`)."
+
+## Prune
+
+Run at session start (before first checkpoint) to reclaim space:
+
+1. ```bash
+   GIT_DIR=<shadow-path> GIT_WORK_TREE=<working-dir> git gc --prune=now
+   ```
+
+2. Read `checkpoint-manifest.md` and verify each entry's hash exists:
+   ```bash
+   GIT_DIR=<shadow-path> git cat-file -t <hash>
+   ```
+   Remove entries with invalid hashes (orphaned by prior gc).
+
+## Compaction Recovery
+
+The checkpoint manifest and shadow repo persist across compaction because they live in `~/.claude/projects/` (not in `/tmp/` or in-memory).
+
+After compaction:
+1. Recompute the directory hash from the current working directory path
+2. Check if `~/.claude/projects/<project-hash>/checkpoints/<dir-hash>/` exists
+3. If yes: read `checkpoint-manifest.md` to recover available checkpoints
+4. If no: checkpoints are unavailable for this session (no error — the pipeline continues without checkpoint protection)
+
+No active marker file is needed — the shadow repo's existence IS the marker. The directory hash computation is deterministic from the working directory path.
+
+## Red Flags
+
+- **NEVER** modify the project's `.git` directory
+- **NEVER** run git commands without `GIT_DIR` and `GIT_WORK_TREE` env vars
+- **NEVER** take a checkpoint mid-wave — wait for all parallel agents to complete before snapshotting
+- **NEVER** auto-restore without user confirmation — always present restore as an option, not an action
+- **NEVER** delete the shadow repo without explicit user request
+
+## Integration
+
+Consuming skills:
+- **crucible:build** — Pipeline boundary checkpoints (pre-design-gate, pre-plan-gate, pre-wave-N, pre-cleanup-task-N, pre-code-review, pre-inquisitor, pre-impl-gate)
+- **crucible:quality-gate** — Pre-fix-round checkpoints for code artifacts (pre-qg-fix-round-N)
+- **crucible:debugging** — Pre-implementation, pre-sibling, and pre-quality-gate checkpoints (pre-debug-fix-cycle-N, pre-where-else, pre-debug-gate)

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -212,7 +212,7 @@ Phase 4: Implementation agent (TDD: failing test, fix, verify)
     |
     v
 Orchestrator: Verify fix -> Success? Phase 4.5. Failed? Cleanup, log, loop back.
-    -> 3 failures? Escalate to user.
+    -> 3 failures? Escalate to user. If checkpoints exist: "Checkpoints available from prior fix cycles. Restore to a known-good state before manual investigation?"
     |
     v
 Phase 4.5: "Where Else?" scan — find and fix sibling locations
@@ -403,6 +403,8 @@ The quality gate challenges:
 
 ### Phase 4: Implementation (Single Subagent -- TDD)
 
+**RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-debug-fix-cycle-N" (where N is the hypothesis cycle count) before dispatching the implementation agent. If the fix attempt fails or introduces regressions, this checkpoint allows clean rollback without relying on WIP commit revert mechanics.
+
 **Prompt template:** `./implementer-prompt.md`
 
 Dispatch a single Implementation agent that receives:
@@ -448,6 +450,8 @@ If Phase 4.5 ran (sibling commits exist): use `git revert <pre-4.5-sha>..HEAD` i
 ---
 
 ### Phase 4.5: "Where Else?" Blast Radius Scan
+
+**RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-where-else" before dispatching the scan agent. This replaces the need to manually track the pre-Phase-4.5 SHA for revert mechanics — the checkpoint captures the full working directory state.
 
 After Phase 4 succeeds and the WIP commit is created, dispatch the "Where Else?" scan agent to find and fix analogous locations in the codebase that have the same bug pattern. Phase 4.5 does NOT run on loop-back paths (fix failed, regressions found).
 
@@ -569,6 +573,8 @@ If `update_path` was provided (merge case): rename the file to use today's date 
 ---
 
 ### Phase 5: Red-Team and Code Review (Post-Fix Quality Gate)
+
+**RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-debug-gate" before invoking the quality gate. If gate fix rounds degrade the fix, this is the rollback target.
 
 After Phase 4.5 completes (or Phase 4 succeeds if no Phase 4.5 ran), the orchestrator runs quality gates before declaring done:
 
@@ -831,6 +837,7 @@ If systematic investigation reveals issue is truly environmental, timing-depende
 
 **Recommended skills:**
 - **`crucible:forge`** -- Retrospective after fix verified (captures debugging lessons)
+- **`crucible:checkpoint`** -- Shadow git checkpoints before implementation, sibling fixes, and quality gate (pre-debug-fix-cycle-N, pre-where-else, pre-debug-gate). Provides structured rollback for fix attempts and sibling work.
 
 ## Real-World Impact
 

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -47,6 +47,8 @@ The orchestrator coordinates the loop but does NOT fix artifacts directly. Fixes
 | mockup | Fix subagent |
 | translation | Fix subagent revises the translation map |
 
+**Before dispatching the fix agent (code artifacts only):** If crucible:checkpoint is available, create checkpoint with reason "pre-qg-fix-round-N". Non-code artifacts (design, plan, hypothesis, mockup, translation) skip this step — they are fully captured by the existing artifact-N.md snapshots.
+
 The fix agent receives: (a) the current artifact, (b) the red-team findings, (c) project context, and (d) the **fix journal** from prior rounds (see Fix Memory below). It returns the revised artifact. The orchestrator writes the revised artifact to the scratch directory and dispatches the next red-team round.
 
 The orchestrator never applies fixes directly. Even trivial fixes go through a fix agent to maintain separation of concerns. The cost of dispatching for a small fix is negligible; the risk of the orchestrator conflating coordination with fixing is not.
@@ -120,6 +122,8 @@ Stagnation uses **weighted scoring** (Fatal=3, Significant=1) AND **Fatal count 
 If either condition is met → progress, loop again. No judge needed.
 
 **Oscillation detection:** If the weighted score *increases* (not just stays the same), escalate immediately as a **regression**. Report: "Round N score (X) is higher than Round N-1 score (Y). The fix cycle introduced new issues. Escalating." No judge needed.
+
+**Regression with checkpoint:** If a pre-qg-fix-round checkpoint exists for the prior round, include in the escalation: "A checkpoint of the pre-fix state exists (`<hash>`). Options: (a) restore to pre-fix checkpoint and retry with different fix strategy, (b) continue with current state, (c) escalate to user." If no checkpoint exists, escalate as currently specified.
 
 ### Judge Dispatch (only when first-pass check would trigger stagnation)
 
@@ -291,3 +295,4 @@ Three exit modes beyond clean approval:
 - **crucible:mockup-builder** — Produces mockups (gateable artifact)
 - **crucible:mock-to-unity** — Produces translation maps and implementations (gateable artifacts)
 - **crucible:build** — Outermost orchestrator, controls all gates in pipeline
+- **crucible:checkpoint** — Shadow git checkpoints before code-artifact fix rounds (recommended). Provides rollback target when fix rounds introduce regressions.


### PR DESCRIPTION
## Summary
- New `crucible:checkpoint` skill providing working directory snapshots via shadow git repositories (GIT_DIR/GIT_WORK_TREE isolation)
- Integrates as RECOMMENDED sub-skill at 7 pipeline boundary points in build, code-artifact fix rounds in quality-gate, and 3 points in debugging
- Supports create, list, restore (full/file), deduplication, eviction (50 max), pre-restore safety snapshots, and compaction recovery

## Changes
- `skills/checkpoint/SKILL.md` — New skill (167 lines)
- `skills/build/SKILL.md` — 7 checkpoint integration points + status body + compaction recovery + escalation language + integration listing
- `skills/quality-gate/SKILL.md` — Pre-fix-round checkpoints (code artifacts only) + regression escalation with restore option
- `skills/debugging/SKILL.md` — Phase 4/4.5/5 checkpoints + escalation language + integration listing

## Contract verification
All 16 checkable invariants from the spec contract verified passing.

Closes #70 | Part of epic #75

## Test plan
- [ ] Verify `skills/checkpoint/SKILL.md` follows the contract API surface
- [ ] Verify all 7 build checkpoint boundaries have correct reason strings
- [ ] Verify quality-gate checkpoint is conditional on code artifacts only
- [ ] Verify debugging has 3 checkpoint integration points
- [ ] Verify RECOMMENDED (not REQUIRED) in all integration points

🤖 Generated with [Claude Code](https://claude.com/claude-code)