### PR TITLE
feat: add AI Slop Signals to reviewer checklist

### DIFF
--- a/skills/build/build-reviewer-prompt.md
+++ b/skills/build/build-reviewer-prompt.md
@@ -67,9 +67,21 @@ Task tool (general-purpose, model: opus or sonnet — lead decides per task comp
     **Quality:**
     - Clean separation of concerns? Single responsibility per component?
     - Clear naming that matches what things DO, not how they work?
-    - Proper error handling?
+    - Proportional error handling? (validate at boundaries, trust internal contracts — see AI Slop Signals for specific diff-level patterns)
     - DRY principle followed?
     - No overengineering or YAGNI violations?
+
+    <!-- CANONICAL: shared/reviewer-common.md — Review Checklist (AI Slop Signals) -->
+    **AI Slop Signals:**
+    AI agents produce characteristic padding that inflates diffs and obscures real changes. Typically Minor severity; Important only when padding obscures real changes. Common patterns:
+    - Comment inflation: comments restating obvious code. Comments explain *why*, not *what*.
+    - Docstring/annotation padding retrofitted onto code not otherwise changed in this diff. (Type annotations required by type-checking config are not padding.)
+    - Over-defensive error handling for conditions that cannot occur given call site and framework guarantees.
+    - Premature abstraction: helpers, wrappers, or type definitions used exactly once without adding meaningful naming.
+    - Backwards-compatibility ghosts: renamed-but-unused vars, re-exported dead types, `// removed` comments.
+    - Unused imports: imports for modules, types, or symbols not referenced in the file.
+    Judge by whether additions serve the task or merely inflate the diff.
+    In the build pipeline, check the de-sloppify cleanup log before flagging these patterns independently.
 
     **Wiring:**
     - Is new code actually connected to the rest of the system?

--- a/skills/code-review/code-reviewer.md
+++ b/skills/code-review/code-reviewer.md
@@ -48,9 +48,21 @@ git diff {BASE_SHA}..{HEAD_SHA}
 ### Quality
 - Clean separation of concerns? Single responsibility per component?
 - Clear naming that matches what things DO, not how they work?
-- Proper error handling?
+- Proportional error handling? (validate at boundaries, trust internal contracts — see AI Slop Signals for specific diff-level patterns)
 - DRY principle followed?
 - No overengineering or YAGNI violations?
+
+### AI Slop Signals
+AI agents produce characteristic padding patterns that aren't bugs but inflate diffs, obscure real changes, and accumulate as maintenance burden. These are typically Minor or Suggestion severity; escalate to Important only when padding materially obscures real changes in the diff. Common patterns include:
+
+- **Comment inflation:** Inline comments restating obvious code (`// increment counter` above `counter++`). Comments should explain *why*, not *what*.
+- **Docstring/annotation padding:** Docstrings or annotations retrofitted onto code not otherwise changed in this diff. New public APIs deserve docs; retrofitting docs onto untouched private helpers is noise. (Type annotations required by the project's type-checking configuration are not padding.)
+- **Over-defensive error handling:** Try/catch, null checks, or validation for conditions that cannot occur given the call site and framework guarantees. Trust internal code; validate at system boundaries only.
+- **Premature abstraction:** Helpers, utilities, wrapper functions, or type definitions used exactly once and not providing a meaningful name for a complex operation. Three similar lines are better than a one-call abstraction that just moves code.
+- **Backwards-compatibility ghosts:** Renamed-but-unused `_old_var`, re-exported types no consumer imports, `// removed` comments for deleted code. If it's unused, delete it completely.
+- **Unused imports:** Import statements for modules, types, or symbols not referenced in the file. Especially common when an agent adds imports speculatively during implementation and doesn't clean up.
+
+**Distinguishing slop from substance:** A docstring on a new public function is legitimate. The same docstring retrofitted onto an existing private helper that wasn't touched — that's padding. Context matters: judge by whether the addition serves the task or merely inflates the diff.
 
 ### Testing
 - Tests actually test behavior (not just mock interactions)?

--- a/skills/shared/reviewer-common.md
+++ b/skills/shared/reviewer-common.md
@@ -25,9 +25,21 @@
 ### Quality
 - Clean separation of concerns? Single responsibility per component?
 - Clear naming that matches what things DO, not how they work?
-- Proper error handling?
+- Proportional error handling? (validate at boundaries, trust internal contracts — see AI Slop Signals for specific diff-level patterns)
 - DRY principle followed?
 - No overengineering or YAGNI violations?
+
+### AI Slop Signals
+AI agents produce characteristic padding patterns that aren't bugs but inflate diffs, obscure real changes, and accumulate as maintenance burden. These are typically Minor or Suggestion severity; escalate to Important only when padding materially obscures real changes in the diff. Common patterns include:
+
+- **Comment inflation:** Inline comments restating obvious code (`// increment counter` above `counter++`). Comments should explain *why*, not *what*.
+- **Docstring/annotation padding:** Docstrings or annotations retrofitted onto code not otherwise changed in this diff. New public APIs deserve docs; retrofitting docs onto untouched private helpers is noise. (Type annotations required by the project's type-checking configuration are not padding.)
+- **Over-defensive error handling:** Try/catch, null checks, or validation for conditions that cannot occur given the call site and framework guarantees. Trust internal code; validate at system boundaries only.
+- **Premature abstraction:** Helpers, utilities, wrapper functions, or type definitions used exactly once and not providing a meaningful name for a complex operation. Three similar lines are better than a one-call abstraction that just moves code.
+- **Backwards-compatibility ghosts:** Renamed-but-unused `_old_var`, re-exported types no consumer imports, `// removed` comments for deleted code. If it's unused, delete it completely.
+- **Unused imports:** Import statements for modules, types, or symbols not referenced in the file. Especially common when an agent adds imports speculatively during implementation and doesn't clean up.
+
+**Distinguishing slop from substance:** A docstring on a new public function is legitimate. The same docstring retrofitted onto an existing private helper that wasn't touched — that's padding. Context matters: judge by whether the addition serves the task or merely inflates the diff.
 
 ### Testing
 - Tests actually test behavior (not just mock interactions)?


### PR DESCRIPTION
## Summary

- Adds **AI Slop Signals** section to the canonical review checklist (`shared/reviewer-common.md`) teaching reviewers to detect 6 patterns of AI-generated padding/inflation in code diffs
- Amends Quality section's error handling item to cross-reference Slop Signals for operational detection
- Syncs to both consumers: `code-review/code-reviewer.md` (full) and `build/build-reviewer-prompt.md` (condensed + cleanup-log coordination)

Inspired by [peakoss/anti-slop](https://github.com/peakoss/anti-slop)'s catalog of AI output smells, adapted as reviewer guidance rather than a GitHub Action.

**The 6 signals:** comment inflation, docstring/annotation padding, over-defensive error handling, premature abstraction, backwards-compatibility ghosts, unused imports.

**Key design decisions (validated through quality gate):**
- Default severity: Minor/Suggestion — escalate to Important only when padding materially obscures real changes
- Type-checking annotation exemption prevents false positives on gradual typing adoption
- Premature abstraction escape valve for legitimate meaningful-naming extractions
- Build-reviewer gets cleanup-log awareness line (code-reviewer operates without prior cleanup pass)
- Quality section cross-references Slop Signals (principle → operational detection)

## Quality Gate

4 red-team rounds, score progression: **5 → 3 → 2 → 0**

| Round | Significant | Key fixes |
|-------|------------|-----------|
| 1 | 5 | Removed scope creep (already in Correctness) and commit message bloat (unactionable in build-reviewer); broadened premature abstraction to include type definitions |
| 2 | 3 | Added severity calibration; qualified premature abstraction; added build-pipeline cleanup-log line |
| 3 | 2 | Cross-referenced Quality → Slop for error handling; narrowed docstring bullet with type-checking exemption |
| 4 | 0 | Clean pass — all candidates investigated and downgraded to Minor |

Post-gate minor fixes: added unused imports signal, changed "Flag these:" to "Common patterns include:" (exemplary not exhaustive framing).

## Test plan

- [ ] Verify canonical sync: `reviewer-common.md` AI Slop Signals section matches `code-reviewer.md`
- [ ] Verify build-reviewer condensed version retains all 6 signals + cleanup-log line
- [ ] Verify Quality section cross-reference present in all 3 files

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)