### PR TITLE
feat: add /recon skill for standalone codebase investigation

### DIFF
--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -1,0 +1,519 @@
+---
+name: recon
+description: "Standalone codebase investigation. Produces a layered Investigation Brief with core findings (structure, patterns, scope, prior art) plus optional depth modules. Dispatches parallel scouts, synthesizes findings, and feeds cartographer. Use before any task requiring codebase understanding."
+---
+
+# Recon
+
+## Overview
+
+Structured, parallel codebase investigation with a layered output model. Produces a core Investigation Brief that all consumers share, plus optional depth modules for consumer-specific needs.
+
+**Skill type:** Rigid — follow exactly, no shortcuts.
+
+**Models:**
+- Core scouts: Sonnet (via Explore agents)
+- Judgment depth agents (impact-analysis, friction-scan, diagnostic-context): Opus
+- Mechanical depth agents (consumer-registry, subsystem-manifest, execution-readiness): Sonnet
+- Orchestrator: runs on whatever model the session uses
+
+**Announce at start:** "Running recon [with task: X / full repo scan] [scope: Y / full repo]."
+
+## Invocation API
+
+```
+/recon
+  task: "Add REST endpoint for user profiles"       # optional — omit for full repo scan
+  context: { decisions: [...], constraints: [...] }   # optional — structured prior decisions
+  session_id: "design-20260404-abc123"                # optional — enables cross-invocation caching
+  modules: ["impact-analysis", "execution-readiness"] # optional — depth modules to produce
+  scope: "src/api/"                                   # optional — directory constraint
+```
+
+### Parameters
+
+**`task`** (optional)
+Free-text description of the task being investigated. Scouts focus exploration on task-relevant areas. Omit for a full repository scan.
+
+**`context`** (optional)
+Structured prior decisions from a parent skill (e.g., accumulated design choices from `/design`'s dimension loop). Passed to scouts alongside the task. Scouts consider these decisions during investigation — avoiding areas already decided, focusing on interfaces affected by prior choices.
+
+- **Input budget:** 4,000 tokens default. Parent skills should compact decisions before passing — each decision as a key-value pair with one-sentence rationale plus affected interfaces.
+- **Exceeding budget:** Orchestrator warns but does not reject. Caller proceeds at the cost of reduced scout context budget.
+- **Total scout input:** task + context + cartographer should stay under 8,000 tokens for effective exploration.
+
+Distinct from `task:` which describes *what* to investigate; `context:` describes *what's already been decided*.
+
+**`session_id`** (optional)
+Enables cross-invocation caching within a session. When provided, the Structure Scout report is cached and reused on subsequent invocations with the same session_id. Pattern Scout always runs fresh (its output varies with cascading context). Parent skills generate the session_id (e.g., `/design` uses its run timestamp). Without a session_id, no caching occurs.
+
+**`modules`** (optional)
+List of depth modules to produce after core synthesis. Valid values:
+
+| Module | Agent | Model | Primary Consumer |
+|---|---|---|---|
+| `impact-analysis` | Impact Analyst | Opus | `/design`, `/build` |
+| `consumer-registry` | Consumer Mapper | Sonnet | `/migrate` |
+| `friction-scan` | Friction Scanner | Opus | `/prospector` |
+| `subsystem-manifest` | Manifest Builder | Sonnet | `/audit` |
+| `diagnostic-context` | Diagnostic Gatherer | Opus | `/debugging` |
+| `execution-readiness` | Readiness Checker | Sonnet | `/build` |
+
+Most invocations request 0-1 depth modules. Omit for core-only output (cheapest).
+
+**`scope`** (optional)
+Directory constraint. When provided, overrides scout scope suggestions entirely — scouts constrain exploration to the given path(s). Cheaper, faster.
+
+### Behavior Matrix
+
+| Configuration | Behavior |
+|---|---|
+| With task | Scouts focus on task-relevant areas |
+| With context | Prior decisions passed to scouts alongside task |
+| Without task | Full repo recon for audit/project-init cold starts |
+| With scope | Explicit scope overrides scout suggestions |
+| With modules | Depth agents dispatched after core synthesis |
+| No modules | Core layer only — cheapest possible recon |
+| With session_id | Structure Scout cached, Pattern Scout always fresh |
+
+### Cost Profile
+
+| Configuration | Agents | Models | Relative Cost |
+|---|---|---|---|
+| Core only | 2 | 2x Sonnet | Low |
+| Core + 1 mechanical module | 3 | 3x Sonnet | Low |
+| Core + 1 judgment module | 3 | 2x Sonnet + 1x Opus | Medium |
+| Core + 2 modules (mixed) | 4 | 2-3x Sonnet + 1-2x Opus | Medium-High |
+| Full repo, no task | 2 | 2x Sonnet | Low (but slower) |
+
+## Communication Requirements (Non-Negotiable)
+
+Recon narrates its progress at these points — **every one is mandatory**:
+
+1. **Before dispatching scouts** — "Dispatching Structure Scout and Pattern Scout [with cartographer context / cold start]."
+2. **After scout completion, before synthesis** — "Scouts complete. Synthesizing core brief. [N conflicts detected.]"
+3. **After depth module completion, before returning** — "Depth module [name] complete. Returning Investigation Brief."
+4. **On overflow re-run** — "Scout [name] exceeded token budget. Re-running with narrowed scope: [new scope]."
+5. **On cartographer conflict** — "Cartographer conflict detected: [brief description]. Flagged as [auto-updated / unresolved]."
+6. **On depth module failure** — "Depth module [name] failed: [timeout / error]. Core brief delivered without this module."
+
+### Direct vs. Sub-Skill Invocation
+
+**When invoked directly** (user calls `/recon`): narration is output to the user in real time.
+
+**When invoked as sub-skill** (called by `/design`, `/build`, etc.): narration lines are included at the top of the returned Investigation Brief under a `## Recon Progress` section. The parent skill can relay these to the user or discard them.
+
+### Pipeline Status
+
+At each narration point, write `pipeline-status.md` to the scratch directory with:
+
+```markdown
+# Pipeline Status
+**Phase:** dispatching | synthesizing | depth-modules | complete
+**Progress:** [free-text description]
+**Timestamp:** [ISO-8601]
+
+## Scouts
+- Structure Scout: [pending | running | complete | failed | cached]
+- Pattern Scout: [pending | running | complete | failed]
+
+## Depth Modules
+<!-- Only present if modules requested -->
+- [module-name]: [pending | running | complete | failed]
+
+## Cartographer
+- Consult: [consulted | cold start | N/A]
+- Record: [pending | dispatched | complete | skipped]
+```
+
+## Phase 1: Cartographer Consult
+
+Before dispatching scouts, check for existing cartographer data.
+
+1. Read `map.md` from cartographer storage directory (direct file read via Read tool — no agent dispatch)
+   - Storage path: `~/.claude/projects/<project-hash>/memory/cartographer/map.md`
+2. **If map exists:** Extract relevant module context for scouts. Pass module files, conventions, and landmines as the `[CARTOGRAPHER]` placeholder content.
+3. **If cold start (no map):** Set `[CARTOGRAPHER]` to "No cartographer data — explore from scratch." Proceed normally.
+4. **Provenance tracking:** Instruct scouts to annotate findings sourced from cartographer with `(cartographer)` in their output. Freshly discovered findings are unmarked. This lets consumers distinguish verified-from-memory vs. discovered-now.
+
+## Phase 2: Scout Dispatch
+
+### Session Cache Check
+
+If `session_id` is provided:
+1. Check for cached Structure Scout report at: `~/.claude/projects/<project-hash>/memory/recon/sessions/<session_id>/structure-scout.md`
+2. **If cached report exists:** Skip Structure Scout dispatch. Use cached report. Mark Structure Scout as `cached` in pipeline status.
+3. **If no cache:** Dispatch normally. After completion, write report to cache path.
+
+Pattern Scout always runs fresh — its output varies with cascading context.
+
+### Dispatch
+
+Dispatch both scouts in parallel (or just Pattern Scout if Structure Scout is cached):
+
+**Structure Scout:**
+```
+Agent tool (subagent_type: Explore, model: sonnet):
+  description: "Structure Scout: map project layout for [task summary]"
+```
+- Template: `./structure-scout-prompt.md`
+- Fill placeholders: `[TASK]`, `[SCOPE]`, `[CONTEXT]`, `[CARTOGRAPHER]`
+
+**Pattern Scout:**
+```
+Agent tool (subagent_type: Explore, model: sonnet):
+  description: "Pattern Scout: discover conventions and prior art for [task summary]"
+```
+- Template: `./pattern-scout-prompt.md`
+- Fill placeholders: `[TASK]`, `[SCOPE]`, `[CONTEXT]`, `[CARTOGRAPHER]`
+
+On completion, write raw scout reports to scratch directory:
+- `<scratch>/structure-scout-report.md`
+- `<scratch>/pattern-scout-report.md`
+
+Narrate: "Scouts complete. Synthesizing core brief. [N conflicts detected.]"
+
+## Phase 3: Core Synthesis (Orchestrator-Local)
+
+**No synthesis subagent.** The orchestrator reads both scout reports and assembles the Investigation Brief directly.
+
+### Scope Merging
+
+**If caller provided explicit `scope:` parameter:** Use it directly. Skip scout suggestions entirely.
+
+**Otherwise, merge scout suggestions:**
+
+1. **In Scope:** Union of both scouts' `suggested_scope.in_scope` paths.
+   - Paths suggested by **both** scouts: marked `high confidence`
+   - Paths suggested by **only one** scout: marked `medium confidence` with attribution (e.g., "suggested by Structure Scout")
+
+2. **Contested paths:** When one scout includes a path and the other excludes it:
+   - Place under `### Contested` in Scope Boundaries (not excluded)
+   - Include reasoning from each scout
+   - **Consumer guidance:** Contested paths should be treated as in-scope unless the consumer has a specific reason to exclude them. The annotation signals lower confidence, not a decision for the consumer to make.
+
+3. **Out of Scope:** Uncontested exclusions — both scouts agree to exclude, or only one scout mentions exclusion and the other is silent.
+
+### Contradiction Detection
+
+Cross-check the two scout reports for conflicting evidence. Examples:
+- Structure Scout maps a directory as inactive but Pattern Scout finds live test references to it
+- Scouts disagree on module boundaries or build system identification
+- One scout identifies a file as an entry point, the other doesn't mention it despite covering the same area
+
+Surface contradictions in `## Conflicts` section with:
+- The tension described
+- Evidence from Structure Scout (claim + evidence)
+- Evidence from Pattern Scout (claim + evidence)
+- Confidence assessment (which is stronger and why, or "unresolved")
+
+Conflicts are high-value cartographer feed-back material.
+
+### Cartographer Conflict Resolution
+
+When scouts report `cartographer-conflict` findings, apply this adjudication table:
+
+| Condition | Both scouts agree? | Evidence type | Action |
+|---|---|---|---|
+| Path no longer exists + both agree | Yes | Negative (absence) | **Auto-update** — path evidence is verifiable |
+| Positive assertion + both agree | Yes | Positive (file exists, pattern found) | **Auto-update** — new finding is grounded |
+| Both agree, no supporting evidence | Yes | Neither | **Unresolved** — agreement alone insufficient (correlated input priors) |
+| Deletion from cartographer | Yes or No | Any | **Always unresolved** — requires user confirmation |
+| Single scout only | No | Any | **Unresolved** — prevents single-scout hallucination |
+
+**Why agreement alone is insufficient:** Both scouts receive the same cartographer context and task description as input. Their exploration is correlated, not independent. Two correlated errors do not constitute independent verification. Auto-update requires agreement PLUS verifiable evidence.
+
+For auto-update actions: queue the update for Phase 5 (Cartographer Feedback).
+For unresolved actions: surface in the `## Conflicts` section of the brief.
+
+### Assemble the Investigation Brief
+
+Build the Investigation Brief markdown with all core sections:
+
+```markdown
+# Investigation Brief
+**Brief version:** 1
+**Task:** [task description or "Full repository scan"]
+**Scope:** [constrained path or "Full repo"]
+**Depth modules:** [list or "Core only"]
+**Cartographer state:** [consulted / cold start / N/A]
+**Commit:** [HEAD SHA at investigation time]
+
+## Project Structure
+[From Structure Scout report — module layout, entry points, build system, key directories]
+
+## Existing Patterns
+[From Pattern Scout report — conventions, naming, test patterns, abstractions]
+
+## Scope Boundaries
+### In Scope
+- [path/area] — [why] — [confidence: high/medium]
+### Out of Scope
+- [path/area] — [why excluded]
+### Contested
+<!-- Only present if scope conflict between scouts -->
+- [path/area] — [scout reasoning from each side]
+
+## Prior Art
+[From Pattern Scout report]
+- **[Description]** — [file paths] — [relevance to current task]
+
+## Conflicts
+<!-- Only present if contradictions detected between scouts -->
+- **[Tension]** — Structure Scout: [claim + evidence]. Pattern Scout: [claim + evidence]. Confidence: [assessment].
+```
+
+## Overflow Handling
+
+### Scout Report Overflow
+
+If a scout report exceeds its token budget (2,000 tokens for scoped, 4,000 for full-repo):
+
+1. **Task-aware truncation:** Sections relevant to the current task retain full content (including reasoning prose needed for contradiction detection). Out-of-scope sections are reduced to headings + first-level bullets.
+2. **If still over budget:** Request a scoped re-run from the scout with a narrower scope constraint.
+   - Narrate: "Scout [name] exceeded token budget. Re-running with narrowed scope: [new scope]."
+   - The re-run replaces the original report (not appended).
+3. **Flag truncated sections** with `(truncated)` so consumers can request full detail.
+
+### Depth Module Overflow
+
+Same policy applies to depth module outputs (3,000 token budget, 2,000 for readiness-checker):
+1. Task-aware truncation first
+2. Scoped re-run if still over
+3. Flag truncated sections
+
+## Phase 4: Depth Module Dispatch
+
+Only if `modules:` parameter is non-empty. Dispatch **after** core synthesis completes — depth agents receive core findings as input context.
+
+### Dispatch
+
+When multiple modules are requested, dispatch them in parallel. Each depth agent receives the assembled core Investigation Brief via the `[CORE_BRIEF]` placeholder.
+
+| Module | Agent | Dispatch | Template |
+|---|---|---|---|
+| `impact-analysis` | Impact Analyst | `Task tool (general-purpose, model: opus)` | `./impact-analyst-prompt.md` |
+| `consumer-registry` | Consumer Mapper | `Agent tool (subagent_type: general-purpose, model: sonnet)` | `./consumer-mapper-prompt.md` |
+| `friction-scan` | Friction Scanner | `Agent tool (subagent_type: general-purpose, model: opus)` | `./friction-scanner-prompt.md` |
+| `subsystem-manifest` | Manifest Builder | `Task tool (general-purpose, model: sonnet)` | `./manifest-builder-prompt.md` |
+| `diagnostic-context` | Diagnostic Gatherer | `Agent tool (subagent_type: general-purpose, model: opus)` | `./diagnostic-gatherer-prompt.md` |
+| `execution-readiness` | Readiness Checker | `Task tool (general-purpose, model: sonnet)` | `./readiness-checker-prompt.md` |
+
+### Placeholder Filling
+
+- `[CORE_BRIEF]` — the assembled core Investigation Brief (all core sections)
+- `[TASK]` — the original task description
+- `[SCOPE]` — scope constraint (if provided)
+- `[TARGET]` — for `consumer-registry` only: the migration target symbol/module. Extract from `context.target` if provided; fall back to the full `task:` string if absent.
+
+### Output Handling
+
+- Write each depth module output to scratch as individual files (e.g., `<scratch>/impact-analysis.md`)
+- Append completed depth module sections to the Investigation Brief after the core sections, separated by `---`
+- Narrate after each: "Depth module [name] complete. Returning Investigation Brief."
+
+### Depth Module Failure
+
+On failure (timeout, error, or agent did not return useful output):
+- Deliver the core brief — it is always complete before depth modules start
+- Flag the failed module in the brief:
+  ```
+  ## [Module Name]
+  *Agent did not complete — request this module again or investigate manually.*
+  ```
+- Narrate: "Depth module [name] failed: [timeout / error]. Core brief delivered without this module."
+
+## Phase 5: Cartographer Feedback
+
+After the Investigation Brief is assembled (core + any depth modules):
+
+1. **Check for new information:** Compare scout findings against cartographer context provided in Phase 1.
+2. **If scouts discovered new information not in the map:** Dispatch cartographer recorder (Sonnet) using the existing `crucible:cartographer` skill's `recorder-prompt.md` template (at `skills/cartographer-skill/recorder-prompt.md`). Pass scout findings as input following the recorder's expected format.
+   - Include auto-update resolutions from cartographer conflict adjudication
+   - New module files, conventions, or landmines flow into cartographer storage
+3. **If nothing new:** Skip recorder dispatch.
+
+**Key constraint:** `/recon` is read-only on the codebase. Cartographer writes go to the memory directory, not the repo.
+
+## Output and Return
+
+Return the Investigation Brief as the agent output (inline return to parent skill).
+
+The brief follows the exact template from the design, including the metadata block:
+
+```markdown
+# Investigation Brief
+**Brief version:** 1
+**Task:** [task description or "Full repository scan"]
+**Scope:** [constrained path or "Full repo"]
+**Depth modules:** [list or "Core only"]
+**Cartographer state:** [consulted / cold start / N/A]
+**Commit:** [HEAD SHA at investigation time]
+
+## Project Structure
+...
+
+## Existing Patterns
+...
+
+## Scope Boundaries
+### In Scope
+...
+### Out of Scope
+...
+### Contested
+...
+
+## Prior Art
+...
+
+## Conflicts
+...
+
+---
+<!-- Depth modules below, only present if requested -->
+
+## Impact Analysis
+...
+
+## Consumer Registry
+...
+
+## Friction Scan
+...
+
+## Subsystem Manifest
+...
+
+## Diagnostic Context
+...
+
+## Execution Readiness
+**Test command:** ...
+**Lint command:** ...
+**CI checks:** ...
+**Manual verification:** ...
+```
+
+**When invoked as sub-skill:** Include `## Recon Progress` section at the top with all narration lines from the run.
+
+## Scratch Directory and Context Management
+
+### Scratch Path
+
+`~/.claude/projects/<project-hash>/memory/recon/scratch/<run-id>/`
+
+- `<run-id>` is a timestamp (e.g., `20260404-143022`)
+- Access restricted to Write/Read/Glob tools — no Bash commands against `.claude/` paths
+
+### Persisted Artifacts
+
+| File | Purpose |
+|---|---|
+| `structure-scout-report.md` | Raw Structure Scout output |
+| `pattern-scout-report.md` | Raw Pattern Scout output |
+| `impact-analysis.md` | Depth module output (if requested) |
+| `consumer-registry.md` | Depth module output (if requested) |
+| `friction-scan.md` | Depth module output (if requested) |
+| `subsystem-manifest.md` | Depth module output (if requested) |
+| `diagnostic-context.md` | Depth module output (if requested) |
+| `execution-readiness.md` | Depth module output (if requested) |
+| `investigation-brief.md` | Final assembled brief |
+| `pipeline-status.md` | Current pipeline status |
+
+### Session Caching
+
+Structure Scout reports are cached for cross-invocation reuse within a session:
+- Cache path: `~/.claude/projects/<project-hash>/memory/recon/sessions/<session_id>/structure-scout.md`
+- When `session_id` is provided, check this path before dispatching Structure Scout
+- Session cache files follow the same 24-hour stale cleanup as run directories
+
+### Stale Directory Cleanup
+
+At orchestrator startup, prune scratch directories older than 24 hours. Check directory timestamps via Glob and remove stale entries.
+
+**Do not clean scratch until the Investigation Brief is returned to the caller.** Compaction recovery depends on scratch contents being available until the full brief is delivered.
+
+## Compaction Recovery
+
+If the orchestrator hits a compaction boundary mid-run:
+
+1. **Read scratch directory listing** — determine which files exist
+2. **Determine phase:**
+   - No scout reports → still in Phase 1 or 2, restart from Phase 1
+   - Scout reports exist, no `investigation-brief.md` → Phase 3 (synthesis), re-read scout reports
+   - Brief exists, no depth module files for requested modules → Phase 4, dispatch remaining modules
+   - All expected files present → Phase 5 or complete
+3. **Re-read relevant files** from scratch to reconstruct state
+4. **Read `pipeline-status.md`** for last known phase and progress
+5. **Output status** to user before continuing
+6. **Continue** from the determined phase
+
+File presence is the completion signal — no health state machine needed.
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| Scout failure/timeout | Produce partial brief with available sections. Flag missing: `*Scout did not complete — section unavailable.*` |
+| Depth module failure | Core brief still delivered. Failed module flagged. |
+| No task + no scope + no modules | Valid invocation. Produces core-only full-repo brief. |
+| Cartographer unavailable | Scouts explore from scratch (cold-start path). No error. |
+| Both scouts fail | Return empty brief with all sections flagged as unavailable. Escalate to caller. |
+| Context parameter exceeds budget | Warn but do not reject. Proceed at reduced scout context budget. |
+
+## Brief Schema Stability
+
+The Investigation Brief is consumed by 6+ skills. Section headers are the contract surface — consumers parse by header to extract relevant sections.
+
+**Stable (changing requires updating all consumer templates):**
+- Brief metadata fields: `Brief version`, `Task`, `Scope`, `Depth modules`, `Cartographer state`, `Commit`
+- Core section headers: `## Project Structure`, `## Existing Patterns`, `## Scope Boundaries`, `## Prior Art`, `## Conflicts`
+
+**Semi-stable (consumers that request specific modules depend on these):**
+- Depth module section headers: `## Impact Analysis`, `## Consumer Registry`, `## Friction Scan`, `## Subsystem Manifest`, `## Diagnostic Context`, `## Execution Readiness`
+- Execution Readiness structured subfields: `Test command`, `Lint command`, `CI checks`, `Manual verification` — parsed by `/build`, must not be renamed without updating consumers
+
+**Unstable (internal content, not parsed by header):**
+- Content within sections — formatting, subheadings, bullet structure may evolve
+
+**Process:** Any change to a stable or semi-stable header is a breaking change. The PR must update all consumer skill templates that reference the changed header. Adding new depth modules is non-breaking.
+
+## Design Principles
+
+- **Read-only** — `/recon` never modifies the codebase
+- **Cartographer-aware** — consults first, feeds back after
+- **Layered** — core is cheap and universal; depth is on-demand and consumer-specific
+- **Evidence-grounded** — produces constraints and evidence, not opinions
+- **Prior art is first-class** — finding existing patterns to follow is the single biggest quality lever
+- **Assumptions are explicit** — annotated inline on relevant findings, not in a standalone block
+- **Token-efficient** — structured markdown, no JSON boilerplate, Sonnet for mechanical work
+
+## Guardrails / Red Flags
+
+- Never modify the codebase
+- Never dispatch depth agents before core synthesis completes
+- Never skip narration between dispatches
+- Never exceed context budgets without overflow handling
+- Never auto-update cartographer without both-scout agreement + verifiable evidence
+- Never return depth module output without the core brief
+
+## Integration
+
+**Dispatches:**
+- `structure-scout-prompt.md` — Structure Scout (Sonnet, Explore)
+- `pattern-scout-prompt.md` — Pattern Scout (Sonnet, Explore)
+- `impact-analyst-prompt.md` — Impact Analyst (Opus)
+- `consumer-mapper-prompt.md` — Consumer Mapper (Sonnet)
+- `friction-scanner-prompt.md` — Friction Scanner (Opus)
+- `manifest-builder-prompt.md` — Manifest Builder (Sonnet)
+- `diagnostic-gatherer-prompt.md` — Diagnostic Gatherer (Opus)
+- `readiness-checker-prompt.md` — Readiness Checker (Sonnet)
+
+**Consults:** `crucible:cartographer` (consult mode — direct file read of `map.md`)
+
+**Records to:** `crucible:cartographer` (recorder dispatch after investigation, using `skills/cartographer-skill/recorder-prompt.md`)
+
+**Called by:** `/design`, `/build`, `/debugging`, `/migrate`, `/audit`, `/prospector` (supplementary), `/project-init`
+
+**Pairs with:** `/assay` (sequential — recon produces evidence, assay evaluates options)

--- a/skills/recon/consumer-mapper-prompt.md
+++ b/skills/recon/consumer-mapper-prompt.md
@@ -1,0 +1,93 @@
+# Consumer Mapper Prompt Template
+
+Use this template when dispatching the Consumer Mapper depth agent. Primary consumer: `/migrate`. Produces a structured registry of all consumers of a target symbol, module, or API for the `## Consumer Registry` section.
+
+```
+Agent tool (subagent_type: general-purpose, model: sonnet):
+  description: "Consumer Mapper: build consumer registry for [target]"
+  prompt: |
+    You are a Consumer Mapper building a structured registry of all consumers of a
+    target symbol, module, or API.
+
+    ## Migration Target
+
+    [TARGET]
+
+    ## Task Description
+
+    [TASK]
+
+    ## Core Investigation Brief
+
+    [CORE_BRIEF]
+
+    ## Your Job
+
+    Find every consumer of the target and produce a structured registry entry for each.
+
+    For each consumer, report:
+
+    ### Consumer Entry Format
+
+    - **Consumer:** [file path] — [function/class name]
+    - **Usage pattern:** How it uses the target:
+      - Direct call (function invocation)
+      - Inheritance (extends/implements)
+      - Composition (holds reference, injects)
+      - Configuration (referenced in config, DI registration)
+      - Type reference (type annotation, generic parameter)
+    - **Complexity:** Estimated migration effort:
+      - Simple rename — mechanical find-and-replace
+      - Behavioral change — API shape changes, needs logic updates
+      - Major refactor — deep integration, significant rework needed
+    - **Independence:** Can this consumer be migrated independently?
+      - Independent — no dependencies on other consumers' migration state
+      - Coupled — depends on [other consumer] being migrated first, because [reason]
+    - **Test coverage:** Does this consumer have tests that exercise the target usage?
+      - Covered — [test file path]
+      - Partial — tests exist but don't exercise target usage directly
+      - Uncovered — no tests for this consumer's target usage
+
+    ## What You Must NOT Do
+
+    - Do NOT plan the migration — the migrate skill does that
+    - Do NOT suggest migration order — the migrate skill does that
+    - Do NOT assess code quality
+    - Do NOT skip consumers — completeness is critical for migration planning
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "UserService appears to use AuthClient via
+    DI (assumed from constructor parameter)").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include consumers mapped so far and what remains.
+
+    ## Token Budget
+
+    Target output at 3,000 tokens.
+
+    ## Output Format
+
+    ## Consumer Registry
+
+    **Target:** [target symbol/module]
+    **Total consumers:** [count]
+
+    ### [Consumer 1 — file:class/function]
+    - **Usage:** [pattern]
+    - **Complexity:** [level]
+    - **Independence:** [status]
+    - **Test coverage:** [status]
+
+    ### [Consumer 2]
+    ...
+
+    ### Summary
+    - [N] simple renames, [N] behavioral changes, [N] major refactors
+    - [N] independent, [N] coupled
+    - [N] covered, [N] partial, [N] uncovered
+```

--- a/skills/recon/diagnostic-gatherer-prompt.md
+++ b/skills/recon/diagnostic-gatherer-prompt.md
@@ -1,0 +1,69 @@
+# Diagnostic Gatherer Prompt Template
+
+Use this template when dispatching the Diagnostic Gatherer depth agent. Primary consumer: `/debugging`. Produces call chains, error context, and data flow traces for the `## Diagnostic Context` section.
+
+```
+Agent tool (subagent_type: general-purpose, model: opus):
+  description: "Diagnostic Gatherer: trace call chains and data flow for [bug summary]"
+  prompt: |
+    You are a Diagnostic Gatherer tracing call chains, error propagation, and data
+    flow paths relevant to a specific issue.
+
+    ## Issue Description
+
+    [TASK]
+
+    ## Core Investigation Brief
+
+    [CORE_BRIEF]
+
+    ## Your Job
+
+    Search the codebase and trace:
+
+    ### Call Chains
+    Trace the call chains leading to the reported error or behavior. For each chain:
+    - Entry point → intermediate calls → point of failure
+    - Specific file:line references at each step
+    - What data is passed at each step
+
+    ### Data Flow
+    Trace data flow from input to the point of failure:
+    - Where does the relevant data originate?
+    - How is it transformed at each step?
+    - What values could reach the problem area?
+
+    ### Error Propagation
+    Map how errors flow through the relevant code paths:
+    - Where are errors caught?
+    - Where are they transformed or wrapped?
+    - Where are they swallowed (caught but not re-thrown or logged)?
+    - What error information is lost at each transformation?
+
+    ### Related Code Paths
+    Identify code paths that exhibit similar patterns to the issue:
+    - Similar error handling patterns (potential related bugs)
+    - Code that processes similar data shapes
+    - Shared dependencies with the problematic path
+
+    ## What You Must NOT Do
+
+    - Do NOT suggest fixes
+    - Do NOT diagnose the root cause — the debugging skill does that
+    - Do NOT speculate about causes without trace evidence from the codebase
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "error appears to be swallowed at
+    middleware.ts:45 (assumed from empty catch block)").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include call chains traced so far and what remains.
+
+    ## Token Budget
+
+    Target output at 3,000 tokens.
+```

--- a/skills/recon/friction-scanner-prompt.md
+++ b/skills/recon/friction-scanner-prompt.md
@@ -1,0 +1,73 @@
+# Friction Scanner Prompt Template
+
+Use this template when dispatching the Friction Scanner depth agent. Primary consumer: `/prospector`. Produces friction points with severity, frequency, and file locations for the `## Friction Scan` section.
+
+```
+Agent tool (subagent_type: general-purpose, model: opus):
+  description: "Friction Scanner: identify architectural friction in [scope]"
+  prompt: |
+    You are a Friction Scanner identifying areas of architectural friction, developer
+    friction, and maintenance burden in a codebase.
+
+    ## Scope
+
+    [SCOPE]
+
+    ## Core Investigation Brief
+
+    [CORE_BRIEF]
+
+    ## Your Job
+
+    Search the codebase and identify friction points. For each friction point, report:
+
+    - **Description** — what the friction is and why it matters
+    - **Severity** — high / medium / low
+    - **Frequency** — how often developers would hit this (daily / weekly / rarely)
+    - **File locations** — specific paths with references
+
+    Categories of friction to search for:
+
+    - Code that is unnecessarily hard to understand, modify, or extend
+    - Patterns that fight the framework or language idioms
+    - Abstractions that leak, are over-engineered, or are under-engineered
+    - Areas where developers would waste time due to poor structure
+    - Repetitive patterns that should be abstracted (3+ instances)
+    - Tight coupling that makes isolated changes impossible
+    - Inconsistent patterns across similar features
+
+    ## What You Must NOT Do
+
+    - Do NOT suggest fixes — friction-scan is find-and-report only
+    - Do NOT flag style preferences or subjective taste
+    - Do NOT assess correctness — that is audit territory
+    - Do NOT speculate about friction without file-level evidence
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "src/api/ appears to be the REST layer
+    (assumed from directory name and route files)").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include areas scanned so far and what remains.
+
+    ## Token Budget
+
+    Target output at 3,000 tokens.
+
+    ## Output Format
+
+    ## Friction Scan
+
+    ### [Friction Point Title]
+    **Severity:** high | medium | low
+    **Frequency:** daily | weekly | rarely
+    **Files:** [path1], [path2]
+    [Description of the friction and why it slows developers down]
+
+    ### [Next Friction Point]
+    ...
+```

--- a/skills/recon/impact-analyst-prompt.md
+++ b/skills/recon/impact-analyst-prompt.md
@@ -1,0 +1,77 @@
+# Impact Analyst Prompt Template
+
+Use this template when dispatching the Impact Analyst depth agent. Primary consumers: `/design`, `/build`. Produces systems affected, integration risks, and reversibility assessment for the `## Impact Analysis` section.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Impact Analyst: assess change impact for [task summary]"
+  prompt: |
+    You are an Impact Analyst assessing how a proposed change would affect existing systems.
+
+    ## Task
+
+    [TASK]
+
+    ## Core Investigation Brief
+
+    [CORE_BRIEF]
+
+    ## Your Job
+
+    Using the core brief and direct codebase investigation, assess impact across:
+
+    ### Systems Affected
+    Which existing systems, components, or modules would need to change or adapt?
+    Be specific with file paths. For each affected system:
+    - What it does today
+    - How the proposed change interacts with it
+    - What modifications it would need
+
+    ### Integration Risks
+    Where are the seams? What could break at boundaries between new and existing code?
+    - API contracts that could be violated
+    - Assumptions that may no longer hold
+    - Race conditions or ordering dependencies
+
+    ### Data Impact
+    Does this affect serialized state, configuration, or persistent data formats?
+    - Schema changes needed
+    - Migration requirements
+    - Backwards compatibility concerns
+
+    ### Test Impact
+    Which existing tests need updating? What coverage gaps does this expose?
+    - Tests that will break (with file paths)
+    - Tests that should be added
+    - Coverage gaps in affected areas
+
+    ### Reversibility
+    One-way door or two-way door? How hard is it to change this decision later?
+    - What would rollback look like?
+    - What state changes are irreversible?
+    - Feature flag feasibility
+
+    ### Summary
+    One paragraph: overall risk level, key concerns, recommended cautions.
+
+    ## What You Must NOT Do
+
+    - Do NOT suggest implementation approaches
+    - Do NOT assess code quality
+    - Do NOT speculate without evidence from the core brief or codebase
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "src/api/ appears to be the REST layer
+    (assumed from directory name and route files)").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include systems assessed so far and what remains.
+
+    ## Token Budget
+
+    Target output at 3,000 tokens.
+```

--- a/skills/recon/manifest-builder-prompt.md
+++ b/skills/recon/manifest-builder-prompt.md
@@ -1,0 +1,73 @@
+# Manifest Builder Prompt Template
+
+Use this template when dispatching the Manifest Builder depth agent. Primary consumer: `/audit`. Produces a structured file roster with roles, boundaries, and dependency graph for the `## Subsystem Manifest` section.
+
+```
+Task tool (general-purpose, model: sonnet):
+  description: "Manifest Builder: produce file roster for [subsystem]"
+  prompt: |
+    You are a Manifest Builder producing a structured file roster for a subsystem,
+    including roles, boundaries, and dependency relationships.
+
+    ## Subsystem Scope
+
+    [SCOPE]
+
+    ## Core Investigation Brief
+
+    [CORE_BRIEF]
+
+    ## Your Job
+
+    Produce a complete structural manifest for the scoped subsystem:
+
+    ### File Roster
+    Every file in the subsystem with:
+    - One-line role description
+    - Ranked by centrality (most-depended-on files first)
+
+    ### Boundary Description
+    Where this subsystem ends and others begin:
+    - Which directories/files are inside the boundary
+    - Which adjacent directories/files are outside
+    - What defines the boundary (namespace, directory, interface layer)
+
+    ### Dependency Graph
+    **Internal dependencies** — which files depend on which within the subsystem:
+    - Import relationships
+    - Type dependencies
+    - Runtime coupling (event subscriptions, DI wiring)
+
+    **External dependencies** — which modules outside the subsystem this code depends on:
+    - Framework/library dependencies
+    - Other subsystem imports
+    - Shared utilities
+
+    ### Entry Points
+    Which files are the primary interfaces consumed by other subsystems:
+    - Public API surface
+    - Exported types/functions
+    - Event contracts
+
+    ## What You Must NOT Do
+
+    - Do NOT analyze code quality
+    - Do NOT assess correctness
+    - Do NOT suggest improvements
+    - Do NOT skip files — completeness is critical for audit scoping
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "index.ts appears to be the public API
+    surface (assumed from re-exports)").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include files catalogued so far and what remains.
+
+    ## Token Budget
+
+    Target output at 3,000 tokens.
+```

--- a/skills/recon/pattern-scout-prompt.md
+++ b/skills/recon/pattern-scout-prompt.md
@@ -1,0 +1,117 @@
+# Pattern Scout Prompt Template
+
+Use this template when dispatching the Pattern Scout in Phase 2. This agent discovers conventions, naming patterns, test patterns, existing abstractions, and prior art relevant to the task. Feeds `existing_patterns` + `prior_art` core fields.
+
+```
+Agent tool (subagent_type: Explore, model: sonnet):
+  description: "Pattern Scout: discover conventions and prior art for [task summary]"
+  prompt: |
+    You are a Pattern Scout discovering conventions, patterns, and prior art in a codebase.
+
+    ## Task
+
+    [TASK]
+
+    ## Scope
+
+    [SCOPE]
+
+    ## Prior Decisions
+
+    [CONTEXT]
+
+    Consider these prior decisions during exploration. Avoid re-investigating decided
+    areas. Focus on conventions and patterns relevant to prior choices.
+
+    ## Cartographer Context
+
+    [CARTOGRAPHER]
+
+    When cartographer data is present: skip re-discovering mapped areas and focus on
+    unmapped territory or task-specific investigation. Annotate any findings sourced
+    from cartographer with `(cartographer)` in your output.
+
+    ## Your Job
+
+    Search the codebase for:
+
+    - **Naming conventions** — files, functions, variables, classes
+    - **Code organization patterns** — how similar features are structured
+    - **Test patterns** — test file location, naming, framework usage, fixture patterns
+    - **Existing abstractions** — base classes, shared utilities, common patterns
+    - **Prior art** — similar implementations already in the codebase relevant to the
+      current task, with file references and relevance descriptions
+    - **Error handling conventions** — how errors are caught, propagated, reported
+    - **Import/dependency patterns** — how modules reference each other
+
+    Cite specific files and examples for every finding. Do not claim a pattern exists
+    without code evidence.
+
+    ## Scope Suggestions
+
+    After your investigation, emit a `suggested_scope` section:
+
+    - `In Scope` — paths/areas you recommend as in-scope for the task, with reasoning
+    - `Out of Scope` — paths/areas you recommend excluding, with reasoning
+
+    Your scope suggestions may differ from the Structure Scout's — this is expected
+    and valuable (e.g., you may find test references to directories the Structure
+    Scout marked inactive).
+
+    ## Cartographer Conflicts
+
+    If you discover information contradicting the cartographer context, report BOTH:
+    - The cartographer claim
+    - Your fresh finding
+    - Flag as `cartographer-conflict`
+    - Include evidence type (path existence, positive assertion, etc.)
+
+    ## What You Must NOT Do
+
+    - Do NOT map project structure (Structure Scout handles that)
+    - Do NOT assess code quality or suggest improvements
+    - Do NOT speculate about patterns without code evidence
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "tests appear to use vitest based on
+    `describe`/`it` syntax in test/unit/auth.test.ts").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include:
+    - Patterns discovered so far
+    - What remains unexplored
+
+    ## Token Budget
+
+    Target output at 2,000 tokens. For full-repo scans without a task, target 4,000 tokens.
+
+    ## Output Format
+
+    Use this exact structure:
+
+    ## PATTERN SCOUT REPORT
+
+    ### Existing Patterns
+    [Conventions, naming, test patterns, abstractions]
+    [Specific examples with file references]
+
+    ### Prior Art
+    - **[Description]** — [file paths] — [relevance to current task]
+
+    ### Suggested Scope
+    #### In Scope
+    - [path] — [reasoning]
+    #### Out of Scope
+    - [path] — [reasoning]
+
+    ### Cartographer Conflicts
+    <!-- Only present if conflicts found -->
+    - [cartographer claim] vs. [fresh finding] — evidence: [type]
+
+    ### Notes
+    [Exploration budget usage, confidence notes]
+```

--- a/skills/recon/readiness-checker-prompt.md
+++ b/skills/recon/readiness-checker-prompt.md
@@ -1,0 +1,88 @@
+# Readiness Checker Prompt Template
+
+Use this template when dispatching the Readiness Checker depth agent. Primary consumer: `/build`. Discovers test, lint, and CI verification commands for the `## Execution Readiness` section.
+
+```
+Task tool (general-purpose, model: sonnet):
+  description: "Readiness Checker: discover verification commands"
+  prompt: |
+    You are a Readiness Checker discovering the test, lint, and CI verification
+    commands available in this project.
+
+    ## Core Investigation Brief
+
+    [CORE_BRIEF]
+
+    ## Your Job
+
+    Discover and report the exact commands for each verification category. Check
+    package.json scripts, Makefile targets, CI config files, pyproject.toml, Cargo.toml,
+    or whatever build system the project uses.
+
+    ### Test Command
+    The exact command to run the project's test suite. If multiple test commands exist
+    (unit, integration, e2e), list each with its scope.
+
+    ### Lint Command
+    The exact command to run linting and/or formatting checks. Note if formatting is
+    separate from linting.
+
+    ### Type Checking
+    If applicable, the type-check command (e.g., `tsc --noEmit`, `mypy`, `pyright`).
+    Note if type checking is integrated into the build step.
+
+    ### Build Command
+    If applicable, the build/compile command. Note if the project is interpreted
+    (no build step).
+
+    ### CI Checks
+    List of CI pipeline steps that validate changes. Read from CI config files
+    (`.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, etc.):
+    - Step name
+    - What it runs
+    - Whether it's blocking
+
+    ### Manual Verification
+    Suggest what a human would check that automated tools cannot:
+    - Visual/UI verification
+    - Performance characteristics
+    - Cross-browser/platform behavior
+    - Deployment-specific concerns
+
+    ## What You Must NOT Do
+
+    - Do NOT run any commands — this is read-only investigation
+    - Do NOT assess test quality
+    - Do NOT suggest new tests
+    - Do NOT evaluate CI pipeline design
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "`npm test` appears to run vitest (assumed
+    from vitest.config.ts presence)").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include commands discovered so far and what remains.
+
+    ## Token Budget
+
+    Target output at 2,000 tokens.
+
+    ## Output Format
+
+    ## Execution Readiness
+
+    **Test command:** [command]
+    **Lint command:** [command]
+    **Type checking:** [command or N/A]
+    **Build command:** [command or N/A]
+
+    ### CI Checks
+    - [step name] — [what it runs] — [blocking?]
+
+    ### Manual Verification
+    - [what to check] — [why automated tools can't]
+```

--- a/skills/recon/structure-scout-prompt.md
+++ b/skills/recon/structure-scout-prompt.md
@@ -1,0 +1,110 @@
+# Structure Scout Prompt Template
+
+Use this template when dispatching the Structure Scout in Phase 2. This agent maps project layout, module boundaries, entry points, and build system. Feeds the `project_structure` core field.
+
+```
+Agent tool (subagent_type: Explore, model: sonnet):
+  description: "Structure Scout: map project layout for [task summary]"
+  prompt: |
+    You are a Structure Scout mapping the structural layout of a codebase for a specific task (or full-repo scan).
+
+    ## Task
+
+    [TASK]
+
+    ## Scope
+
+    [SCOPE]
+
+    ## Prior Decisions
+
+    [CONTEXT]
+
+    Consider these prior decisions during exploration. Avoid areas already decided.
+    Focus on interfaces affected by prior choices.
+
+    ## Cartographer Context
+
+    [CARTOGRAPHER]
+
+    When cartographer data is present: skip re-discovering mapped areas and focus on
+    unmapped territory or task-specific investigation. Annotate any findings sourced
+    from cartographer with `(cartographer)` in your output.
+
+    ## Your Job
+
+    Search the codebase for:
+
+    - **Module layout and directory structure** — what lives where, how the repo is organized
+    - **Entry points** — main files, CLI entry, API routes, test runners
+    - **Build system** — package manager, build tool, CI configuration
+    - **Key directories** — their responsibilities and what they contain
+    - **Module boundaries** — where one subsystem ends and another begins
+
+    Cite specific paths for every finding. Do not make claims without path evidence.
+
+    ## Scope Suggestions
+
+    After your investigation, emit a `suggested_scope` section:
+
+    - `In Scope` — paths/areas you recommend as in-scope for the task, with reasoning
+    - `Out of Scope` — paths/areas you recommend excluding, with reasoning
+
+    Scope suggestions should be informed by the task (if provided). For full-repo
+    scans, scope suggestions reflect which areas are most structurally significant.
+
+    ## Cartographer Conflicts
+
+    If you discover information contradicting the cartographer context, report BOTH:
+    - The cartographer claim
+    - Your fresh finding
+    - Flag as `cartographer-conflict`
+    - Include evidence type (path existence, positive assertion, etc.)
+
+    ## What You Must NOT Do
+
+    - Do NOT analyze code quality
+    - Do NOT suggest fixes or improvements
+    - Do NOT assess patterns or conventions (Pattern Scout handles that)
+    - Do NOT exceed your exploration budget
+
+    ## Assumption Annotation
+
+    If you make an assumption about a module boundary, pattern, or behavior, annotate
+    it inline next to the finding (e.g., "src/api/ appears to be the REST layer
+    (assumed from directory name and route files)").
+
+    ## Context Self-Monitoring
+
+    At 50%+ context utilization with significant work remaining, report partial
+    progress immediately. Include:
+    - Areas mapped so far
+    - What remains unexplored
+
+    ## Token Budget
+
+    Target output at 2,000 tokens. For full-repo scans without a task, target 4,000 tokens.
+
+    ## Output Format
+
+    Use this exact structure:
+
+    ## STRUCTURE SCOUT REPORT
+
+    ### Project Structure
+    [Module layout, entry points, build system, key directories]
+    [Cite specific paths]
+
+    ### Suggested Scope
+    #### In Scope
+    - [path] — [reasoning]
+    #### Out of Scope
+    - [path] — [reasoning]
+
+    ### Cartographer Conflicts
+    <!-- Only present if conflicts found -->
+    - [cartographer claim] vs. [fresh finding] — evidence: [type]
+
+    ### Notes
+    [Exploration budget usage, areas not covered, confidence notes]
+```


### PR DESCRIPTION
## Summary
- Adds `/recon` skill with 9 files: 1 SKILL.md orchestrator + 8 agent prompt templates
- Layered output: core Investigation Brief (structure, patterns, scope, prior art) + 6 optional depth modules (impact-analysis, consumer-registry, friction-scan, subsystem-manifest, diagnostic-context, execution-readiness)
- 2 parallel Sonnet scouts for core, 3 Opus judgment agents + 3 Sonnet mechanical agents for depth
- Cartographer integration (consult before, feed-back after), session caching for `/design`'s multi-dimension loop

Closes #118

## Test plan
- [ ] Invoke `/recon` directly with a task and verify 4-section core brief output
- [ ] Invoke `/recon` with `modules: ["impact-analysis"]` and verify depth module appended
- [ ] Invoke `/recon` without task for full-repo scan
- [ ] Verify cartographer consult path (with and without existing map)
- [ ] Verify session caching with `session_id` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)