### PR TITLE
feat: reduce CSB frequency + disk-write-then-summarize (#140, #141)

### DIFF
--- a/docs/plans/2026-04-06-csb-frequency-design.md
+++ b/docs/plans/2026-04-06-csb-frequency-design.md
@@ -1,0 +1,59 @@
+---
+ticket: "#140"
+title: "Reduce CSB emission frequency"
+date: "2026-04-06"
+source: "spec"
+---
+
+# Reduce CSB Emission Frequency
+
+## Problem
+
+CSBs (~150-250 tokens each) are emitted at 6+ trigger types in build and 5 trigger types in debugging. They stack in conversation history — autocompact can't selectively shed old ones. Each emission adds tokens that persist until compaction.
+
+## Change
+
+Remove low-value CSB triggers. Keep only triggers where the CSB serves a genuine recovery or communication purpose.
+
+### Build Skill — Checkpoint Timing
+
+**Current triggers (5):**
+1. Phase transitions → handoff manifest (already not a CSB)
+2. Phase 3 progress: after every 3 task completions
+3. Quality gate entry/exit
+4. Escalations
+5. Health transitions
+
+**Revised triggers (3):**
+1. Phase transitions → handoff manifest (unchanged)
+2. Escalations (keep — user needs full state)
+3. Health transitions (keep — state change worth recording)
+
+**Dropped:**
+- Every-3-task progress CSBs → replace with pipeline-status.md write only (already happens). The status file provides ambient awareness without bloating conversation context.
+- Quality gate entry/exit → the gate is a sub-operation within a phase, not a phase boundary. Pipeline-status.md captures gate progress.
+
+### Debugging Skill — Checkpoint Timing
+
+**Current triggers (5):**
+1. Phase transitions → handoff manifests at major boundaries, CSBs at minor ones
+2. Hypothesis cycles: after each hypothesis formed/invalidated
+3. Fix attempts: after each Phase 4 attempt
+4. Escalations
+5. Health transitions
+
+**Revised triggers (4):**
+1. Phase transitions → handoff manifests at major boundaries, CSBs at minor ones (unchanged)
+2. Fix attempts: after each Phase 4 attempt (keep — fix cycles are the core loop)
+3. Escalations (keep)
+4. Health transitions (keep)
+
+**Dropped:**
+- Hypothesis cycles → these fire frequently during Phase 2 (every hypothesis formed AND invalidated). Replace with pipeline-status.md write only.
+
+## Acceptance Criteria
+
+1. Build Checkpoint Timing section reduced from 5 to 3 triggers
+2. Debugging Checkpoint Timing section reduced from 5 to 4 triggers
+3. Pipeline-status.md writes still happen at all former CSB trigger points (ambient awareness preserved)
+4. Existing handoff manifest behavior unchanged

--- a/docs/plans/2026-04-06-disk-write-summarize-design.md
+++ b/docs/plans/2026-04-06-disk-write-summarize-design.md
@@ -1,0 +1,65 @@
+---
+ticket: "#141"
+title: "Disk-write-then-summarize convention"
+date: "2026-04-06"
+source: "spec"
+---
+
+# Disk-Write-Then-Summarize Convention
+
+## Problem
+
+Orchestrators write state to disk (scratch files, findings, fix journals) but the full content also stays in conversation history via tool call results. The disk copy is authoritative — the conversation copy is dead weight. This doubles storage for every state write.
+
+Disk-mediated dispatch (#97) solved this for subagent prompts. This extends the pattern to orchestrator state.
+
+## Change
+
+Add a convention to the three orchestrator skills (build, debugging, quality-gate): after writing structured state to disk, the orchestrator emits a 2-3 line summary referencing the disk path instead of relying on the full content remaining in conversation.
+
+### The Convention
+
+**After any Write tool call that persists orchestrator state to a scratch directory, emit a brief summary:**
+
+```
+[State type] written to [path]. [1-line summary of contents].
+```
+
+**Examples:**
+- "Fix journal round 4 written to scratch/fix-journal.md. 3 findings addressed via extracted helper pattern."
+- "Round 3 findings written to scratch/round-3-findings.md. Score: 4 (1 Fatal, 1 Significant). Down from 7."
+- "Task 5 completion written to task-list. 2 files changed, review clean on pass 1."
+
+**The orchestrator should not re-read the full content from its own conversation history after writing to disk.** If it needs the content later (e.g., to pass to a subagent), it reads from disk via the Read tool.
+
+### Where to Apply
+
+**Quality-gate:** After writing `round-N-findings.md`, `round-N-score.md`, `fix-journal.md` entries, `artifact-N.md` snapshots. These are the highest-volume writes (one per round, multiple files per round).
+
+**Build Phase 3:** After writing task completion status, review findings summaries, and wave verification results to scratch/task files.
+
+**Debugging:** After writing `hypothesis-log.md` updates, `phase-state.md` updates, and investigation findings to scratch.
+
+### Implementation
+
+Add a short section to each orchestrator skill's scratch directory documentation:
+
+**"Disk-Write-Then-Summarize Convention"** (~5-8 lines per skill):
+> After writing structured state to the scratch directory, emit a 1-2 line summary referencing the file path. Do not rely on the full content persisting in conversation — if you need it later, re-read from disk. This keeps conversation context lean while disk remains the source of truth.
+
+## Key Decisions
+
+### DEC-1: Convention in orchestrator skills, not in shared dispatch convention (High Confidence)
+
+The shared dispatch convention covers subagent dispatch files. This covers orchestrator-to-disk writes, which are a different pattern. Keeping them separate avoids overloading `shared/dispatch-convention.md`.
+
+### DEC-2: No enforcement mechanism — just clear instructions (High Confidence)
+
+Like disk-mediated dispatch, this is an instruction the model follows, not compiled code. The pattern is simple enough (write, then summarize) that LLM compliance is high. The existing dispatch convention proves this pattern works.
+
+## Acceptance Criteria
+
+1. Quality-gate SKILL.md includes the convention in its scratch directory section
+2. Build SKILL.md includes the convention in its context management section
+3. Debugging SKILL.md includes the convention in its scratch directory section
+4. Convention text is ~5-8 lines per skill (not a major SKILL.md addition)


### PR DESCRIPTION
## Summary
Two context protection improvements from epic #96:

- **#140 — Reduce CSB emission frequency:** Build drops 2 low-value triggers (every-3-task, QG entry/exit: 5->3). Debugging drops hypothesis-cycle trigger (5->4). Pipeline-status.md writes preserved at all former trigger points for ambient awareness.
- **#141 — Disk-write-then-summarize:** After writing structured state to disk, emit 1-2 line summary instead of relying on full content in conversation. Applied to build (all phases), quality-gate (round files), and debugging (scratch state). Disk is source of truth; conversation is for coordination.

## Rationale (from audit)
These were the only 2 of 5 proposed items that survived audit. The other 3 (fix journal compression, per-phase budget, context watermark) were dropped because they assume the model can observe or control its own context window.

## Files Changed
- Spec docs in docs/plans/ (repo)
- User-level skill files: build, debugging, quality-gate SKILL.md (not in repo)

## Test plan
- [ ] Run /build — verify CSBs only emit at phase transitions, escalations, health transitions
- [ ] Run /debugging — verify no CSB on hypothesis formed/invalidated
- [ ] Verify pipeline-status.md still updates at all former trigger points
- [ ] Verify orchestrator emits summaries after disk writes, not full content

Generated with Claude Code