### PR TITLE
feat: integrate /siege into /build and /spec pipelines (#153)

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -876,6 +876,32 @@ After all tasks complete:
    - This is NOT a full implementation re-review — scope it to only the fixer's changes
    - Iterative until clean, same as step 3
    - Skip if the inquisitor reported all PASS (no fixes were needed)
+5.5. **CONDITIONAL: Security review via crucible:siege**
+   <!-- CANONICAL: shared/security-signals.md -->
+   a. **Contract check:** If a contract YAML exists for this ticket with `security_review.status: "required"`, siege is mandatory — skip to step (d).
+   b. **Code scan:** If no contract directive (or contract has `security_review.status: "recommended"` or field absent), scan for siege activation signals:
+      - **Scan targets:** design doc content + `git diff <base-sha>..HEAD` (changed file contents)
+      - **Method:** Case-insensitive keyword matching using the 7-category keyword lists from `shared/security-signals.md`
+      - Count distinct categories matched (one hit per category is sufficient)
+   c. **Threshold evaluation:**
+      - **0 signals:** Skip siege silently. No narration needed.
+      - **1 signal:** Log in narration: "1 security signal detected ([category]) — skipping siege. Invoke `/siege --force` manually if needed." Record in manifest and decision journal: `security-review | choice=skip | reason=1 signal ([category])`.
+      - **2+ signals:** Proceed to step (d).
+   d. **Dispatch siege:**
+      - **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-siege" before dispatching siege. If siege's fix cycle produces regressions, this is the rollback target.
+      - Dispatch `crucible:siege` with:
+        - Target: design doc + full implementation diff (artifact type: `mixed`)
+        - `deployment_context`: from contract `security_review.deployment_context` if present, else unset (siege defaults to `public`)
+      - Narration: "Security signals detected: [list categories]. Dispatching siege."
+      - Decision journal: `security-review | choice=dispatch | reason=[N] signals ([categories]) [or contract-required]`
+      - **Session index event:** Emit to outbox: `{"ts":"<now>","seq":0,"type":"security_review","summary":"Siege dispatched: [N] signals detected","detail":{"skill":"build","signals":[categories]}}`
+   e. **Blocking behavior:** Siege iterates internally until zero Critical + zero High.
+      - If siege completes clean: continue to step 6 (quality-gate)
+      - If siege escalates (stagnation, user input needed): escalate to user with siege context
+      - If siege's fix cycle produced code changes: re-run crucible:code-review scoped to siege fix commits only (`git diff <pre-siege-sha>..HEAD`). Same pattern as post-inquisitor conditional review at step 5.
+   f. **Escape hatches:** User can override automatic siege behavior:
+      - `--force-siege` — Dispatch siege regardless of signal count. Maps to siege's `--force` flag. Decision journal: `security-review | choice=force-dispatch | reason=user --force-siege flag`
+      - `--skip-siege` — Suppress siege even when signals/contract require it. Maps to siege's `--skip` flag. Decision journal: `security-review | choice=force-skip | reason=user --skip-siege flag`
 6. **RECOMMENDED SUB-SKILL:** Use crucible:checkpoint — create checkpoint with reason "pre-impl-gate" before dispatching the implementation quality gate. If gate fix rounds degrade the code, this is the rollback target.
 6. **REQUIRED SUB-SKILL:** Use crucible:quality-gate on full implementation (artifact type: "code", iterative until clean) **(Non-negotiable — see Quality Gate Requirement.)**
 7. **RECOMMENDED SUB-SKILL:** Use crucible:forge (retrospective mode) — capture what happened vs what was planned
@@ -910,6 +936,7 @@ At completion (before reporting to user, i.e. step 9), read the metrics log and 
   Active work time:      2h 47m
   Wall clock time:       11h 13m
   Quality gate rounds:   4 (design: 2, plan: 1, impl: 1)
+  Siege:                 dispatched (3 agents, 2 rounds, 0 Critical, 0 High) | skipped (0 signals) | skipped (1 signal: auth)
   Task tiers:           3 Tier 1, 3 Tier 2, 2 Tier 3
   Subagent savings:     ~21 dispatches skipped vs all-Tier-3
   Est. input tokens:    ~32,100 (128,400 chars)

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -951,6 +951,7 @@ At completion (before reporting to user, i.e. step 9), read the metrics log and 
 - Active work time (merge overlapping parallel intervals — NOT naive sum)
 - Wall clock time (first dispatch to final completion)
 - Quality gate rounds (per gate: design, plan, implementation)
+- Siege status (dispatched with agent count, rounds, and final severity counts — or skipped with signal count and reason)
 - Estimated input tokens (sum of `input_chars` from manifest / 4)
 - Estimated output tokens (sum of `output_chars` from manifest / 4)
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -303,6 +303,7 @@ Before running interactive design, check whether `/spec` (or a prior `/build` ru
 
 3. **Full match (design doc + implementation plan + contract all present):**
    - Skip interactive design (the Phase 1 design sub-skill below) — design doc already exists
+   - **Security review check:** If the contract contains `security_review` field, note it in the Phase 1→2 handoff manifest under Active Constraints: "Contract requires security review (`security_review.status: [required|recommended]`) — siege will be evaluated in Phase 4 Step 5.5." This ensures the directive survives phase handoffs and compaction recovery.
    - Quality-gate the existing design doc with staleness context: "This design doc is pre-existing from /spec and may be stale — verify against current codebase state before proceeding"
    - **Staleness rejection:** If the quality gate finds that the design doc references files, interfaces, or modules that no longer exist in the codebase, reject the doc as fundamentally stale. Fall back to running Phase 1 interactively. Inform user: "Pre-existing design doc for #NNN is fundamentally stale (references [specific items] that no longer exist). Running interactive design instead."
    - If quality gate passes: Run Phase 2 on the pre-existing implementation plan — skip Plan Writer (plan already exists), but run Plan Reviewer + innovate + quality-gate on the existing plan. This ensures the plan gets the same review rigor as a freshly written plan.

--- a/skills/shared/security-signals.md
+++ b/skills/shared/security-signals.md
@@ -1,0 +1,94 @@
+---
+version: 1
+---
+
+# Security Signal Detection
+
+> Shared reference for security signal detection consumed by build, spec, and audit.
+> For full heuristic semantics, see `skills/siege/SKILL.md` § Activation Heuristic.
+
+## Signal Categories
+
+Seven categories of security-sensitive content. Each category is independently matched — one keyword hit per category is sufficient to count that category as detected.
+
+### 1. Authentication / Authorization
+
+Keywords: `login`, `session`, `token`, `RBAC`, `permission`, `auth`, `JWT`, `OAuth`, `SAML`, `ACL`, `role`, `access control`, `identity`, `SSO`, `MFA`, `2FA`
+
+### 2. Cryptographic Operations
+
+Keywords: `hash`, `encrypt`, `decrypt`, `sign`, `verify`, `key management`, `certificate`, `TLS`, `SSL`, `HMAC`, `AES`, `RSA`, `bcrypt`, `argon2`, `scrypt`, `cipher`, `digest`, `PKI`
+
+### 3. External Input Handling
+
+Keywords: `API endpoint`, `upload`, `deserializ`, `parse`, `URL`, `request body`, `webhook`, `form input`, `input validation`, `sanitiz`, `user input`, `query parameter`, `file upload`, `multipart`
+
+### 4. Secrets Management
+
+Keywords: `API key`, `credential`, `connection string`, `environment variable`, `secret`, `password`, `.env`, `vault`, `key rotation`, `service account`, `bearer token`
+
+### 5. Network Boundaries
+
+Keywords: `inter-service`, `webhook handler`, `CORS`, `proxy`, `gateway`, `gRPC`, `REST API`, `WebSocket`, `HTTP endpoint`, `reverse proxy`, `load balancer`, `ingress`, `egress`
+
+### 6. Data Persistence with PII
+
+Keywords: `user data`, `PII`, `personal data`, `GDPR`, `retention`, `logging sensitive`, `email address`, `phone number`, `SSN`, `data protection`, `anonymiz`, `pseudonymiz`, `data subject`
+
+### 7. Dependency Introduction
+
+Keywords: `new package`, `npm install`, `pip install`, `cargo add`, `version bump`, `native binding`, `dependency`, `third-party`, `supply chain`, `package.json`, `requirements.txt`, `Cargo.toml`
+
+## Activation Threshold
+
+**2+ distinct categories** must match to activate siege. A single category match is insufficient (too many false positives).
+
+| Matched Categories | Action |
+|---|---|
+| 0 | No security review needed. Silent skip. |
+| 1 | `security_review: recommended` in contract. Build logs but does not dispatch siege. |
+| 2+ | `security_review: required` in contract. Build dispatches siege automatically. |
+
+## Scanning Targets
+
+Signal detection scans text content. The scan targets vary by consuming skill:
+
+| Skill | Scan Targets |
+|---|---|
+| **spec** | Ticket body, investigation findings, design doc content |
+| **build** | Design doc content, `git diff <base-sha>..HEAD` (changed file contents) |
+| **audit** | Existing behavior — audit performs its own security surface detection |
+
+Scanning is case-insensitive keyword matching. One keyword hit per category is sufficient — do not count multiple hits within the same category.
+
+## Contract Field: `security_review`
+
+Optional top-level field in the contract YAML schema (version 1.0). Presence indicates security signals were detected during spec writing. Absence means no signals detected.
+
+```yaml
+security_review:
+  status: required | recommended
+  signals_detected:
+    - category: "auth"
+      evidence: "ticket mentions login flow and JWT token handling"
+    - category: "external_input"
+      evidence: "design doc includes REST API endpoint definitions"
+  deployment_context: public | intranet | hybrid  # optional
+```
+
+### Field Semantics
+
+| Field | Required | Description |
+|---|---|---|
+| `status` | Yes | `required` (2+ signals) or `recommended` (1 signal) |
+| `signals_detected` | Yes | Non-empty array of matched categories with evidence text |
+| `signals_detected[].category` | Yes | One of: `auth`, `crypto`, `external_input`, `secrets`, `network`, `pii_data`, `dependencies` |
+| `signals_detected[].evidence` | Yes | Brief description of what triggered this category |
+| `deployment_context` | No | Flows to siege's `deployment_context` parameter if present |
+
+### Escape Hatches
+
+These are passed as flags when invoking build:
+
+- `--force-siege` — Dispatch siege regardless of signal count (maps to siege `--force`)
+- `--skip-siege` — Suppress siege even when signals/contract require it (maps to siege `--skip`)

--- a/skills/siege/SKILL.md
+++ b/skills/siege/SKILL.md
@@ -40,6 +40,8 @@ Audit finds bugs, robustness gaps, and architecture issues. Quality-gate iterate
 
 ## Activation Heuristic
 
+<!-- CANONICAL: shared/security-signals.md — consumption-optimized keyword lists for build/spec/audit -->
+
 ### Content-Aware Detection
 
 Siege activates when the orchestrator (build, audit, or user session) encounters **two or more** of these high-risk signals in the target artifact:
@@ -84,6 +86,22 @@ When `true`: Chain Analyst annotates chain steps with MITRE ATT&CK technique IDs
 - `--force` -- Activate Siege regardless of heuristic (user explicitly wants security review)
 - `--skip` -- Suppress Siege activation even when heuristic triggers (user explicitly declines)
 - When audit detects security surfaces during its Phase 2 analysis, it may recommend: "Security surfaces detected. Run `/siege` for full security audit." This is a recommendation, not automatic invocation.
+
+## Pipeline Integration
+
+<!-- CANONICAL: shared/security-signals.md -->
+Siege integrates with orchestrator skills via `shared/security-signals.md`, which codifies the 7-category activation heuristic in a consumption-optimized format:
+
+- **crucible:build** — Phase 4 Step 5.5 checks for siege activation signals in the implementation diff and design doc. If 2+ signals detected (or contract specifies `security_review: required`), siege is dispatched automatically. Critical/High findings block the pipeline identically to quality-gate Fatal/Significant.
+- **crucible:spec** — Step 3.5 scans ticket content for signals during contract generation. Adds `security_review: required|recommended` to the contract YAML, which build consumes.
+- **crucible:audit** — Existing recommendation behavior unchanged. Audit may still recommend siege when it detects security surfaces.
+
+When dispatched from build, siege receives:
+- Artifact type: `mixed` (design doc + implementation diff)
+- `deployment_context`: from contract `security_review.deployment_context` if present, else defaults to `public`
+- Scope: determined by siege's own scope-based agent count heuristic (3/4/6 agents based on file count)
+
+Build's escape hatches (`--force-siege`, `--skip-siege`) map to siege's `--force` and `--skip` flags respectively.
 
 ### Execution Intensity
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -538,7 +538,12 @@ After generating the contract YAML, validate against the schema:
    - `api_surface[].params` must be present for `function`, `class`, and `interface` types. Each param must have `name`, `type`, and `required` fields.
    - `invariants.checkable[].check_method` must be one of: `grep`, `code-inspection`, `file-structure`
    - `invariants.testable[].test_tag` must match the pattern `contract:<category>:<id>`
-3. **Integration point validation:** For each entry in `integration_points`, verify that the referenced contract file exists in `docs/plans/` or the scratch directory's `contracts/` folder. If the referenced contract does not yet exist (upstream ticket not yet processed), log a warning but do not block.
+3. **Security review field validation (when present):**
+   - `security_review.status` must be one of: `required`, `recommended`
+   - `security_review.signals_detected` must be a non-empty array
+   - Each entry must have `category` (one of: `auth`, `crypto`, `external_input`, `secrets`, `network`, `pii_data`, `dependencies`) and `evidence` (non-empty string)
+   - `security_review.deployment_context` (if present) must be one of: `public`, `intranet`, `hybrid`
+4. **Integration point validation:** For each entry in `integration_points`, verify that the referenced contract file exists in `docs/plans/` or the scratch directory's `contracts/` folder. If the referenced contract does not yet exist (upstream ticket not yet processed), log a warning but do not block.
 4. **On validation failure:** Report specific errors. Re-dispatch the contract generation step with the validation errors as feedback. If the second attempt also fails, log the errors, mark the contract as having validation warnings, and continue -- do not block the entire run on a malformed contract.
 
 ### Step 6: Lightweight Per-Ticket Validation
@@ -714,6 +719,18 @@ integration_points:
     surface: "AuthService.validate_token"
     notes: "Depends on the new token format from #124"
 
+# Security review directive -- optional, present when security signals detected
+# during spec writing. Consumed by /build Phase 4 Step 5.5 to dispatch siege.
+# Omit entirely if no signals detected. See shared/security-signals.md.
+security_review:                           # OPTIONAL
+  status: "required"                       # required (2+ signals) | recommended (1 signal)
+  signals_detected:
+    - category: "auth"                     # auth | crypto | external_input | secrets | network | pii_data | dependencies
+      evidence: "ticket mentions login flow and JWT tokens"
+    - category: "external_input"
+      evidence: "design doc includes API endpoint definitions"
+  deployment_context: "public"             # OPTIONAL — public | intranet | hybrid
+
 # Decisions made where multiple viable paths existed
 ambiguity_resolutions:
   - id: "AMB-1"
@@ -760,6 +777,9 @@ When `/spec` resolves an ambiguity or defines an API surface on ticket N that af
 | `invariants` | Yes | Must have at least one checkable or testable |
 | `invariants.checkable[].check_method` | Yes | `grep`, `code-inspection`, or `file-structure` |
 | `invariants.testable[].test_tag` | Yes | Pattern: `contract:<category>:<id>` |
+| `security_review` | No | Optional; present when security signals detected (see `shared/security-signals.md`) |
+| `security_review.status` | Conditional | Required when `security_review` present. `required` or `recommended` |
+| `security_review.signals_detected` | Conditional | Required when `security_review` present. Non-empty array of `{category, evidence}` |
 | `integration_points` | No | May be empty if no cross-ticket deps |
 | `ambiguity_resolutions` | No | May be empty if all decisions were high-confidence |
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -321,6 +321,7 @@ Before any dispatch work, check for a crashed prior spec session:
   |                +-- Run investigation (same depth as /design)
   |                +-- Dependency discovery check -> write discoveries.json
   |                +-- Update local status -> "writing"
+  |                +-- Security signal scan (shared/security-signals.md) -> include security_review in contract if signals detected
   |                +-- Write design doc + implementation plan + contract to output/
   |                +-- Contract schema validation
   |                +-- Update local status -> "validating"
@@ -334,7 +335,7 @@ Before any dispatch work, check for a crashed prior spec session:
   |                +-- Copy outputs from ticket dirs to docs/plans/
   |                +-- Commit outputs to spec/<epic-number> branch (serialized)
   |                +-- Check for re-queued tickets, update wave schedule
-  |                +-- Output status update to terminal
+  |                +-- Output status update to terminal (include security_review status per ticket if present)
   |
   +-- [11] End-of-run quality gate
   |        +-- Phase 1: Per-document gates (design + plan per ticket, in parallel)

--- a/skills/spec/spec-writer-prompt.md
+++ b/skills/spec/spec-writer-prompt.md
@@ -246,6 +246,39 @@ Task tool (general-purpose, model: opus, team_name: "spec-[EPIC_NUMBER]", name: 
 
     ---
 
+    ## Step 3.5: Security Signal Scan
+
+    Before generating documents, scan for security-sensitive content using the keyword
+    lists from `shared/security-signals.md`. This determines whether the contract should
+    carry a `security_review` directive for `/build` to consume.
+
+    1. **Scan targets:** ticket body (`[TICKET_BODY]`), your investigation findings, and
+       the design doc content you are about to write.
+    2. **Match categories:** For each of the 7 signal categories in `security-signals.md`,
+       check if any keyword from that category appears in the scan targets (case-insensitive).
+       Count distinct categories matched — one hit per category is sufficient.
+    3. **Determine status:**
+       - **2+ categories matched:** Include `security_review` in the contract with
+         `status: required`. List matched categories with brief evidence snippets.
+       - **1 category matched:** Include `security_review` in the contract with
+         `status: recommended`. List the single matched category with evidence.
+       - **0 categories matched:** Omit the `security_review` field entirely.
+    4. **Deployment context:** If the ticket or design implies a deployment environment
+       (e.g., "public API", "internal tool", "intranet service"), include
+       `deployment_context` in the field. Otherwise omit it (siege defaults to `public`).
+
+    Record the scan result in `[SCRATCH_DIR]/decisions.md`:
+    ```markdown
+    ## Decision: SEC-SCAN (Ticket [TICKET_NUMBER])
+
+    **Choice:** security_review [status|omitted] — [N] signal categories detected
+    **Confidence:** high
+    **Categories:** [list matched categories or "none"]
+    **Evidence:** [brief evidence per category]
+    ```
+
+    ---
+
     ## Step 4: Document Generation
 
     Produce three files in `[SCRATCH_DIR]/output/`:
@@ -419,6 +452,19 @@ Task tool (general-purpose, model: opus, team_name: "spec-[EPIC_NUMBER]", name: 
         surface: "InterfaceName.method_name"  # specific API surface element
         notes: "Brief explanation of the dependency"
 
+    # Security review directive -- optional field, present when security signals
+    # detected during spec writing (Step 3.5). Consumed by /build Phase 4 Step 5.5.
+    # Omit entirely if no signals detected.
+    # See shared/security-signals.md for signal categories and threshold rules.
+    security_review:                           # OPTIONAL — omit if 0 signals
+      status: "required"                       # required (2+ signals) | recommended (1 signal)
+      signals_detected:
+        - category: "auth"                     # one of: auth, crypto, external_input, secrets, network, pii_data, dependencies
+          evidence: "ticket mentions login flow and JWT token handling"
+        - category: "external_input"
+          evidence: "design doc includes REST API endpoint definitions"
+      deployment_context: "public"             # OPTIONAL — public | intranet | hybrid
+
     # Decisions made where multiple viable paths existed.
     # May be empty if all decisions were high-confidence.
     ambiguity_resolutions:
@@ -437,6 +483,9 @@ Task tool (general-purpose, model: opus, team_name: "spec-[EPIC_NUMBER]", name: 
       what can be checked by reading code vs. what requires running tests.
     - `integration_points`: Reference upstream contracts from `[UPSTREAM_CONTRACTS]`.
       Add any downstream integration points discovered during investigation.
+    - `security_review`: Include if Step 3.5 detected security signals. Copy the status,
+      matched categories, and deployment context directly from your Step 3.5 scan results.
+      Omit entirely if no signals were detected.
     - `ambiguity_resolutions`: Mirror the decisions from Step 3 that had medium or low
       confidence. High-confidence decisions with no viable alternatives do not need
       entries here.


### PR DESCRIPTION
## Summary

- **New shared reference** `skills/shared/security-signals.md` codifying siege's 7-category activation heuristic with keyword lists for automated detection
- **Spec integration**: Step 3.5 scans ticket content for security signals, adds `security_review: required|recommended` to contract YAML
- **Build integration**: Phase 4 Step 5.5 checks contract directives and/or scans implementation diff, auto-dispatches siege when 2+ signals detected. Critical/High block the pipeline.
- **Siege integration notes**: New Pipeline Integration section documenting build/spec/audit coordination
- Escape hatches (`--force-siege`, `--skip-siege`) map to siege's existing `--force`/`--skip` flags

## Test plan

- [ ] Verify `shared/security-signals.md` lists all 7 categories with keywords matching siege SKILL.md
- [ ] Verify `security_review` contract field schema is consistent across spec-writer-prompt, spec SKILL.md, and security-signals.md
- [ ] Verify build Step 5.5 correctly handles all three states: contract-required, 2+ signals, 0-1 signals
- [ ] Verify category enum values (`auth`, `crypto`, `external_input`, `secrets`, `network`, `pii_data`, `dependencies`) match across all files
- [ ] Verify escape hatches documented consistently in build and siege
- [ ] Run `/build` on a security-relevant feature to confirm siege auto-dispatches

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)