### PR TITLE
fix: add exploitability tags, reject self-acknowledged findings, elevate chains

### DIFF
--- a/skills/siege/SKILL.md
+++ b/skills/siege/SKILL.md
@@ -272,13 +272,20 @@ Orchestrator reads all 6 findings files from `scratch/<run-id>/`. Steel-man-then
 
    **Step 4 — Write dedup summary:** Write `scratch/<run-id>/dedup-summary.md` with: raw finding count, exact-dedup merges, fuzzy-dedup clusters, final deduplicated count. This is the set that enters steel-man-then-kill.
 1b. **Design-phase cross-reference:** If this Siege run targets code that had a prior design-phase red-team or Siege run on the design doc, check the threat model's Historical Findings for matches. Tag findings that were already flagged at design time: "Previously flagged in design review — implementation did not address." This helps triage: design-flagged findings that persist into code are higher priority than net-new findings.
-2. **Chain detection:** After dedup, scan for findings from different agents that touch the same data flow path or trust boundary. Flag as a chain ONLY when the orchestrator can articulate the specific multi-step exploitation scenario. Proximity alone is not chaining.
+2. **Chain detection:** After dedup, scan for findings from different agents that touch the same data flow path or trust boundary. Flag as a chain ONLY when the orchestrator can articulate the specific multi-step exploitation scenario. Proximity alone is not chaining. Assign exploitability to each chain using weakest-link inheritance: if any step is Hardening, the chain is Hardening. A chain is Active only when every step is independently exploitable today.
 3. **Severity classification** (no demotion without proof):
    - **Critical:** Exploitable with no authentication, or leads to full system compromise, or affects all users. Equivalent to CVSS 9.0+.
    - **High:** Exploitable with some prerequisites (valid session, specific input), significant data exposure or privilege escalation. CVSS 7.0-8.9.
    - **Medium:** Requires unlikely conditions or provides limited impact. CVSS 4.0-6.9.
    - **Low:** Theoretical, defense-in-depth improvement, or informational.
    - **Severity promotion bias:** When a finding sits between two severity levels, promote. Solo dev, silent security bugs are expensive. Demotion requires concrete proof that the exploitation scenario is infeasible (not merely unlikely).
+
+   **Exploitability tag (required on every finding):**
+   Every finding must be tagged with exactly one exploitability class. This is orthogonal to severity — a High/Active is urgent, a High/Hardening is important but not on fire.
+   - **Active:** Exploitable in the current codebase without hypothetical preconditions. An attacker can trigger this today.
+   - **Hardening:** Not currently exploitable, but the design has a latent weakness that becomes exploitable if a reasonable future change occurs (e.g., a new route added without the same guard, a config flag flipped). These matter — but they are a different urgency than active vulnerabilities.
+
+   The tag appears in both the 5-line initial format and the full report format. The final report groups findings by exploitability within each severity level (Active first, then Hardening).
 4. **Write initial report** to `scratch/<run-id>/report.md` using the initial lightweight finding format.
 
 ## Phase 4: Security Gate (Iterative Loop)
@@ -289,7 +296,7 @@ The security gate iterates until **zero Critical + zero High** findings remain, 
 
 Adopts quality-gate's iterative pattern with security-specific scoring.
 
-**Scoring:** Critical = 5, High = 2, Medium = 0 (medium findings are tracked but do not block the gate).
+**Scoring:** Critical = 5, High = 2, Medium = 0 (medium findings are tracked but do not block the gate). Both Active and Hardening findings contribute equally to the gate score — exploitability affects triage priority in the report, not gate blocking. A Critical/Hardening finding ("one reasonable change from full compromise") is too dangerous to pass through.
 
 **Loop:**
 1. Present findings from Phase 3 (or latest round) to the fix agent
