### PR TITLE
feat: harden quality-gate non-skippability across all orchestrators

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -32,6 +32,24 @@ Every status update must include:
 
 **This requirement exists because:** Long-running autonomous pipelines can run for hours. Without narration, the user sees nothing but a spinner. They can't assess progress, can't decide whether to intervene, and can't learn from the pipeline's decisions.
 
+## Quality Gate Requirement (Non-Negotiable)
+
+**Every quality gate in this pipeline MUST run to completion.** This is NOT optional — you may NOT self-assess whether a quality gate is "needed" based on task size, complexity, or scope.
+
+Quality gates are unconditional at all three gate points:
+1. **Phase 1, Step 2** — Design doc gate
+2. **Phase 2, Step 3** — Plan gate
+3. **Phase 4, Step 6** — Implementation gate
+
+**Common rationalizations that are NEVER valid reasons to skip:**
+- "This is a small change"
+- "This is trivial / simple / straightforward"
+- "This is just a config change / documentation update / one-liner"
+- "The quality gate won't find anything on something this simple"
+- "I fixed the findings, so the gate is done" — **fixing findings is NOT the same as passing the gate.** The iteration loop must complete with a clean verification round (0 Fatal, 0 Significant on a fresh review). Fix agents introduce new issues or incompletely resolve old ones — that is why fresh-eyes re-review exists.
+
+**This requirement exists because:** Quality gates consistently find issues the pipeline misses regardless of task size. There is no category of task that is immune. In observed runs, tasks self-assessed as "trivial" had the same defect rate as complex tasks. The only way to skip a quality gate is with explicit user approval — an unambiguous instruction specifically referencing the gate, not general feedback like "looks good" or "move on."
+
 ## Pipeline Status
 
 Write a status file to `~/.claude/projects/<hash>/memory/pipeline-status.md` at every narration point. This file is overwritten (not appended) and provides ambient awareness for the user in a second terminal.
@@ -290,7 +308,7 @@ After the user approves the design and before starting Phase 2:
 **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-design-gate" before dispatching innovate and quality-gate on the design doc.
 
 1. **Innovate:** Dispatch `crucible:innovate` on the design doc. Plan Writer incorporates the proposal.
-2. **Quality gate:** Dispatch `crucible:quality-gate` on the (potentially updated) design doc with artifact type "design". Iterates until clean or stagnation.
+2. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on the (potentially updated) design doc with artifact type "design". Iterates until clean or stagnation. **(Non-negotiable — see Quality Gate Requirement.)**
 3. If the quality gate requires changes, the Plan Writer updates the design doc and re-commits.
 4. Design doc is now finalized — proceed to acceptance tests.
 
@@ -446,7 +464,7 @@ Use `./plan-reviewer-prompt.md` template for the dispatch prompt.
 **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-plan-gate" before dispatching innovate and quality-gate on the plan.
 
 1. **Innovate:** Dispatch `crucible:innovate` on the approved plan. Plan Writer incorporates the proposal into the plan.
-2. **Quality gate:** Dispatch `crucible:quality-gate` on the (potentially updated) plan with artifact type "plan". Provides the plan and design doc as context.
+2. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on the (potentially updated) plan with artifact type "plan". Provides the plan and design doc as context. **(Non-negotiable — see Quality Gate Requirement.)**
 
 The quality gate handles the iterative red-team loop — fresh review each round, weighted stagnation detection, 15-round safety limit, escalation. See `crucible:quality-gate` for details.
 
@@ -829,7 +847,7 @@ After all tasks complete:
    - Iterative until clean, same as step 3
    - Skip if the inquisitor reported all PASS (no fixes were needed)
 6. **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-impl-gate" before dispatching the implementation quality gate. If gate fix rounds degrade the code, this is the rollback target.
