### PR TITLE
feat: negative knowledge persistence — QG dead ends in Cartographer landmines

### DIFF
--- a/skills/cartographer-skill/SKILL.md
+++ b/skills/cartographer-skill/SKILL.md
@@ -367,7 +367,7 @@ When dispatching an implementer, reviewer, investigator, or any subagent that wi
    - **What to load per subagent type:** See the subagent loading table below.
    - **`Last loaded` update:** Loading is a pure-read operation. After all subagent dispatches for the current phase complete, the orchestrator batch-updates the `Last loaded` field on all signatures that were loaded during that phase.
 8. If no module file exists: dispatch without it (subagent explores normally, record afterwards)
-9. When loading landmines for debugging investigators and synthesis agents, include `dead_ends` and `diagnostic_path` fields for hypothesis cross-referencing
+9. When loading landmines for debugging investigators and synthesis agents, include `dead_ends` and `diagnostic_path` fields for hypothesis cross-referencing. **Source-tag filtering:** Dead-end entries include a `(source: qg)` or `(source: debugging)` tag. Debugging investigators should only receive `source: debugging` entries for hypothesis cross-referencing — QG-sourced dead ends describe fix strategies, not diagnostic hypotheses, and would create noise. Reviewer and red-team subagents receive all entries regardless of source tag.
 
 ### What Each Subagent Type Gets
 

--- a/skills/cartographer-skill/recorder-prompt.md
+++ b/skills/cartographer-skill/recorder-prompt.md
@@ -107,8 +107,17 @@ Task tool (general-purpose, model: sonnet):
       tried and evidence that ruled them out) and `diagnostic_path` (steps
       that found the root cause). These fields are optional for non-debugging
       landmines. Format:
-        - **Dead ends:** [hypothesis] — ruled out because [evidence].
+        - **Dead ends:** [hypothesis] — ruled out because [evidence]. (source: debugging)
         - **Diagnostic path:** [steps that found root cause].
+    - For QG-originated landmines (from forge step 6b), dead-end entries
+      describe fix strategies rather than diagnostic hypotheses. Format:
+        - **Dead ends:** [fix strategy] — ruled out because [reason]. (source: qg)
+        - **Diagnostic path:** [round progression].
+    - **Dedup on UPDATE:** When updating existing landmine entries with new
+      dead-end evidence, preserve each distinct failure description as a
+      separate bullet. Do not merge two different failure descriptions into
+      one sentence. Two dead-ends that share a file path but describe
+      different failure modes remain as separate bullets within the same entry.
     - If updating an existing file, MERGE with existing content. Do not
       drop existing entries unless they are demonstrably wrong.
     - Keep module files under 100 lines. If you're exceeding that, the

--- a/skills/forge-skill/SKILL.md
+++ b/skills/forge-skill/SKILL.md
@@ -190,7 +190,13 @@ After any skill that completes a significant task reports success. The calling s
 3. Subagent returns structured retrospective entry
 4. Write entry to `~/.claude/projects/<project-hash>/memory/forge/retrospectives/YYYY-MM-DD-HHMMSS-<slug>.md`
 5. Update `patterns.md` — read current file, merge new findings, rewrite