@@ -367,7 +374,7 @@ If the fix agent or user identifies a finding as a false positive:
 ### Initial Findings (Per-Agent Output) -- 5 Lines Max
 
 ```
-**[ID]** [severity] -- [title]
+**[ID]** [severity] [Active|Hardening] -- [title]
 File: [path]:[line_range] | Agent: [agent_name]
 Attack: [1-sentence exploitation scenario]
 Evidence: [specific code reference or design element]
@@ -392,7 +399,7 @@ Critical and High findings are expanded in the Phase 3 report:
 
 ```
 ### [ID]: [title]
-**Severity:** [Critical|High] | **Agent:** [agent_name] | **Chain:** [yes/no]
+**Severity:** [Critical|High] | **Exploitability:** [Active|Hardening] | **Agent:** [agent_name] | **Chain:** [yes/no]
 **File:** [path]:[line_range]
 
 **Exploitation Scenario:**
@@ -428,20 +435,27 @@ Written to `scratch/<run-id>/report.md` and presented to the user.
 ## Scope Limitations
 [What Siege cannot detect -- see Known Limitations. Always present.]
 
+## Attack Chains
+[Multi-step chains identified by Chain Analyst, with full exploitation narrative. Chains are the highest-signal output — present them first so the reviewer sees composed threats before individual findings.
+Chains inherit exploitability from their weakest link: if ANY step in the chain requires a future change to become exploitable, the entire chain is Hardening. A chain is Active only when every step is independently exploitable today.]
+
 ## Critical Findings
+### Active Vulnerabilities
+[Full report format for each, or "None"]
+### Hardening
 [Full report format for each, or "None"]
 
 ## High Findings
+### Active Vulnerabilities
+[Full report format for each, or "None"]
+### Hardening
 [Full report format for each, or "None"]
 
 ## Medium Findings
-[Initial 5-line format for each, or "None"]
+[Initial 5-line format for each, or "None". Medium and Low use the compact 5-line format which includes the exploitability tag per-finding. No Active/Hardening sub-grouping — these severities do not block the gate, so triage ordering is less critical.]
 
 ## Low Findings
 [Initial 5-line format for each, or "None"]
-
-## Attack Chains
-[Multi-step chains identified by Chain Analyst, with full exploitation narrative]
 
 ## Accepted Risks
 [Any findings the user acknowledged with rationale, or "None"]
@@ -476,10 +490,10 @@ Updated at the end of every Siege run (Phase 5). Accumulates across sessions.
 
 ## Historical Findings
 ### [date] -- [target]
-- [finding ID]: [severity] [title] -- [status: resolved|accepted|open]
+- [finding ID]: [severity] [Active|Hardening] [title] -- [status: resolved|accepted|open]
 
 ## Accepted Risks
