### PR TITLE
feat: add auto skill extraction to forge retrospective (#71)

### DIFF
--- a/skills/forge-skill/SKILL.md
+++ b/skills/forge-skill/SKILL.md
@@ -52,9 +52,20 @@ All data lives in the project memory directory:
   patterns.md                       # Aggregated patterns (max 200 lines)
   mutation-proposals/
     YYYY-MM-DD-<topic>.md           # Skill mutation proposals
+  skill-proposals/
+    YYYY-MM-DD-<topic>.md           # Skill extraction proposals
 ```
 
 **Context budget:** `patterns.md` MUST stay under 200 lines. It is loaded into context during feed-forward. Individual retrospective files are NOT loaded during feed-forward — only during mutation analysis.
+
+**Skill-Worthy Patterns section format** (within `patterns.md`):
+
+```markdown
+## Skill-Worthy Patterns
+
+- **[Pattern name]** (count: N, last seen: YYYY-MM-DD): [Description]
+  - Status: none | proposed ([path]) | accepted | rejected
+```
 
 ## Trajectory Capture (Opt-In)
 
@@ -141,7 +152,6 @@ Before writing ANY trajectory entry, apply these redaction steps in order:
 If the redaction pass cannot complete (e.g., malformed config, regex error), log a
 warning and skip trajectory recording for this invocation. Do NOT write an unredacted
 entry. Trajectory capture is a nice-to-have — it must never leak sensitive data.
-
 ---
 
 ## Mode 1: Post-Task Retrospective
@@ -209,6 +219,41 @@ After any skill that completes a significant task reports success. The calling s
       - Otherwise: append to `failed_trajectories.jsonl`
    e. Check file size: if the target file exceeds `max_entries` lines, remove the
       oldest entries (from the top of the file) to bring it back to `max_entries`.
+9. **Skill extraction check (all sessions):** Evaluate the just-produced
+   retrospective entry against the following trigger heuristics. If ANY
+   trigger fires, dispatch a Skill Extraction Analyst subagent (Sonnet)
+   using `./extraction-analyst-prompt.md`.
+
+   **Trigger heuristics (ANY fires = dispatch analyst):**
+   - **Complexity**: Execution summary references 5+ distinct tool calls or
+     subagent dispatches in a non-trivial sequence (sequential steps with
+     dependencies, not parallel reads of unrelated files)
+   - **Error recovery**: "What Went Wrong" describes errors that were overcome
+     AND "What Worked" credits a specific approach for the recovery
+   - **User correction**: Execution summary notes user redirection that led
+     to a successful outcome different from the original approach
+   - **Novel workflow**: "What Worked" describes a pattern not present in any
+     existing skill's SKILL.md description frontmatter (check skill names
+     and descriptions against the pattern)
+   - **Recurrence**: The positive pattern in "What Worked" matches an existing
+     entry in patterns.md "Skill-Worthy Patterns" with count >= 2, AND no
+     proposal has been generated for it yet
+
+   **Dispatch input:** retrospective entry, execution summary, existing skill
+   names/descriptions, existing proposals in skill-proposals/ and
+   mutation-proposals/.
+
+   **Handle output:**
+   - "No proposal warranted" -> Record pattern name in patterns.md
+     Skill-Worthy Patterns section (increment count or add new entry)
+   - NEW SKILL proposal -> Write to skill-proposals/YYYY-MM-DD-<topic>.md,
+     update patterns.md entry with status: proposed
+   - EXTEND EXISTING proposal -> Write to mutation-proposals/YYYY-MM-DD-<topic>.md
+     with `source: extraction` tag, update patterns.md entry with status: proposed
+
+   This step is RECOMMENDED, not REQUIRED. Failure does not break the
+   retrospective. If the analyst cannot determine skill-worthiness, record
+   the pattern and move on.
 
 ### Update Rules for patterns.md
 
@@ -219,11 +264,23 @@ After any skill that completes a significant task reports success. The calling s
 5. Prune warnings that have not occurred in the last 10 retrospectives (pattern may be resolved)
 6. Keep total file **under 200 lines** — compress or remove stale entries
 7. Write the updated file
+8. Update the "Skill-Worthy Patterns" section:
+   - If the retrospective's "What Worked" section describes a reusable pattern, add or increment it
+   - Each entry: pattern name, occurrence count, last-seen date, proposal status (none|proposed|accepted|rejected)
+   - Maximum 10 entries, 2 lines each
+   - Prune patterns not seen in last 10 retrospectives (same rule as warnings)
+   - Mark patterns as "resolved" (compress to single line) when their proposal has been accepted or rejected
 
 ### After Writing
 
 If total retrospective count >= 10 AND any deviation type has 3+ occurrences, suggest to user:
 > "Forge has accumulated enough data for skill improvement proposals. Would you like to run mutation analysis?"
+
+If a skill extraction proposal was generated in step 9, notify the user:
+> "Forge detected a skill-worthy workflow: [proposed skill name or extension target]. Proposal written to [path]. When you're ready, you can use skill-creator with this proposal as a starting point."
+
+Do NOT prompt for immediate action. The notification is informational. The user
+decides when (or whether) to act on it.
 
 ### Trajectory Recording Without Retrospective
 
@@ -324,6 +381,11 @@ The Forge produces proposals for human review. It does not edit skill files. It 
 
 **Forge is RECOMMENDED, not REQUIRED.** It is a learning accelerator, not a quality gate. Skipping it does not produce broken output — it misses an opportunity to learn.
 
+**Skill extraction** is an internal step within Mode 1 (Retrospective). It does
+not require any calling skill to pass additional data -- the retrospective entry
+itself provides the input. The extraction analyst may read existing skill
+descriptions from the skill directories to check for overlap.
+
 ## Quick Reference
 
 | Mode | Trigger | Model | Template | Output |
@@ -341,6 +403,10 @@ The Forge produces proposals for human review. It does not edit skill files. It 
 - Load individual retrospective files into feed-forward (context bloat)
 - Run mutation analysis with fewer than 10 retrospectives
 - Treat feed-forward warnings as hard blockers (they are advisories)
+- Auto-create skills from extraction proposals (Iron Law applies to extraction too)
+- Dispatch skill-creator from within the forge pipeline
+- Generate skill proposals for trivial workflows (single-step, domain-specific)
+- Propose a new skill when an existing skill already covers the workflow
 - Store raw user prompts in trajectory files — only store prompt hashes and redacted summaries
 - Write a trajectory entry without completing the redaction pass
 - Auto-enable trajectory capture — it must be explicitly opted into via config file
@@ -350,6 +416,9 @@ The Forge produces proposals for human review. It does not edit skill files. It 
 - Check for patterns.md before design/planning
 - Write mutation proposals to disk for human review
 - Handle cold start gracefully (no data = no feed-forward, just say so)
+- Check existing skill descriptions before flagging a workflow as "novel"
+- Include confidence level on every extraction proposal
+- Write proposals to disk before notifying the user
 - Check trajectory-config.json before any trajectory operation
 - Run the full redaction pass before writing any trajectory entry
 - Set `redacted: true` only after the redaction pass completes
@@ -365,6 +434,9 @@ The Forge produces proposals for human review. It does not edit skill files. It 
 | "Only one data point, feed-forward is useless" | Even one warning is better than none. Report limited data. |
 | "I'll run the retrospective later" | Later never comes. Run it now, while context is fresh. |
 | "I already know what went wrong" | Knowing is not recording. Write it down so FUTURE sessions know too. |
+| "This workflow is obviously worth a skill, just create it" | Iron Law: proposals only. Humans decide. Even the best-looking workflow may be a one-off. |
+| "Every session has a skill-worthy pattern" | If >30% of retrospectives trigger proposals, the heuristics are too loose. Tighten them. |
+| "The proposal is low-confidence, not worth writing" | Low-confidence proposals are seeds. They become medium when they recur. Write them down. |
 | "Trajectory data is too noisy to be useful" | Even noisy data reveals patterns at scale. 10 failed trajectories with the same deviation type IS a signal. |
 | "I'll enable trajectory capture later" | Later means no data for the current project. Enable it now if you want eval generation from real usage. |
 | "The redaction pass is too conservative" | Conservative redaction protects the user. A missed eval scenario is cheaper than a leaked secret. |
@@ -388,9 +460,22 @@ The Forge produces proposals for human review. It does not edit skill files. It 
 - Problem: 3 retrospectives, agent proposes sweeping skill changes
 - Fix: Minimum 10 retrospectives. Below that, patterns are noise.
 
+**Proposing skills for domain-specific workflows**
+- Problem: Agent proposes a skill for "deploying to our specific Kubernetes cluster" -- a workflow only useful for this one project
+- Fix: The extraction analyst must assess generalizability. Workflows that reference project-specific infrastructure, APIs, or conventions are positive patterns, not skill candidates.
+
+**Ignoring extraction proposals**
+- Problem: Proposals accumulate in skill-proposals/ and are never reviewed
+- Fix: During feed-forward, the advisor can surface pending proposals as a reminder: "N skill proposals awaiting review." Users should periodically review and accept/reject.
+
+**Duplicate proposals from extraction and mutation**
+- Problem: Mode 3 mutation analysis recommends a new skill that extraction already proposed
+- Fix: Mutation analyst cross-references skill-proposals/ before recommending new skills. If a proposal exists, add evidence to it.
+
 ## Prompt Templates
 
 - `./retrospective-prompt.md` — Post-task retrospective analyst dispatch
 - `./feed-forward-prompt.md` — Pre-task feed-forward advisor dispatch
 - `./mutation-proposal-prompt.md` — Skill mutation analyst dispatch
 - `./diagnostic-extraction-prompt.md` — Debugging session diagnostic pattern extraction dispatch
+- `./extraction-analyst-prompt.md` -- Skill-worthy workflow detection and proposal generation dispatch

--- a/skills/forge-skill/extraction-analyst-prompt.md
+++ b/skills/forge-skill/extraction-analyst-prompt.md
@@ -1,0 +1,157 @@
+# Skill Extraction Analyst -- Dispatch Template
+
+Dispatch a Sonnet subagent when trigger heuristics detect a skill-worthy workflow
+in a retrospective entry.
+
+```
+Task tool (general-purpose, model: sonnet):
+  description: "Forge skill extraction analysis for [task name]"
+  prompt: |
+    You are a skill extraction analyst. Your job is to evaluate whether a
+    successful workflow should be captured as a reusable Crucible skill, and
+    if so, produce a structured proposal for human review.
+
+    You produce proposals for human review. You do NOT create skills, invoke
+    skill-creator, modify existing skills, or dispatch any agent to do so.
+
+    ## Retrospective Entry
+
+    [PASTE the full retrospective entry just produced]
+
+    ## Execution Summary
+
+    [PASTE the execution summary provided to the retrospective]
+
+    ## Existing Skills
+
+    [List all crucible skill names with their description frontmatter]
+
+    ## Existing Skill Proposals
+
+    [List any existing proposals in skill-proposals/ and mutation-proposals/
+     to avoid duplicates. "None" if no proposals exist.]
+
+    ## Trigger Signal
+
+    [Which heuristic trigger(s) fired: complexity, error-recovery,
+     user-correction, novel-workflow, recurrence]
+
+    ## Your Job
+
+    Evaluate whether this workflow merits extraction as a reusable skill.
+
+    **Step 1: Assess reusability**
+    - Is this workflow generalizable beyond this specific task/codebase?
+    - Would a different agent session benefit from having these steps codified?
+    - Is the workflow multi-step with decision points (not just "run one command")?
+    - If the answer to any of these is "no", STOP and output:
+      "No proposal warranted. Record as positive pattern only: [pattern name]"
+
+    **Step 2: Check existing coverage**
+    - Does any existing skill already cover this workflow?
+    - If partially covered: recommend extending that skill (patch proposal)
+    - If fully covered: STOP and output:
+      "Workflow already covered by [skill-name]. No proposal needed."
+
+    **Step 3: Determine proposal type**
+    - NEW SKILL: The workflow is distinct from all existing skills
+    - EXTEND EXISTING: The workflow belongs in an existing skill but is missing
+
+    **Step 4: Generate proposal**
+
+    For NEW SKILL proposals:
+
+    ---
+    type: new-skill
+    status: proposed
+    proposed_name: "[kebab-case skill name]"
+    trigger_description: "[When should this skill activate -- user phrases, task shapes]"
+    source_retrospective: "[YYYY-MM-DD-HHMMSS-slug]"
+    confidence: low | medium | high
+    ---
+
+    ## Workflow Shape
+
+    [Numbered sequence of steps, decision points, and tool calls that
+     constitute this workflow. Be specific enough that skill-creator
+     can use this as input.]
+
+    ## Trigger Conditions
+
+    [When should this skill fire? What user phrases, what task shapes,
+     what context cues?]
+
+    ## Expected Inputs and Outputs
+
+    [What does the workflow receive? What does it produce?]
+
+    ## Existing Skill Overlap
+
+    [Which current skills partially cover this territory? Why is a new
+     skill warranted despite the overlap?]
+
+    ## Evidence
+
+    [Which retrospective entries demonstrate this workflow's value?
+     Cite by date and task description.]
+
+    ## Recommendation
+
+    [One paragraph: why this should become a skill, expected impact,
+     who benefits]
+
+    For EXTEND EXISTING proposals:
+
+    ---
+    type: extend-existing
+    status: proposed
+    source: extraction
+    target_skill: "[crucible:skill-name]"
+    source_retrospective: "[YYYY-MM-DD-HHMMSS-slug]"
+    confidence: low | medium | high
+    ---
+
+    ## Target Skill
+
+    [Which skill to extend]
+
+    ## Current Coverage
+
+    [What the skill currently covers in the relevant area -- quote the section]
+
+    ## Proposed Addition
+
+    ```markdown
+    [Exact text to add to the skill -- workflow steps, new reference, new pattern]
+    ```
+
+    ## Evidence
+
+    [Which retrospective entries demonstrate the value]
+
+    ## Expected Impact
+
+    [What this addition prevents or enables]
+
+    ## Rules
+
+    - If the workflow is trivial (describable in one sentence) or entirely
+      domain-specific (applies only to this exact codebase), do not generate
+      a proposal. Record as a positive pattern only.
+    - NEW SKILL proposals must describe a workflow with 3+ distinct steps.
+      Single-action patterns belong in existing skills.
+    - EXTEND EXISTING proposals must include exact proposed text, not
+      vague suggestions.
+    - Confidence levels: low = 1 supporting session, medium = 2-3 sessions
+      or strong single-session signal (user praised, complex recovery),
+      high = 4+ sessions.
+    - Check for duplicates: if a proposal already exists for the same
+      workflow pattern (in skill-proposals/ or mutation-proposals/),
+      do not create a new one. Instead, output:
+      "Duplicate of existing proposal [path]. Add as supporting evidence."
+    - Maximum 1 proposal per retrospective. If multiple skill-worthy
+      patterns exist, propose the strongest and record others as
+      positive patterns for recurrence tracking.
+    - NEVER propose creating a skill that duplicates an existing skill's
+      core purpose. Extensions over duplication.
+```

--- a/skills/forge-skill/feed-forward-prompt.md
+++ b/skills/forge-skill/feed-forward-prompt.md
@@ -66,6 +66,19 @@ Task tool (general-purpose, model: sonnet):
 
     Only surface calibration data when there are 3+ data points. Do not speculate from a single session.
 
+    ## Positive Workflow Patterns
+
+    In addition to warnings about deviation patterns, also look for
+    skill-worthy positive patterns in the "Skill-Worthy Patterns" section
+    of patterns.md. If the upcoming task has similarities to a tracked
+    positive pattern, surface it as a REINFORCEMENT (not a warning):
+
+    > "Previous sessions found success with [pattern]. Consider applying
+    > the same approach here."
+
+    Reinforcements count toward the 3-5 targeted output limit alongside
+    warnings. Maximum 1 reinforcement per feed-forward output.
+
     ## Rules
 
     - Maximum 5 warnings. Prioritize by relevance to THIS task, not by frequency.

--- a/skills/forge-skill/mutation-proposal-prompt.md
+++ b/skills/forge-skill/mutation-proposal-prompt.md
@@ -22,6 +22,11 @@ Task tool (general-purpose, model: opus):
 
     [List all crucible skill names available in the system]
 
+    ## Existing Skill Extraction Proposals
+
+    [PASTE list of any proposals in skill-proposals/, including their
+     proposed name, confidence, and source retrospective. "None" if empty.]
+
     ## Your Job
 
     Analyze the retrospective data for patterns that suggest specific skill
@@ -75,6 +80,11 @@ Task tool (general-purpose, model: opus):
     ## New Skill Candidates
 
     - [If a pattern suggests an entirely new skill, describe it briefly]
+    - [Cross-reference with existing extraction proposals: if a proposal
+      already exists for this pattern, cite it and add supporting evidence
+      rather than creating a duplicate recommendation]
+    - [If an existing low-confidence extraction proposal is supported by
+      accumulation evidence, recommend upgrading its confidence]
 
     ## Rules
 
@@ -91,4 +101,7 @@ Task tool (general-purpose, model: opus):
     - If no proposals are warranted, say so honestly. Do not manufacture
       proposals to justify the analysis.
     - Limit to 5 proposals maximum. Quality over quantity.
+    - Before recommending a new skill, check whether an extraction proposal
+      already exists in skill-proposals/. If so, add your evidence to that
+      proposal rather than creating a parallel recommendation.
 ```


### PR DESCRIPTION
## Summary
- Adds post-retrospective skill extraction pipeline to forge Mode 1 with 5 trigger heuristics (complexity, error recovery, user correction, novel workflow, recurrence)
- New `extraction-analyst-prompt.md` Sonnet subagent template for evaluating skill-worthy workflows
- Positive pattern tracking in `patterns.md` for cross-session reinforcement
- Mutation analyst (Mode 3) cross-references extraction proposals to avoid duplicates

## Changes
- `skills/forge-skill/SKILL.md` — Step 8 in Mode 1, storage additions, red flags, rationalization prevention, common mistakes
- `skills/forge-skill/extraction-analyst-prompt.md` — New prompt template
- `skills/forge-skill/mutation-proposal-prompt.md` — Cross-reference with extraction proposals
- `skills/forge-skill/feed-forward-prompt.md` — Positive pattern surfacing

## Contract verification
All 12 checkable invariants verified passing.

Closes #71 | Part of epic #75

## Test plan
- [ ] Verify 5 trigger heuristics are enumerated in Mode 1 step 8
- [ ] Verify extraction-analyst-prompt.md includes Iron Law compliance
- [ ] Verify proposals never auto-create skills (user confirmation required)
- [ ] Verify mutation analyst cross-references extraction proposals
- [ ] Verify forge remains 3 modes (no new mode added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)