-6. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on full implementation (artifact type: "code", iterative until clean)
+6. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on full implementation (artifact type: "code", iterative until clean) **(Non-negotiable — see Quality Gate Requirement.)**
 7. **RECOMMENDED SUB-SKILL:** Use crucible:forge (retrospective mode) — capture what happened vs what was planned
 7.5. **Chronicle signal fallback:** If forge retrospective was skipped (user declined, session ending),
    append a minimal chronicle signal directly:
@@ -866,6 +884,8 @@ At completion (before reporting to user, i.e. step 9), read the metrics log and 
 - Active work time (merge overlapping parallel intervals — NOT naive sum)
 - Wall clock time (first dispatch to final completion)
 - Quality gate rounds (per gate: design, plan, implementation)
+
+**Gate tracking verification:** Before compiling the pipeline summary (Phase 4 Step 9), verify that all three gate categories (design, plan, implementation) show round count >= 1 with clean final rounds (0 Fatal, 0 Significant). If any gate was skipped with explicit user approval, record it as `USER_SKIP` in the metrics. A zero without user approval indicates a gate was dropped — report this in the summary.
 
 ### Pipeline Decision Journal
 
@@ -972,6 +992,12 @@ When a contract YAML exists for the current ticket, the quality gate adds contra
 - Emitting a Compression State Block with stale or missing Key Decisions (decisions must be cumulative across all prior blocks)
 - Allowing the Goal field to drift across successive Compression State Blocks (must match original user request)
 - Exceeding 10 entries in the Key Decisions list without overflow-compressing the oldest
+- Skipping a REQUIRED quality gate because the task seems "small", "simple", or "trivial"
+- Self-assessing that a quality gate is unnecessary based on perceived task complexity
+- Rationalizing that quality-gate findings would be "minor" as justification to skip
+- Declaring a quality gate "done" after fixing findings without a clean verification round (fixing is not passing)
+- Short-circuiting the quality-gate iteration loop by assuming fixes are self-evidently correct
+- Interpreting general user feedback as approval to skip a quality gate that has not yet run — once a gate has run and presented findings to the user, the user's decision to proceed is authoritative. Pre-gate skip approval must be an unambiguous instruction specifically referencing the gate.
 
 ## Integration
 

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -855,7 +855,15 @@ This is NOT a failed hypothesis -- this is a wrong architecture. Discuss with yo
 
 ## Quality Gate
 
-This skill produces **hypotheses** (Phase 3.5) and **fixes** (Phase 5). When used standalone, quality gate is invoked at Phase 3.5 (on hypotheses) and Phase 5 (on fixes). When used as a sub-skill, the parent orchestrator may handle gating.
+This skill produces **hypotheses** (Phase 3.5) and **fixes** (Phase 5).
+
+**When used standalone:** Debugging is the outermost orchestrator and MUST invoke quality-gate at Phase 3.5 (on hypotheses) and Phase 5 (on fixes). These gates are non-negotiable regardless of fix size — a "one-liner" fix is not exempt.
+
+**When used as a sub-skill:** The parent orchestrator is responsible for dispatching gates (per the Invocation Convention: "Skills NEVER self-invoke quality-gate"). If you are unsure whether you are standalone or a sub-skill, invoke the gate — double-gating is preferable to no gating.
+
+**The only legitimate skip** is at Phase 5 when there is no code change (bug was already resolved). Do not extrapolate from this — it applies only to the specific "no code change" scenario, not to "small" or "trivial" changes.
+
+**Gate tracking:** Before declaring done, verify that Phase 3.5 (hypothesis gate) and Phase 5 (fix gate, unless legitimately skipped for no-code-change) each show round count >= 1 with clean final rounds. If any gate was skipped with explicit user approval, record it as `USER_SKIP`.
 
 ---
 
@@ -884,6 +892,14 @@ If you catch yourself thinking:
 - Forming hypotheses before receiving synthesis report
 - **"One more fix attempt" (when already at Cycle 3+)**
 - **Each fix reveals new problem in different place**
