### PR TITLE
spec: add design doc, plan, and contract for distill skill (#111)

### DIFF
--- a/docs/plans/2026-04-05-distill-contract.yaml
+++ b/docs/plans/2026-04-05-distill-contract.yaml
@@ -17,10 +17,10 @@ api_surface:
 
   - name: "Tier1PandocConversion"
     type: "function"
-    signature: "pandoc -f $FORMAT -t markdown --wrap=none $INPUT_PATH -o $OUTPUT_PATH"
+    signature: "pandoc -f \"$FORMAT\" -t markdown --wrap=none \"$INPUT_PATH\" -o \"$OUTPUT_PATH\""
     params:
       - name: "FORMAT"
-        type: "string — pandoc format flag (docx, rtf, html, odt, epub, rst, org, latex, ipynb)"
+        type: "string — pandoc format flag (docx, rtf, html, odt, epub, rst, org, latex, ipynb). Note: .html and .htm both map to 'html' — 9 format flags, 10 file extensions."
         required: true
       - name: "INPUT_PATH"
         type: "string — absolute path to source file"
@@ -29,7 +29,7 @@ api_surface:
         type: "string — absolute path for converted .md output"
         required: true
     returns: "Markdown file at OUTPUT_PATH"
-    description: "Tier 1 conversion via pandoc. Supports 10 formats natively."
+    description: "Tier 1 conversion via pandoc. Supports 9 formats (10 file extensions counting .html/.htm separately)."
 
   - name: "Tier2PDFConversion"
     type: "function"

--- a/docs/plans/2026-04-05-distill-design.md
+++ b/docs/plans/2026-04-05-distill-design.md
@@ -62,7 +62,7 @@ Converted files (`.md`, `.digest.md`, `.csv`) are working artifacts, not source 
 
 The tiered design minimizes dependencies — most formats need only pandoc (already installed). Heavier tools are loaded only when needed.
 
-### Tier 1: Pandoc-Native (10 formats, single command each)
+### Tier 1: Pandoc-Native (9 formats / 10 file extensions, single command each)
 
 | Extension | Format | Pandoc `-f` flag |
 |---|---|---|

--- a/docs/plans/2026-04-05-distill-implementation-plan.md
+++ b/docs/plans/2026-04-05-distill-implementation-plan.md
@@ -9,7 +9,7 @@ source: "spec"
 
 ## Task Overview
 
-10 tasks across 3 waves. Wave 1 is the skill skeleton + Tier 1 (pandoc) + tool checks + input handling. Wave 2 adds Tier 2 (PDF) + Tier 3 (Python venv). Wave 3 adds the digest pass + pre-flight checks + integration.
+9 tasks (plus 3b) across 3 waves. Wave 1 is the skill skeleton + Tier 1 (pandoc) + tool checks + input handling. Wave 2 adds Tier 2 (PDF) + Tier 3 (Python venv). Wave 3 adds the digest pass + pre-flight checks + integration.
 
 ## Wave 1: Skill Skeleton + Tier 1
 
@@ -159,7 +159,7 @@ Implement three pre-flight checks:
 
 Pre-flight runs before conversion for each file. Failures are per-file (don't halt the batch).
 
-### Task 10: Implement conversion summary and token metrics
+### Task 9: Implement conversion summary and token metrics
 
 **Files:** `skills/distill/SKILL.md` (summary section)
 **Complexity:** Low
@@ -192,8 +192,7 @@ Task 1, Task 3    ← Task 5 (Tier 2)
 Task 1, Task 3    ← Task 6 (Tier 3)
 Task 2, 5, 6      ← Task 7 (digest)
 Task 1            ← Task 8 (pre-flight)
-Task 2, 5, 6, 7   ← Task 9 (not used — renumbered)
-Task 2, 5, 6, 7   ← Task 10 (summary)
+Task 2, 5, 6, 7   ← Task 9 (summary)
 ```
 
 ## Implementation Notes


### PR DESCRIPTION
## Summary

- Design doc, implementation plan, and contract for the `/distill` skill (#111)
- Converts heavy document formats (PDF, Word, Excel, PowerPoint, 10+ others) to token-efficient Markdown/CSV
- Core value: structurally-aware digest pass compresses to 20-30% of token count
- Three conversion tiers: Pandoc-native (9 formats), PDF (pdftotext + Claude structuring), Python venv (pptx/xlsx)
- 4 rounds of quality gate review, all Significant findings resolved

## Artifacts

| File | Purpose |
|---|---|
| `docs/plans/2026-04-05-distill-design.md` | Full design with architecture, decisions, acceptance criteria |
| `docs/plans/2026-04-05-distill-implementation-plan.md` | 9-task plan across 3 waves |
| `docs/plans/2026-04-05-distill-contract.yaml` | Machine-readable contract (v1.0 schema) |

## Key Design Decisions

- **DEC-1:** python-pptx for PPTX (pandoc 3.1.3 doesn't support pptx input)
- **DEC-2:** Output alongside source files (easy discovery, clear association)
- **DEC-3:** Digest as primary output, full .md as intermediate
- **DEC-4:** Sequential processing for v1 (parallel deferred)
- **DEC-5:** Venv in /tmp, not project-local

## Test plan

- [ ] Design doc has all required sections and frontmatter
- [ ] Implementation plan tasks are concrete and dependency graph is correct
- [ ] Contract passes schema validation (version, api_surface, invariants)
- [ ] Run `/build #111` to implement from these spec artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)