-6. For debugging sessions, the retrospective also extracts diagnostic patterns using a dedicated extraction subagent (Opus). Dispatch using `./diagnostic-extraction-prompt.md`. Patterns are written to cartographer's landmines via `crucible:cartographer` (record mode) with `dead_ends` and `diagnostic_path` fields.
+6. For debugging sessions, the retrospective also extracts diagnostic patterns using a dedicated extraction subagent (Opus). Dispatch using `./diagnostic-extraction-prompt.md`. Patterns are written to cartographer's landmines via `crucible:cartographer` (record mode) with `dead_ends` and `diagnostic_path` fields. Tag dead-end entries with `(source: debugging)`.
+6b. For build sessions with QG fix journals: glob for `~/.claude/projects/<project-hash>/memory/quality-gate/fix-journal-*.md`. For each handoff file found:
+    a. Read `landmines.md` and check for existing entries matching the same module + same failed approach (same file path AND same module AND 3+ non-stopword shared terms). If matching entries exist, skip extraction — handoff was already processed. Delete the handoff file.
+    b. If no match: dispatch the diagnostic extraction subagent (Opus) using `./diagnostic-extraction-prompt.md` with the QG-specific addendum (see that file's "Source Context: Quality Gate Fix Journal" section). Tag dead-end entries with `(source: qg)`.
+    c. Write extracted dead ends to cartographer's landmines via `crucible:cartographer` (record mode).
+    d. Delete the handoff file after successful extraction.
+    e. **Cap-pressure behavior:** If `landmines.md` is within 10 lines of its 100-line cap, write only Fatal-severity dead ends. At cap, skip and emit a chronicle signal: `{ "event": "dead_end_cap_skip", "module": "<module>", "source": "qg" }`.
 7. For build sessions with a decision journal, the retrospective also extracts
    substantive design decisions. The retrospective analyst identifies decisions
    that are NOT operational routing (reviewer-model, gate-round, task-grouping,
@@ -390,6 +396,13 @@ Before `crucible:design`, `crucible:planning`, or `crucible:build` begins its co
        - Write regenerated summary to `chronicle/summary.md`
     d. Load `chronicle/summary.md` into context alongside `patterns.md`
     e. Pass both to the Feed-Forward Advisor in Step 4
+3.7. **Dead-end context** (if cartographer data exists):
+    a. Check if `~/.claude/projects/<project-hash>/memory/cartographer/landmines.md` exists
+    b. If not found: skip (no dead-end data yet)
+    c. If found: identify the upcoming task's target file paths from the task description. Resolve each to a cartographer module via `Path:` prefix matching (same logic as Cartographer Mode 3 Load step 7). Scan `landmines.md` for entries with file paths resolving to the same modules.
+    d. If 0 matching entries: skip
+    e. If 1+ matching entries: extract the matching entries (both `source: qg` and `source: debugging`). Pass to the Feed-Forward Advisor in Step 4 under the "Dead-End Context" section.
+    **Note:** Forge scans `landmines.md` directly rather than routing through Cartographer Mode 3 Load to avoid coupling — feed-forward works even when no Cartographer consult runs in the current session.
 4. Dispatch a **Feed-Forward Advisor** subagent (Sonnet) using `./feed-forward-prompt.md`
 4b. **Trajectory context** (if trajectory capture is enabled):
     Also read `~/.claude/projects/<hash>/memory/trajectories/failed_trajectories.jsonl`

--- a/skills/forge-skill/diagnostic-extraction-prompt.md
+++ b/skills/forge-skill/diagnostic-extraction-prompt.md
@@ -1,6 +1,26 @@
 # Diagnostic Pattern Extraction Prompt
 
-Use this template when dispatching a diagnostic pattern extraction subagent during forge retrospectives for debugging sessions.
+Use this template when dispatching a diagnostic pattern extraction subagent during forge retrospectives for debugging sessions (step 6) and build sessions with QG fix journals (step 6b).
+
+## Source Context: Quality Gate Fix Journal (prepend for step 6b dispatches only)
+
+When the source is a QG fix journal (not a debugging session), prepend this context before the "Session Artifacts" section:
+
+> The artifacts below are from a quality gate fix cycle, not a debugging session. The fix journal records iterative attempts to resolve red-team findings on a code artifact.
+>
+> Mapping to your extraction targets:
+> - "Hypotheses tried" = fix strategies attempted per round (## Round N Fix entries)
+> - "Evidence that ruled them out" = verifier Unresolved assessments + next-round re-raises of the same finding
+> - "Root cause" = the final successful fix approach (last round entry)
+> - "Diagnostic path" = the progression across rounds from initial approach to resolution
+>
+> Extract dead ends where: a fix approach was tried in round N, the verifier marked it Unresolved or the next review re-raised the same finding, and a different approach succeeded in a later round. These are genuine dead ends with discriminating evidence.
+>
+> Skip entries where the fix was simply incomplete (addressed 2 of 3 findings) rather than wrong-approach (tried X, X didn't work, Y worked).
+>
+> Tag all dead-end entries with `(source: qg)` after the evidence text.
+
+---
 
 ```
 Task tool (general-purpose, model: opus):

--- a/skills/forge-skill/feed-forward-prompt.md
+++ b/skills/forge-skill/feed-forward-prompt.md
@@ -25,6 +25,24 @@ Task tool (general-purpose, model: sonnet):
     Chronicle data is aggregate statistics, not individual task details. Use it for
     pattern detection, not specifics.
 
+    ## Dead-End Context (if available)
+
+    [PASTE matching landmine dead-end entries from landmines.md that are relevant
+    to this task's target modules, or "No dead-end data for target modules" if
+    none match]
+
+    If dead-end entries are provided above, they represent specific prior failures
+    in modules this task touches. Use them as context when forming your advisories.
+    They count toward your 5-warning maximum — prioritize by relevance to THIS
+    task, not by source type.
+
+    Dead-end context is most valuable when the upcoming task directly modifies
+    files in the dead-end's module. If the task only peripherally touches the
+    module (e.g., importing from it but not modifying it), deprioritize dead-end
+    warnings in favor of process-level warnings from patterns.md. When both
+    compete for the 5-warning cap, direct-module dead-ends take priority over
+    peripheral-module dead-ends.
+
     ## Upcoming Task
 
     [Brief description of what is about to be brainstormed/planned/executed]

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -258,7 +258,7 @@ Quality gate writes round state to disk for compaction recovery.
 
 **Active run marker:** At the start of the gate, write `~/.claude/projects/<project-hash>/memory/quality-gate/active-run-<run-id>.md` containing the run-id and scratch directory path. Delete only your own marker when the gate completes. After compaction, glob for `active-run-*.md` files to locate active runs — recover the one whose run-id matches context, or the most recent if context is lost.
 
-**Stale cleanup:** At the start of each gate, delete scratch directories whose timestamps are older than 2 hours AND that are NOT referenced by any `active-run-*.md` marker.
+**Stale cleanup:** At the start of each gate, delete scratch directories whose timestamps are older than 2 hours AND that are NOT referenced by any `active-run-*.md` marker. Also delete any `fix-journal-*.md` handoff files in the `memory/quality-gate/` directory whose mtime is older than 24 hours (the longer window accommodates overnight breaks between QG and forge sessions).
 
 **After each round, write:**
 - `round-N-score.md`: weighted score, Fatal count, Significant count, Minor count
@@ -290,6 +290,8 @@ Emit a Compression State Block at:
 - **Before stagnation judge dispatch:** When the first-pass check would trigger stagnation
 - **Gate completion:** When the gate passes or escalates (before returning to parent skill)
 - **Health transitions:** On any GREEN->YELLOW or YELLOW->RED transition
+
+**Dead-end handoff (step 4a, code artifacts only):** After Minor Issue Handling and before cleanup, if `fix-journal.md` exists in the scratch directory and contains 1+ round entries, copy its contents to `~/.claude/projects/<project-hash>/memory/quality-gate/fix-journal-<run-id>.md` (using the gate's run-id). This is a **transient handoff artifact** for the next forge retrospective. On stagnation/escalation exit paths, also write the handoff file before escalating — stagnated sessions produce the highest-value dead-end data.
 
 **Cleanup:** Delete scratch directory and your `active-run-<run-id>.md` marker after the gate completes (pass or stagnation).
 


### PR DESCRIPTION
## Summary

- QG fix journals (which approaches failed and why) were deleted with scratch directories before Forge could extract them
- Adds QG step 4a: timestamped handoff file survives scratch cleanup for Forge to consume
- Adds Forge step 6b: extracts dead ends from QG fix journals into Cartographer landmines with `(source: qg)` tags
- Adds Forge step 3.7: surfaces landmine dead ends in feed-forward advisories with priority tiebreaker
- Source-tag filtering ensures QG dead ends (fix strategies) don't pollute debugging hypothesis cross-referencing
- Triple-filter dedup, cap-pressure behavior, 24h orphan cleanup

67 lines across 6 files. Passed 7 rounds of quality-gate adversarial review (score: 12→2, 0 fatals from round 3).

Closes #94

## Related

- #92 — landmines.md entry retirement policy (deferred improvement)
- #93 — semantic dedup for dead-end entries (deferred improvement)

## Test plan

- [ ] Run a build with QG that hits 3+ rounds — verify `fix-journal-<run-id>.md` handoff file is created before scratch cleanup
- [ ] Run forge retrospective after QG — verify dead ends extracted to `landmines.md` with `(source: qg)` tag
- [ ] Run feed-forward on a task touching a module with dead ends — verify dead-end context appears in advisory
- [ ] Verify debugging investigators only see `(source: debugging)` entries
- [ ] Verify handoff files are cleaned up after extraction
- [ ] Verify 24h orphan cleanup deletes stale handoff files

🤖 Generated with [Claude Code](https://claude.com/claude-code)