+
+**Quality gate violations:**
+- "This fix is too small to need a quality gate"
+- "It's just a one-liner, the gate won't find anything"
+- Skipping Phase 3.5 or Phase 5 quality gate without explicit user approval
+- Declaring a quality gate "done" after fixing findings without a clean verification round (fixing is not passing)
+- Extrapolating from the "no code change" skip to justify skipping on small changes
+- Interpreting general user feedback as approval to skip a quality gate that has not yet run
 
 **Compression State violations:**
 - Skipping Compression State Block emission at checkpoint boundaries

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -333,7 +333,7 @@ After Phase 5, the orchestrator consolidates all outputs into `scratch/<run-id>/
 
 **On approval:** Save the plan to `docs/plans/YYYY-MM-DD-<topic>-migration-plan.md`. If `--plan-only` mode: stop here, report success.
 
-**Quality gate:** Dispatch `crucible:quality-gate` on the migration plan with artifact type "plan". Iterate until clean or stagnation.
+**REQUIRED SUB-SKILL:** Use crucible:quality-gate on the migration plan with artifact type "plan". Iterate until clean or stagnation. **(Non-negotiable — see Quality Gate Requirement.)**
 
 ---
 
@@ -450,6 +450,18 @@ Escalate to the user when:
 - `./compatibility-designer-prompt.md` -- Phase 4 shim/adapter design
 - `./wave-grouper-prompt.md` -- Phase 5 consumer wave assignment
 
+## Quality Gate Requirement (Non-Negotiable)
+
+**Every quality gate in this pipeline MUST run to completion.** This is NOT optional — you may NOT self-assess whether a quality gate is "needed" based on migration step size, complexity, or perceived mechanical nature.
+
+Migration work is especially vulnerable to "this is mechanical/boilerplate" rationalization. Mechanical changes still introduce bugs — mismatched imports, forgotten call sites, subtle behavioral differences in new APIs. Quality gates catch these regardless of how "simple" the migration step appears.
+
+**Fixing findings is NOT the same as passing the gate.** The iteration loop must complete with a clean verification round (0 Fatal, 0 Significant on a fresh review).
+
+**The only valid skip** is an unambiguous user instruction specifically referencing the gate. General feedback is not skip approval.
+
+**Gate tracking:** Before compiling the migration summary, verify gate round counts by category: `plan` (Phase 5), `code-per-phase` (Phase 7, one entry per executed phase), `cleanup` (Phase 8). Each must show round count >= 1 with clean final rounds. If any gate was skipped with explicit user approval, record it as `USER_SKIP`. A zero without user approval indicates a gate was dropped — report this in the summary.
+
 ## Quality Gate Orchestration
 
 | Pipeline Stage | Artifact Type | Purpose |
@@ -457,3 +469,18 @@ Escalate to the user when:
 | After Phase 5 (plan consolidation) | plan | Verify migration plan completeness, phase boundary safety |
 | Phase 7 (per-phase, after build completes) | code | Verify phase implementation correctness |
 | Phase 8 (after cleanup) | code | Verify clean removal of compatibility layer |
+
+## Red Flags
+
+**Quality gate violations:**
+- Skipping a quality gate because the migration step is "mechanical" or "boilerplate"
+- Self-assessing that a quality gate is unnecessary based on perceived migration step simplicity
+- Declaring a quality gate "done" after fixing findings without a clean verification round (fixing is not passing)
+- Short-circuiting the quality-gate iteration loop by assuming fixes are self-evidently correct
+- Interpreting general user feedback as approval to skip a quality gate that has not yet run
+
+**Compression State violations:**
+- Skipping Compression State Block emission at checkpoint boundaries
+- Emitting a Compression State Block with stale or missing Key Decisions (decisions must be cumulative across all prior blocks)
+- Allowing the Goal field to drift across successive Compression State Blocks (must match original user request)
+- Exceeding 10 entries in the Key Decisions list without overflow-compressing the oldest

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -68,6 +68,14 @@ On consensus-eligible rounds:
 **Cost control:** The consensus dispatch replaces (not supplements) the single-model dispatch on eligible rounds.
 **Fallback:** If consensus is unavailable on an eligible round, dispatch standard single-model red-team review.
 
+## Non-Skippability
+
+**This gate cannot be bypassed without explicit user approval.** Task size, complexity, or scope is never a valid reason to skip. The invoking skill is responsible for always dispatching the gate AND letting it run to completion.
+
+**The gate is not "done" until it completes with a clean round** (0 Fatal, 0 Significant on a fresh review). Fixing findings and moving on without a verification round is a skip, not a pass. The iteration loop exists because fix agents introduce new issues or incompletely resolve old ones — fresh-eyes re-review catches what the fixer missed.
+
+**The only valid skip** is an unambiguous user instruction specifically referencing the gate (e.g., "skip the quality gate"). General feedback like "looks good" or "move on" is not skip approval. Once a gate has run and presented findings to the user, the user's decision to proceed is authoritative.
+
 ## Fix Mechanism
 
 The orchestrator coordinates the loop but does NOT fix artifacts directly. Fixes are dispatched to a **separate subagent** to maintain separation of concerns between coordination, review, and remediation.
@@ -345,7 +353,9 @@ Three exit modes beyond clean approval:
 
 - Orchestrator fixing artifacts directly instead of dispatching a fix agent
 - Rationalizing away red-team findings instead of addressing them
-- Skipping the gate without user approval
+- Skipping the gate without explicit user approval — including autonomous decisions based on task size, complexity, or scope assessment ("this is small", "this is trivial", "this is just a config change")
+- Rationalizing that a change doesn't need adversarial review based on perceived simplicity
+- Declaring the gate complete after fixing findings without a clean verification round — the iteration loop must run to completion (0 Fatal, 0 Significant on a fresh review)
 - Exceeding the 15-round safety limit without escalating
 - Using the same red-team agent across rounds (always dispatch fresh)
 - Declaring stagnation on raw issue count without using weighted score (Fatal=3, Significant=1)

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -539,6 +539,16 @@ On re-invocation of `/spec` with the same epic URL:
 3. **Skip** `committed` tickets. **Retry** `failed` and `re-queued` tickets. **Resume** `pending` tickets. **Re-process** `needs-respec` tickets with upstream contracts now available. **Unblock** `blocked` tickets: present blocking decision context and options to user, collect input, then resume.
 4. Present the resume plan to the user before proceeding.
 
+## Quality Gate Requirement (Non-Negotiable)
+
+**Every quality gate in this pipeline MUST run to completion.** This is NOT optional — you may NOT self-assess whether a quality gate is "needed" based on ticket size, complexity, or scope. Spec dispatches quality gates on every committed ticket (potentially dozens), which creates strong temptation to skip on "simple" tickets. Do not yield to this temptation.
+
+**Fixing findings is NOT the same as passing the gate.** The iteration loop must complete with a clean verification round (0 Fatal, 0 Significant on a fresh review). Spec is the highest-volume gate dispatcher — the short-circuit temptation is strongest here.
+
+**The only valid skip** is an unambiguous user instruction specifically referencing the gate. General feedback is not skip approval.
+
+**Gate tracking:** Before compiling the end-of-run summary, verify that every committed ticket has per-document gate round counts >= 1 with clean final rounds. If any gate was skipped with explicit user approval, record it as `USER_SKIP`. A zero without user approval indicates a gate was dropped — report this in the summary.
+
 ## End-of-Run Quality Gate
 
 After all waves complete and all tickets are in terminal states, run a two-phase quality gate.
@@ -547,14 +557,14 @@ After all waves complete and all tickets are in terminal states, run a two-phase
 
 For each committed ticket, dispatch two standard quality gate passes using existing artifact types:
 
-1. **Design doc gate:** Dispatch `crucible:quality-gate` with artifact type `design` on the ticket's design doc. Review scope: Are decisions well-reasoned? Are acceptance criteria testable? Is the current-state analysis accurate?
-2. **Implementation plan gate:** Dispatch `crucible:quality-gate` with artifact type `plan` on the ticket's implementation plan. Review scope: Are tasks concrete? Do they align with the design doc? Are dependencies between tasks identified?
+1. **Design doc gate:** **(Non-negotiable — see Quality Gate Requirement.)** Dispatch `crucible:quality-gate` with artifact type `design` on the ticket's design doc. Review scope: Are decisions well-reasoned? Are acceptance criteria testable? Is the current-state analysis accurate?
+2. **Implementation plan gate:** **(Non-negotiable — see Quality Gate Requirement.)** Dispatch `crucible:quality-gate` with artifact type `plan` on the ticket's implementation plan. Review scope: Are tasks concrete? Do they align with the design doc? Are dependencies between tasks identified?
 
 These use the quality gate's existing iterative fix loop. Each gate runs within normal context budgets (one document per gate invocation). Per-document gates can run in parallel across tickets (via Agent Teams, or sequentially via Agent tool fallback).
 
 ### Phase 2: Cross-Ticket Integration Check
 
-After all per-document gates pass, run a lightweight integration check across ticket boundaries using the prompt template `spec/integration-check-prompt.md`. This is NOT dispatched through `crucible:quality-gate`'s iterative loop -- it is a focused consistency review with a targeted remediation path.
+After all per-document gates pass, run a mandatory integration check across ticket boundaries using the prompt template `spec/integration-check-prompt.md`. **(Non-negotiable — see Quality Gate Requirement.)** This check is mandatory but is NOT dispatched through `crucible:quality-gate`'s iterative loop — it is a focused consistency review with targeted remediation.
 
 **Input (kept small for context budget):**
 - All contract YAML files (500-1000 tokens each)
@@ -729,6 +739,11 @@ When `/spec` resolves an ambiguity or defines an API surface on ticket N that af
 - Emitting a Compression State Block with stale or missing Key Decisions (decisions must be cumulative across all prior blocks)
 - Allowing the Goal field to drift across successive Compression State Blocks (must match original user request)
 - Exceeding 10 entries in the Key Decisions list without overflow-compressing the oldest
+- Skipping a per-document quality gate because the ticket seems "small", "simple", or "trivial"
+- Self-assessing that a quality gate is unnecessary based on perceived ticket complexity
+- Declaring a quality gate "done" after fixing findings without a clean verification round (fixing is not passing)
+- Skipping the integration check because "all per-document gates passed so it's fine"
+- Interpreting general user feedback as approval to skip a quality gate that has not yet run — once a gate has run and presented findings to the user, the user's decision to proceed is authoritative
 
 ## Integration
 


### PR DESCRIPTION
## Summary

Closes #109

- Adds "Non-Negotiable Quality Gate Requirement" sections to **build**, **spec**, and **migrate** skill definitions (matching the proven Communication Requirement pattern)
- Adds "Non-Skippability" section to **quality-gate** itself
- Hardens **debugging** with standalone/sub-skill delegation clarity and double-gating safety net
- Upgrades red flags across all 5 orchestrators with anti-skip, anti-short-circuit, and anti-vague-feedback-approval patterns
- Adds lightweight gate-tracking verification notes to pipeline metrics

Addresses two distinct failure modes:
1. **Full skip** — autonomously deciding a gate isn't needed for "small" tasks
2. **Iteration short-circuit** — fixing findings and declaring the gate "done" without a clean verification round

## Test plan

- [ ] Run `/build` on a representative task and verify all 3 gate categories appear in session metrics with round count >= 1
- [ ] Verify no existing gate behavior is weakened (all REQUIRED labels preserved)
- [ ] Verify red flags are present in all 5 skill files
- [ ] Check that debugging's no-code-change skip is explicitly bounded as the ONLY legitimate skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)