-- [finding ID]: [severity] [title] -- Accepted [date] by [user]
+- [finding ID]: [severity] [Active|Hardening] [title] -- Accepted [date] by [user]
   Rationale: [user-provided rationale]
   Next review: [date, set by sentinel schedule]
 ```
@@ -718,8 +732,9 @@ Siege effectiveness is measured by:
 **Agents must NOT:**
 - Modify any code during Phase 2 (analysis is read-only; fixes happen in Phase 4 only)
 - Flag findings without specific evidence (no "consider adding input validation" without pointing to the exact unvalidated input)
-- Exceed 5 findings per agent (focus on highest-impact; the Chain Analyst cap is 5 chains). Every finding must have a concrete, demonstrable exploitation scenario in the CURRENT codebase. Speculative findings about hypothetical future code are not findings.
+- Exceed 5 findings per agent (focus on highest-impact; the Chain Analyst cap is 5 chains). Every **Active** finding must have a concrete, demonstrable exploitation scenario in the CURRENT codebase. **Hardening** findings must name a specific, reasonable future change that would make the weakness exploitable — not hypothetical future code in general, but a concrete change (e.g., "adding a public route that calls this unguarded helper"). Speculative findings that cannot identify either a current exploit or a named future-change trigger are not findings.
 - Speculate about vulnerabilities in code they did not receive in their Tier 2 partition
+- File findings where no concrete exploitation scenario (Active or Hardening) can be constructed. If unsure, the agent should either commit to the finding (with evidence of a current exploit or a named future-change trigger) or not file it.
 
 **The orchestrator must NOT:**
 - Proceed to Phase 2 without user-confirmed manifest
@@ -734,8 +749,10 @@ Siege effectiveness is measured by:
 
 ## Red Flags
 
-- Running Siege as a "light scan" (there is no light mode -- if activated, it runs fully)
+- Running Siege below the scope-appropriate agent count (3/4/6 -- match the scope, not convenience)
 - Treating Siege findings as audit findings (security findings require exploitation scenarios, not just code quality observations)
+- Mixing active vulnerabilities and design hardening without the exploitability tag (different urgency, different reviewer response)
+- Filing findings where no exploitation scenario (Active or Hardening) can be constructed (wastes reviewer time)
 - Skipping the Chain Analyst (the most valuable agent for finding real-world exploits)
 - Accepting risks without written rationale (silent suppression)
 - Committing `threat-model.md` or `accepted-risks.md` to the repository

--- a/skills/siege/siege-betrayed-consumer-prompt.md
+++ b/skills/siege/siege-betrayed-consumer-prompt.md
@@ -66,9 +66,11 @@ Task tool (general-purpose, model: opus):
        stdout, which is captured by CloudWatch, which is readable by all
        developers with AWS access."
 
-    4. **Cap at 5 findings.** Every finding must trace a concrete data path
-       in the current code. "This could leak data if someone adds logging
-       later" is not a finding.
+    4. **Cap at 5 findings.** Every **Active** finding must trace a concrete
+       data path in the current code. **Hardening** findings must name a
+       specific, reasonable future change that would make the weakness
+       exploitable. "This could leak data if someone adds logging later"
+       is not a finding unless you name the specific logging change and path.
 
     ## What You Must NOT Do
 
@@ -76,6 +78,7 @@ Task tool (general-purpose, model: opus):
     - Do NOT flag injection or access control issues
     - Do NOT speculate without code evidence
     - Do NOT flag missing features (only flag broken trust contracts)
+    - Do NOT file findings where no concrete exploitation scenario (Active or Hardening) can be constructed
 
     ## Context Self-Monitoring
 
@@ -83,8 +86,12 @@ Task tool (general-purpose, model: opus):
 
     ## Output Format
 
+    **Exploitability tags:**
+    - **Active:** Exploitable in the current codebase today, no hypothetical preconditions.
+    - **Hardening:** Not currently exploitable, but becomes exploitable if a specific, reasonable future change occurs. You MUST name that change.
+
     <!-- dedup: file=[path] line=[start-end] cwe=[CWE-ID] agent=betrayed-consumer -->
-    **[SIEGE-BC-N]** [severity] -- [title]
+    **[SIEGE-BC-N]** [severity] [Active|Hardening] -- [title]
     File: [path]:[line_range] | Agent: Betrayed Consumer
     Attack: [what data is exposed, to whom, through what path]
     Evidence: [specific code -- the log statement, the unfiltered response, the plaintext storage]

--- a/skills/siege/siege-boundary-attacker-prompt.md
+++ b/skills/siege/siege-boundary-attacker-prompt.md
@@ -76,10 +76,12 @@ Task tool (general-purpose, model: opus):
        - **Medium** -- Requires unlikely conditions or limited impact
        - **Low** -- Theoretical, defense-in-depth improvement
 
-    5. **Cap at 5 findings.** Focus on highest impact. Every finding must
-       have a concrete, demonstrable exploitation scenario in the CURRENT
-       codebase. Speculative findings about hypothetical future endpoints
-       or unwritten code are not findings.
+    5. **Cap at 5 findings.** Focus on highest impact. Every **Active**
+       finding must have a concrete, demonstrable exploitation scenario
+       in the CURRENT codebase. **Hardening** findings must name a
+       specific, reasonable future change that would make it exploitable.
+       Speculative findings about hypothetical future endpoints or
+       unwritten code without a named trigger are not findings.
 
     ## What You Must NOT Do
 
@@ -87,6 +89,7 @@ Task tool (general-purpose, model: opus):
     - Do NOT flag auth/access control issues (Insider Threat handles that)
     - Do NOT flag configuration issues (Infrastructure Prober handles that)
     - Do NOT speculate -- every finding must have code evidence
+    - Do NOT file findings where no concrete exploitation scenario (Active or Hardening) can be constructed
     - Do NOT produce extended analysis or blast radius (that's Phase 3)
 
     ## Context Self-Monitoring
@@ -98,10 +101,14 @@ Task tool (general-purpose, model: opus):
 
     ## Output Format
 
+    **Exploitability tags:**
+    - **Active:** Exploitable in the current codebase today, no hypothetical preconditions.
+    - **Hardening:** Not currently exploitable, but becomes exploitable if a specific, reasonable future change occurs. You MUST name that change.
+
     Use this EXACT format for each finding (5 lines + dedup metadata):
 
     <!-- dedup: file=[path] line=[start-end] cwe=[CWE-ID] agent=boundary-attacker -->
-    **[SIEGE-BA-N]** [severity] -- [title]
+    **[SIEGE-BA-N]** [severity] [Active|Hardening] -- [title]
     File: [path]:[line_range] | Agent: Boundary Attacker
     Attack: [1-sentence exploitation scenario with specific payload]
     Evidence: [specific code reference -- quote the vulnerable line]

--- a/skills/siege/siege-chain-analyst-prompt.md
+++ b/skills/siege/siege-chain-analyst-prompt.md
@@ -115,7 +115,11 @@ Task tool (general-purpose, model: opus):
 
     ## Output Format
 
-    **[SIEGE-CA-N]** [severity] -- [chain title]
+    **Exploitability tags:**
+    - **Active:** Every step in the chain is exploitable in the current codebase today.
+    - **Hardening:** Any step in the chain requires a future change to become exploitable. Chains inherit exploitability from their weakest link -- if any step is Hardening, the chain is Hardening. You MUST name the specific future change.
+
+    **[SIEGE-CA-N]** [severity] [Active|Hardening] -- [chain title]
     File: [path1]:[line] → [path2]:[line] → [path3]:[line] | Agent: Chain Analyst
     Attack: [multi-step exploitation narrative: step 1 → step 2 → impact]
     Evidence: [code at each step in the chain]

--- a/skills/siege/siege-fresh-attacker-prompt.md
+++ b/skills/siege/siege-fresh-attacker-prompt.md
@@ -57,8 +57,10 @@ Task tool (general-purpose, model: opus):
        attack, the finding is informational, not a vulnerability.
 
     4. **Cap at 5 findings.** Quality over quantity. One well-evidenced
-       finding is worth more than five hunches. Every finding must be
-       demonstrable in the current codebase.
+       finding is worth more than five hunches. Every **Active** finding
+       must be demonstrable in the current codebase. **Hardening** findings
+       must name a specific, reasonable future change that would make the
+       weakness exploitable.
 
     ## What You Must NOT Do
 
@@ -66,6 +68,7 @@ Task tool (general-purpose, model: opus):
       the other agents do)
     - Do NOT suggest fixes
     - Do NOT speculate without code evidence
+    - Do NOT file findings where no concrete exploitation scenario (Active or Hardening) can be constructed
     - Do NOT say "this could potentially be vulnerable" — either show the
       attack or mark it Low
 
@@ -75,8 +78,12 @@ Task tool (general-purpose, model: opus):
 
     ## Output Format
 
+    **Exploitability tags:**
+    - **Active:** Exploitable in the current codebase today, no hypothetical preconditions.
+    - **Hardening:** Not currently exploitable, but becomes exploitable if a specific, reasonable future change occurs. You MUST name that change.
+
     <!-- dedup: file=[path] line=[start-end] cwe=[CWE-ID] agent=fresh-attacker -->
-    **[SIEGE-FA-N]** [severity] -- [title]
+    **[SIEGE-FA-N]** [severity] [Active|Hardening] -- [title]
     File: [path]:[line_range] | Agent: Fresh Attacker
     Attack: [what you'd do with this, concretely]
     Evidence: [the code that caught your eye and why]

--- a/skills/siege/siege-infrastructure-prober-prompt.md
+++ b/skills/siege/siege-infrastructure-prober-prompt.md
@@ -76,15 +76,19 @@ Task tool (general-purpose, model: opus):
        path actually reachable in this codebase? CISA KEV matches are
        automatic Critical — these are actively exploited in the wild.
 
-    5. **Cap at 5 findings.** Every finding must have concrete evidence in
-       the current codebase. A dependency CVE counts if the vulnerable code
-       path is reachable. A CISA KEV match is always a finding regardless.
+    5. **Cap at 5 findings.** Every **Active** finding must have concrete
+       evidence of exploitability in the current codebase. **Hardening**
+       findings must name a specific, reasonable future change that would
+       make the weakness exploitable. A dependency CVE counts if the
+       vulnerable code path is reachable. A CISA KEV match is always a
+       finding regardless.
 
     ## What You Must NOT Do
 
     - Do NOT suggest fixes
     - Do NOT flag injection or access control issues
     - Do NOT speculate without evidence
+    - Do NOT file findings where no concrete exploitation scenario (Active or Hardening) can be constructed
     - Do NOT downgrade CISA KEV matches — actively exploited = Critical
 
     ## Context Self-Monitoring
@@ -93,8 +97,12 @@ Task tool (general-purpose, model: opus):
 
     ## Output Format
 
+    **Exploitability tags:**
+    - **Active:** Exploitable in the current codebase today, no hypothetical preconditions.
+    - **Hardening:** Not currently exploitable, but becomes exploitable if a specific, reasonable future change occurs. You MUST name that change.
+
     <!-- dedup: file=[path] line=[start-end] cwe=[CWE-ID] agent=infrastructure-prober -->
-    **[SIEGE-IP-N]** [severity] -- [title]
+    **[SIEGE-IP-N]** [severity] [Active|Hardening] -- [title]
     File: [path]:[line_range] | Agent: Infrastructure Prober
     Attack: [what an attacker gains from this misconfiguration]
     Evidence: [specific code or config reference]

--- a/skills/siege/siege-insider-threat-prompt.md
+++ b/skills/siege/siege-insider-threat-prompt.md
@@ -66,9 +66,12 @@ Task tool (general-purpose, model: opus):
     4. **Construct concrete attacks.** "As user with role X, send request Y
        to endpoint Z, gain access to W."
 
-    5. **Cap at 5 findings.** Every finding must have a concrete exploitation
-       scenario in the CURRENT codebase. "This endpoint could be vulnerable
-       if a future endpoint reuses this pattern" is not a finding.
+    5. **Cap at 5 findings.** Every **Active** finding must have a concrete
+       exploitation scenario in the CURRENT codebase. **Hardening** findings
+       must name a specific, reasonable future change that would make it
+       exploitable. "This endpoint could be vulnerable if a future endpoint
+       reuses this pattern" is not a finding unless you name the specific
+       pattern and trigger.
 
     ## What You Must NOT Do
 
@@ -76,6 +79,7 @@ Task tool (general-purpose, model: opus):
     - Do NOT flag injection vulnerabilities (Boundary Attacker handles that)
     - Do NOT flag configuration issues (Infrastructure Prober handles that)
     - Do NOT speculate without code evidence
+    - Do NOT file findings where no concrete exploitation scenario (Active or Hardening) can be constructed
 
     ## Context Self-Monitoring
 
@@ -84,8 +88,12 @@ Task tool (general-purpose, model: opus):
 
     ## Output Format
 
+    **Exploitability tags:**
+    - **Active:** Exploitable in the current codebase today, no hypothetical preconditions.
+    - **Hardening:** Not currently exploitable, but becomes exploitable if a specific, reasonable future change occurs. You MUST name that change.
+
     <!-- dedup: file=[path] line=[start-end] cwe=[CWE-ID] agent=insider-threat -->
-    **[SIEGE-IT-N]** [severity] -- [title]
+    **[SIEGE-IT-N]** [severity] [Active|Hardening] -- [title]
     File: [path]:[line_range] | Agent: Insider Threat
     Attack: [as user with role X, do Y to gain Z]
     Evidence: [specific code -- the missing check or bypassable check]

--- a/skills/siege/siege-stagnation-judge-prompt.md
+++ b/skills/siege/siege-stagnation-judge-prompt.md
@@ -28,6 +28,11 @@ Task tool (general-purpose, model: sonnet):
     - A fix that closes one vulnerability but creates a different one in
       a different security domain IS progress if the new vulnerability
       is genuinely unrelated.
+    - **Exploitability transitions matter.** A finding that changes from
+      Active (exploitable today) to Hardening (requires a future change)
+      at the same severity is progress — the active exploitation path was
+      closed. A finding that changes from Hardening to Active at the same
+      severity is regression — a latent risk became live.
 
     ## Round N-1 Findings
 
@@ -58,6 +63,17 @@ Task tool (general-purpose, model: sonnet):
 
     ### Step 2: Semantic Comparison
     Classify each Round N finding as Recurring or New.
+
+    ### Step 2b: Exploitability Transition Check
+    For findings classified as Recurring, check whether the exploitability
+    tag changed between rounds:
+    - **Active → Hardening** at same severity: reclassify as **Progressed**
+      (the active exploitation path was closed). Count as New for Step 3
+      decision rules.
+    - **Hardening → Active** at same severity: reclassify as **Regressed**.
+      Count as Recurring AND force STAGNATION if any Regressed findings
+      exist (a latent risk became live — the fix made things worse).
+    - **No exploitability change:** keep original Recurring/New classification.
 
     ### Step 3: Apply Decision Rules
 
@@ -90,6 +106,8 @@ Task tool (general-purpose, model: sonnet):
     ### Classification
     - **Recurring findings:** [list or "None"]
     - **New findings:** [list or "None"]
+    - **Progressed findings (Active→Hardening):** [list or "None"]
+    - **Regressed findings (Hardening→Active):** [list or "None" — any Regressed finding forces STAGNATION]
     - **Difficulty classes (if all new):** [Surface/Structural per finding]
     - **Consecutive structural rounds:** [0 | 1 | 2]
 


### PR DESCRIPTION
## Summary
- Adds `Active` / `Hardening` exploitability tag to all finding formats (5-line initial + full report) and all 6 agent prompt templates — distinguishes "exploitable today" from "latent design weakness"
- Adds guardrail against self-acknowledged acceptable findings in SKILL.md + all agent prompts — if an agent's own write-up says "this is expected behavior," it must not file the finding
- Moves Attack Chains to top of report (before individual findings) — chains are the highest-signal output and what differentiates siege from a regular code review
- Report now groups findings by exploitability within each severity level (Active first, then Hardening)

Closes #115

## Test plan
- [ ] Run `/siege` and verify all findings include `[Active|Hardening]` tag
- [ ] Verify no findings contain self-contradictory "this is acceptable" language
- [ ] Verify report shows Attack Chains before Critical/High sections
- [ ] Verify Critical and High sections are split into Active/Hardening subsections

🤖 Generated with [Claude Code](https://claude.com/claude-code)