### PR TITLE
feat: skill-selection evals for routing accuracy (#86)

### DIFF
--- a/skills/skill-selection-evals/GRADING.md
+++ b/skills/skill-selection-evals/GRADING.md
@@ -44,6 +44,24 @@ Selection eval results are reported alongside execution eval metrics:
 
 The selection accuracy metric answers: "When the agent receives a prompt, how often does it route to the correct skill?" This complements the execution delta which answers: "Once the correct skill is invoked, how much better is the output?"
 
+## Difficulty Stratification
+
+Each eval includes a `difficulty` field (easy, medium, hard) based on how ambiguous the routing decision is:
+
+- **Easy**: Clear trigger words or explicit skill references. Agent should always get these right.
+- **Medium**: Reasonable ambiguity where context matters. Errors here indicate weak disambiguation.
+- **Hard**: Same verb maps to different skills, or the correct skill is counter-intuitive. Errors here are expected at baseline and improvement targets.
+
+Report accuracy stratified by difficulty:
+
+| Difficulty | Count | Pass | Partial | Fail | Accuracy |
+|-----------|-------|------|---------|------|----------|
+| Easy | 9 | - | - | - | - |
+| Medium | 8 | - | - | - | - |
+| Hard | 6 | - | - | - | - |
+
+Difficulty-stratified accuracy reveals whether improvements are lifting hard cases (valuable) or just confirming easy cases already work (low signal).
+
 ## Interpreting Results
 
 - **Low selection accuracy on a boundary** indicates the disambiguation guidance for those skills needs improvement (SKILL.md triggers, getting-started routing table).

--- a/skills/skill-selection-evals/GRADING.md
+++ b/skills/skill-selection-evals/GRADING.md
@@ -1,0 +1,52 @@
+# Skill-Selection Eval Grading
+
+## Running the Evals
+
+Present each eval's `prompt` to the agent in a fresh conversation. Observe which skill the agent selects (invokes or announces it will use). Record the selected skill.
+
+For cascade evals, record the full sequence of skills invoked.
+
+## Grading Criteria
+
+### Pass
+- **Direct/Negative/Context-dependent**: Agent selects exactly the `expected_skill`.
+- **Cascade**: Agent selects all skills in `expected_skill` in the correct order.
+
+### Partial
+- **Direct/Negative/Context-dependent**: Agent selects the correct skill alongside unnecessary additional skills, or selects a related skill that partially addresses the prompt.
+- **Cascade**: Agent selects all correct skills but in wrong order, or omits one skill from the sequence.
+
+### Fail
+- **Direct/Negative/Context-dependent**: Agent selects a skill from `common_mistakes` or an unrelated skill. Agent does not invoke any skill.
+- **Cascade**: Agent selects fewer than half the correct skills, or invokes them in fundamentally wrong order (e.g., build before design).
+
+## Baseline Measurement Protocol
+
+1. Run all evals against the current getting-started routing table and SKILL.md trigger descriptions without any modifications.
+2. Record grade (Pass/Partial/Fail) for each eval.
+3. Compute:
+   - **Overall accuracy**: Pass count / total evals
+   - **Per-boundary accuracy**: Pass count / evals in boundary
+   - **Per-dimension accuracy**: Pass count / evals in dimension
+4. Store results in `evals/baseline-results.json` with timestamp.
+
+## Integration with Eval Summary
+
+Selection eval results are reported alongside execution eval metrics:
+
+| Metric | Value |
+|--------|-------|
+| Execution evals (with skill) | 96% |
+| Execution evals (without skill) | 67% |
+| Execution delta | +29% |
+| **Selection accuracy** | *baseline TBD* |
+| **Selection accuracy by boundary** | *baseline TBD* |
+
+The selection accuracy metric answers: "When the agent receives a prompt, how often does it route to the correct skill?" This complements the execution delta which answers: "Once the correct skill is invoked, how much better is the output?"
+
+## Interpreting Results
+
+- **Low selection accuracy on a boundary** indicates the disambiguation guidance for those skills needs improvement (SKILL.md triggers, getting-started routing table).
+- **Context-dependent failures** indicate the agent relies on verb matching rather than situational analysis.
+- **Cascade failures** indicate the agent does not maintain pipeline discipline for multi-step workflows.
+- **Negative selection failures** indicate trigger descriptions are too broad (matching prompts they should not).

--- a/skills/skill-selection-evals/SKILL.md
+++ b/skills/skill-selection-evals/SKILL.md
@@ -26,6 +26,10 @@ Crucible's 49 execution evals measure quality once a skill is invoked. Selection
 4. **completion-claims** — verify vs finish
 5. **bug-handling** — debugging vs verify vs audit
 
+## Difficulty Ratings
+
+Each eval is rated easy/medium/hard based on routing ambiguity. This enables stratified baseline measurement — distinguishing between improvements that lift hard cases (high value) vs confirming easy cases already work (low signal).
+
 ## See Also
 
 - `evals/evals.json` — the eval data

--- a/skills/skill-selection-evals/SKILL.md
+++ b/skills/skill-selection-evals/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: skill-selection-evals
+description: "Eval-only skill for measuring skill routing accuracy. Not invoked directly — contains selection evals that test whether the agent picks the correct skill for a given prompt."
+---
+
+# Skill-Selection Evals
+
+This is not an executable skill. It contains evaluation data for measuring the accuracy of skill selection (routing) decisions.
+
+## Purpose
+
+Crucible's 49 execution evals measure quality once a skill is invoked. Selection evals measure whether the **right skill gets invoked** in the first place.
+
+## Eval Types
+
+- **Direct selection**: Given a prompt, does the agent pick the correct skill?
+- **Negative selection**: Given a prompt that sounds like skill X but is not, does the agent avoid the false positive?
+- **Context-dependent**: Same verb, different context, different correct skill.
+- **Cascade ordering**: Multi-skill tasks requiring correct invocation order.
+
+## Boundaries Tested
+
+1. **test-methodology** — TDD vs test-coverage vs adversarial-tester
+2. **review-direction** — code-review vs review-feedback
+3. **adversarial-scope** — red-team vs inquisitor vs audit vs siege
+4. **completion-claims** — verify vs finish
+5. **bug-handling** — debugging vs verify vs audit
+
+## See Also
+
+- `evals/evals.json` — the eval data
+- `GRADING.md` — grading criteria and baseline measurement protocol

--- a/skills/skill-selection-evals/evals/evals.json
+++ b/skills/skill-selection-evals/evals/evals.json
@@ -1,0 +1,236 @@
+{
+  "skill_name": "skill-selection-evals",
+  "eval_type": "selection",
+  "evals": [
+    {
+      "id": "test-methodology-direct-01",
+      "dimension": "direct",
+      "boundary": "test-methodology",
+      "prompt": "I just changed the auth module, make sure existing tests still make sense",
+      "expected_skill": "test-coverage",
+      "common_mistakes": ["test-driven-development", "verify"],
+      "context": "Code already exists and was recently modified. Tests exist but may be stale after the change.",
+      "reasoning": "TDD is for new code written test-first. Verify checks claims of completion. Test-coverage audits existing tests after code changes to find staleness, needed updates, or removal."
+    },
+    {
+      "id": "test-methodology-direct-02",
+      "dimension": "direct",
+      "boundary": "test-methodology",
+      "prompt": "I need to implement a Luhn validator for credit card numbers. Let's build it with tests.",
+      "expected_skill": "test-driven-development",
+      "common_mistakes": ["test-coverage", "build"],
+      "context": "New feature, no existing code. User wants test-first development.",
+      "reasoning": "This is greenfield implementation where no code exists yet. 'Build it with tests' signals test-first approach. TDD writes failing tests before implementation. Test-coverage only applies when tests already exist. Build would skip the test-first discipline."
+    },
+    {
+      "id": "test-methodology-direct-03",
+      "dimension": "direct",
+      "boundary": "test-methodology",
+      "prompt": "I just finished implementing the rate limiter. Try to break it — find edge cases I missed.",
+      "expected_skill": "adversarial-tester",
+      "common_mistakes": ["test-coverage", "test-driven-development", "red-team"],
+      "context": "Implementation is complete. User wants adversarial testing to find unknown failure modes.",
+      "reasoning": "Implementation is done — this is not TDD (code exists) or test-coverage (not auditing existing tests for staleness). Adversarial-tester reads implementation diffs and writes tests designed to make it break. Red-team reviews artifacts for design flaws, not implementation edge cases."
+    },
+    {
+      "id": "test-methodology-negative-01",
+      "dimension": "negative",
+      "boundary": "test-methodology",
+      "prompt": "Write tests for the parser I just built last week. It handles JSON, YAML, and TOML.",
+      "expected_skill": "test-coverage",
+      "common_mistakes": ["test-driven-development"],
+      "context": "Code was built last week. Tests need to be added after the fact. This is retroactive test addition, not test-first development.",
+      "reasoning": "Despite saying 'write tests', this is NOT TDD. The parser already exists — TDD requires writing tests BEFORE implementation. Test-coverage audits and adds tests for existing code. The key signal is 'I just built' (past tense) — the code-before-test ship has sailed."
+    },
+    {
+      "id": "test-methodology-context-01",
+      "dimension": "context-dependent",
+      "boundary": "test-methodology",
+      "prompt": "Write tests for the checkout flow.",
+      "expected_skill": "test-coverage",
+      "common_mistakes": ["test-driven-development"],
+      "context": "The checkout flow already exists in production. This is adding test coverage to existing, working code.",
+      "reasoning": "Same verb ('write tests') but context determines the skill. When the code already exists and is in production, this is test-coverage (audit and add tests for existing code). If the checkout flow did not exist yet, this would be TDD. The distinguishing signal is whether code exists."
+    },
+    {
+      "id": "review-direction-direct-01",
+      "dimension": "direct",
+      "boundary": "review-direction",
+      "prompt": "I'm done with the feature branch. Can you review my changes before I create a PR?",
+      "expected_skill": "code-review",
+      "common_mistakes": ["review-feedback", "quality-gate"],
+      "context": "User is requesting a review of their own work before submission. No external feedback has been received.",
+      "reasoning": "Code-review is for when you want your work reviewed — requesting a review. Review-feedback is for when you have RECEIVED review comments and need to process them. The direction is outbound (requesting review), not inbound (receiving feedback)."
+    },
+    {
+      "id": "review-direction-direct-02",
+      "dimension": "direct",
+      "boundary": "review-direction",
+      "prompt": "I got 6 comments on my PR from the tech lead. Help me work through them.",
+      "expected_skill": "review-feedback",
+      "common_mistakes": ["code-review"],
+      "context": "User has received review feedback on a PR and needs to process and respond to the comments.",
+      "reasoning": "Review-feedback handles inbound review comments — analyzing them for technical merit, identifying unclear or contradictory items, and determining the right response. Code-review would be requesting a new review, which is the wrong direction."
+    },
+    {
+      "id": "review-direction-negative-01",
+      "dimension": "negative",
+      "boundary": "review-direction",
+      "prompt": "The senior dev left some comments on my PR saying 'looks good, just clean up the naming'. Help me with the review.",
+      "expected_skill": "review-feedback",
+      "common_mistakes": ["code-review"],
+      "context": "Despite using the word 'review', the user has RECEIVED feedback and needs to process it. The feedback is inbound.",
+      "reasoning": "The word 'review' appears but the direction is inbound — the user received comments and needs to process them. Review-feedback handles this. Code-review would be wrong because the user is not requesting a fresh review of their code."
+    },
+    {
+      "id": "review-direction-context-01",
+      "dimension": "context-dependent",
+      "boundary": "review-direction",
+      "prompt": "Review this code.",
+      "expected_skill": "code-review",
+      "common_mistakes": ["review-feedback", "audit"],
+      "context": "User is presenting their own code and asking for a review. No prior feedback exists — this is a request for review.",
+      "reasoning": "Same word 'review' but context determines direction. Here the user is requesting a review (outbound) — code-review. If the user had said 'I got a review on this code, help me address it', the direction would be inbound — review-feedback. Audit would be wrong because the user is asking for a targeted review, not a multi-lens adversarial subsystem audit."
+    },
+    {
+      "id": "adversarial-scope-direct-01",
+      "dimension": "direct",
+      "boundary": "adversarial-scope",
+      "prompt": "I just finished the design doc for the new notification service. Red-team it.",
+      "expected_skill": "red-team",
+      "common_mistakes": ["audit", "quality-gate", "siege"],
+      "context": "Single artifact (design doc) ready for adversarial review. Not a full codebase review, not a security audit.",
+      "reasoning": "Red-team is for adversarial review of a single artifact (design doc, plan, code, PR). Audit reviews existing codebase subsystems through parallel lenses. Quality-gate iterates with fixes until clean. Siege is specifically security-focused. The key signal is 'red-team it' on a single artifact."
+    },
+    {
+      "id": "adversarial-scope-direct-02",
+      "dimension": "direct",
+      "boundary": "adversarial-scope",
+      "prompt": "The payment module has been in production for a year. I want a thorough review of the whole subsystem — correctness, robustness, architecture, everything.",
+      "expected_skill": "audit",
+      "common_mistakes": ["red-team", "code-review", "prospector"],
+      "context": "Existing codebase subsystem, multi-dimensional review requested. Not a single artifact — an entire subsystem with multiple files.",
+      "reasoning": "Audit dispatches parallel analysis agents across four lenses (correctness, robustness, consistency, architecture) on an existing subsystem. Red-team reviews a single artifact. Code-review is lighter-weight. Prospector looks for architectural friction across the whole codebase, not a specific subsystem."
+    },
+    {
+      "id": "adversarial-scope-negative-01",
+      "dimension": "negative",
+      "boundary": "adversarial-scope",
+      "prompt": "We just assembled the full feature — auth, API routes, database migrations, and frontend. Hunt for cross-component bugs before we ship.",
+      "expected_skill": "inquisitor",
+      "common_mistakes": ["audit", "red-team", "adversarial-tester"],
+      "context": "Full feature assembled from multiple components. Need to find integration issues across component boundaries, not review a single artifact or existing subsystem.",
+      "reasoning": "Inquisitor runs 5 parallel adversarial dimensions against the complete implementation diff to find cross-component bugs. Audit reviews existing subsystems (this is new code). Red-team reviews single artifacts. Adversarial-tester finds edge cases in a single implementation, not cross-component integration issues."
+    },
+    {
+      "id": "adversarial-scope-context-01",
+      "dimension": "context-dependent",
+      "boundary": "adversarial-scope",
+      "prompt": "Audit this for security vulnerabilities.",
+      "expected_skill": "siege",
+      "common_mistakes": ["audit", "red-team"],
+      "context": "Despite using the word 'audit', the focus is specifically on security. This narrows the scope from general audit to security audit.",
+      "reasoning": "Siege is the security-specific audit — dispatches 6 parallel agents across attacker perspectives, iterates until zero Critical + zero High findings. General audit covers correctness, robustness, consistency, architecture — broader but not security-deep. The 'security vulnerabilities' qualifier triggers siege over audit."
+    },
+    {
+      "id": "completion-claims-direct-01",
+      "dimension": "direct",
+      "boundary": "completion-claims",
+      "prompt": "Tests pass and the feature works. Let's create a PR and merge.",
+      "expected_skill": "finish",
+      "common_mistakes": ["verify", "code-review"],
+      "context": "User has verified tests pass and wants to ship. This is an integration decision — how to get the work into the codebase.",
+      "reasoning": "Finish guides completion — presenting options for merge, PR, or cleanup. Verify gathers evidence (running tests, confirming output). The user has already gathered evidence ('tests pass'). The remaining decision is how to integrate the work, which is finish's domain."
+    },
+    {
+      "id": "completion-claims-direct-02",
+      "dimension": "direct",
+      "boundary": "completion-claims",
+      "prompt": "I think the migration is done. Can you confirm everything actually works?",
+      "expected_skill": "verify",
+      "common_mistakes": ["finish", "test-coverage"],
+      "context": "User is uncertain about completion. They need evidence, not an integration decision.",
+      "reasoning": "Verify runs verification commands and confirms output before any success claims — evidence before assertions. The user says 'I think' (uncertain) and 'confirm everything works' (needs evidence). Finish would be premature — the user has not yet confirmed the work is correct."
+    },
+    {
+      "id": "completion-claims-negative-01",
+      "dimension": "negative",
+      "boundary": "completion-claims",
+      "prompt": "Everything looks good to me. Ship it!",
+      "expected_skill": "verify",
+      "common_mistakes": ["finish"],
+      "context": "User claims completion but has not provided evidence of running tests or verification commands in the current session. 'Looks good to me' is a subjective claim, not verified evidence.",
+      "reasoning": "Despite the user's confidence, verify requires fresh evidence in the current session. 'Looks good to me' is not the same as 'tests pass and here is the output'. Verify must run before finish — the completion claim needs evidence backing."
+    },
+    {
+      "id": "completion-claims-context-01",
+      "dimension": "context-dependent",
+      "boundary": "completion-claims",
+      "prompt": "We're done here.",
+      "expected_skill": "verify",
+      "common_mistakes": ["finish"],
+      "context": "No test output or verification evidence has been presented in the conversation. The completion claim is unsupported.",
+      "reasoning": "Same completion signal but context matters. If tests had been run and confirmed passing earlier in the conversation, this would trigger finish (integration decision). Without evidence, 'we're done' should trigger verify first — evidence before assertions. The absence of prior verification is the distinguishing context."
+    },
+    {
+      "id": "bug-handling-direct-01",
+      "dimension": "direct",
+      "boundary": "bug-handling",
+      "prompt": "This endpoint returns 500 sometimes. Here's the error log showing a NullPointerException in the order handler.",
+      "expected_skill": "debugging",
+      "common_mistakes": ["verify", "audit"],
+      "context": "Active failure with error evidence. This is a bug to investigate and fix, not a completion check or subsystem review.",
+      "reasoning": "Debugging handles active failures — bugs, test failures, unexpected behavior. The user has an error log showing a specific failure. Verify checks completion claims (no active failure here). Audit reviews subsystems (this is a specific bug, not a broad review)."
+    },
+    {
+      "id": "bug-handling-direct-02",
+      "dimension": "direct",
+      "boundary": "bug-handling",
+      "prompt": "The tests pass but users are reporting that search results are wrong. Something is off.",
+      "expected_skill": "debugging",
+      "common_mistakes": ["verify", "test-coverage"],
+      "context": "Tests pass but behavior is wrong. This is a bug — the tests are insufficient or the bug is in an untested path.",
+      "reasoning": "Despite tests passing, there is unexpected behavior (wrong search results). This is a debugging scenario — investigate the root cause. Verify would just re-run the (already passing) tests. Test-coverage would audit test quality but not investigate the specific user-reported issue."
+    },
+    {
+      "id": "bug-handling-context-01",
+      "dimension": "context-dependent",
+      "boundary": "bug-handling",
+      "prompt": "Something is wrong with the caching system.",
+      "expected_skill": "debugging",
+      "common_mistakes": ["audit", "verify"],
+      "context": "User reports something is wrong — this is an active problem, not a proactive review. The phrasing indicates a current issue, not a desire for broad subsystem review.",
+      "reasoning": "'Something is wrong' signals an active problem — debugging territory. If the user said 'review the caching system for potential issues', that would be audit (proactive review). If they said 'verify the caching system works', that would be verify. The 'wrong' qualifier indicates a bug to investigate."
+    },
+    {
+      "id": "cascade-direct-01",
+      "dimension": "cascade",
+      "boundary": "test-methodology",
+      "prompt": "I want to add a webhook retry system with exponential backoff. Let's design it and build it properly.",
+      "expected_skill": ["design", "build"],
+      "common_mistakes": ["build", "planning"],
+      "context": "New feature requiring both design exploration and implementation. The user wants the full pipeline.",
+      "reasoning": "Design must come before build — 'design it and build it' is the correct sequence. Skipping design and going straight to build violates the design-before-build discipline. Planning alone is insufficient — it produces a task list but not the design exploration. The correct cascade is design (explored questions, investigated options) then build (implementation pipeline)."
+    },
+    {
+      "id": "cascade-direct-02",
+      "dimension": "cascade",
+      "boundary": "bug-handling",
+      "prompt": "The payment processor is double-charging some customers. Fix it and make sure it's actually fixed before we deploy.",
+      "expected_skill": ["debugging", "verify"],
+      "common_mistakes": ["debugging", "finish"],
+      "context": "Active bug requiring investigation, fix, and verified confirmation before deployment.",
+      "reasoning": "Debugging investigates root cause and implements fix. Verify then confirms the fix actually works with fresh evidence. Skipping verify after debugging and going straight to finish (deploy) risks deploying an unverified fix. The correct cascade is debugging (find and fix) then verify (prove it works)."
+    },
+    {
+      "id": "cascade-direct-03",
+      "dimension": "cascade",
+      "boundary": "completion-claims",
+      "prompt": "I need to add real-time notifications to the dashboard. Let's think through the design, plan the tasks, then build it.",
+      "expected_skill": ["design", "planning", "build"],
+      "common_mistakes": ["build", "design"],
+      "context": "User explicitly requests the full pipeline: design exploration, task planning, then implementation.",
+      "reasoning": "The user spells out the three-phase cascade: design (explore options, investigate questions), planning (break into tasks with ordering), build (implement). Skipping to build alone misses design exploration. Design alone misses the planning phase that produces the task breakdown. The full sequence ensures each phase informs the next."
+    }
+  ]
+}

--- a/skills/skill-selection-evals/evals/evals.json
+++ b/skills/skill-selection-evals/evals/evals.json
@@ -8,9 +8,13 @@
       "boundary": "test-methodology",
       "prompt": "I just changed the auth module, make sure existing tests still make sense",
       "expected_skill": "test-coverage",
-      "common_mistakes": ["test-driven-development", "verify"],
+      "common_mistakes": [
+        "test-driven-development",
+        "verify"
+      ],
       "context": "Code already exists and was recently modified. Tests exist but may be stale after the change.",
-      "reasoning": "TDD is for new code written test-first. Verify checks claims of completion. Test-coverage audits existing tests after code changes to find staleness, needed updates, or removal."
+      "reasoning": "TDD is for new code written test-first. Verify checks claims of completion. Test-coverage audits existing tests after code changes to find staleness, needed updates, or removal.",
+      "difficulty": "medium"
     },
     {
       "id": "test-methodology-direct-02",
@@ -18,19 +22,28 @@
       "boundary": "test-methodology",
       "prompt": "I need to implement a Luhn validator for credit card numbers. Let's build it with tests.",
       "expected_skill": "test-driven-development",
-      "common_mistakes": ["test-coverage", "build"],
+      "common_mistakes": [
+        "test-coverage",
+        "build"
+      ],
       "context": "New feature, no existing code. User wants test-first development.",
-      "reasoning": "This is greenfield implementation where no code exists yet. 'Build it with tests' signals test-first approach. TDD writes failing tests before implementation. Test-coverage only applies when tests already exist. Build would skip the test-first discipline."
+      "reasoning": "This is greenfield implementation where no code exists yet. 'Build it with tests' signals test-first approach. TDD writes failing tests before implementation. Test-coverage only applies when tests already exist. Build would skip the test-first discipline.",
+      "difficulty": "easy"
     },
     {
       "id": "test-methodology-direct-03",
       "dimension": "direct",
       "boundary": "test-methodology",
-      "prompt": "I just finished implementing the rate limiter. Try to break it — find edge cases I missed.",
+      "prompt": "I just finished implementing the rate limiter. Try to break it \u2014 find edge cases I missed.",
       "expected_skill": "adversarial-tester",
-      "common_mistakes": ["test-coverage", "test-driven-development", "red-team"],
+      "common_mistakes": [
+        "test-coverage",
+        "test-driven-development",
+        "red-team"
+      ],
       "context": "Implementation is complete. User wants adversarial testing to find unknown failure modes.",
-      "reasoning": "Implementation is done — this is not TDD (code exists) or test-coverage (not auditing existing tests for staleness). Adversarial-tester reads implementation diffs and writes tests designed to make it break. Red-team reviews artifacts for design flaws, not implementation edge cases."
+      "reasoning": "Implementation is done \u2014 this is not TDD (code exists) or test-coverage (not auditing existing tests for staleness). Adversarial-tester reads implementation diffs and writes tests designed to make it break. Red-team reviews artifacts for design flaws, not implementation edge cases.",
+      "difficulty": "easy"
     },
     {
       "id": "test-methodology-negative-01",
@@ -38,9 +51,12 @@
       "boundary": "test-methodology",
       "prompt": "Write tests for the parser I just built last week. It handles JSON, YAML, and TOML.",
       "expected_skill": "test-coverage",
-      "common_mistakes": ["test-driven-development"],
+      "common_mistakes": [
+        "test-driven-development"
+      ],
       "context": "Code was built last week. Tests need to be added after the fact. This is retroactive test addition, not test-first development.",
-      "reasoning": "Despite saying 'write tests', this is NOT TDD. The parser already exists — TDD requires writing tests BEFORE implementation. Test-coverage audits and adds tests for existing code. The key signal is 'I just built' (past tense) — the code-before-test ship has sailed."
+      "reasoning": "Despite saying 'write tests', this is NOT TDD. The parser already exists \u2014 TDD requires writing tests BEFORE implementation. Test-coverage audits and adds tests for existing code. The key signal is 'I just built' (past tense) \u2014 the code-before-test ship has sailed.",
+      "difficulty": "hard"
     },
     {
       "id": "test-methodology-context-01",
@@ -48,9 +64,12 @@
       "boundary": "test-methodology",
       "prompt": "Write tests for the checkout flow.",
       "expected_skill": "test-coverage",
-      "common_mistakes": ["test-driven-development"],
+      "common_mistakes": [
+        "test-driven-development"
+      ],
       "context": "The checkout flow already exists in production. This is adding test coverage to existing, working code.",
-      "reasoning": "Same verb ('write tests') but context determines the skill. When the code already exists and is in production, this is test-coverage (audit and add tests for existing code). If the checkout flow did not exist yet, this would be TDD. The distinguishing signal is whether code exists."
+      "reasoning": "Same verb ('write tests') but context determines the skill. When the code already exists and is in production, this is test-coverage (audit and add tests for existing code). If the checkout flow did not exist yet, this would be TDD. The distinguishing signal is whether code exists.",
+      "difficulty": "hard"
     },
     {
       "id": "review-direction-direct-01",
@@ -58,9 +77,13 @@
       "boundary": "review-direction",
       "prompt": "I'm done with the feature branch. Can you review my changes before I create a PR?",
       "expected_skill": "code-review",
-      "common_mistakes": ["review-feedback", "quality-gate"],
+      "common_mistakes": [
+        "review-feedback",
+        "quality-gate"
+      ],
       "context": "User is requesting a review of their own work before submission. No external feedback has been received.",
-      "reasoning": "Code-review is for when you want your work reviewed — requesting a review. Review-feedback is for when you have RECEIVED review comments and need to process them. The direction is outbound (requesting review), not inbound (receiving feedback)."
+      "reasoning": "Code-review is for when you want your work reviewed \u2014 requesting a review. Review-feedback is for when you have RECEIVED review comments and need to process them. The direction is outbound (requesting review), not inbound (receiving feedback).",
+      "difficulty": "easy"
     },
     {
       "id": "review-direction-direct-02",
@@ -68,9 +91,12 @@
       "boundary": "review-direction",
       "prompt": "I got 6 comments on my PR from the tech lead. Help me work through them.",
       "expected_skill": "review-feedback",
-      "common_mistakes": ["code-review"],
+      "common_mistakes": [
+        "code-review"
+      ],
       "context": "User has received review feedback on a PR and needs to process and respond to the comments.",
-      "reasoning": "Review-feedback handles inbound review comments — analyzing them for technical merit, identifying unclear or contradictory items, and determining the right response. Code-review would be requesting a new review, which is the wrong direction."
+      "reasoning": "Review-feedback handles inbound review comments \u2014 analyzing them for technical merit, identifying unclear or contradictory items, and determining the right response. Code-review would be requesting a new review, which is the wrong direction.",
+      "difficulty": "easy"
     },
     {
       "id": "review-direction-negative-01",
@@ -78,9 +104,12 @@
       "boundary": "review-direction",
       "prompt": "The senior dev left some comments on my PR saying 'looks good, just clean up the naming'. Help me with the review.",
       "expected_skill": "review-feedback",
-      "common_mistakes": ["code-review"],
+      "common_mistakes": [
+        "code-review"
+      ],
       "context": "Despite using the word 'review', the user has RECEIVED feedback and needs to process it. The feedback is inbound.",
-      "reasoning": "The word 'review' appears but the direction is inbound — the user received comments and needs to process them. Review-feedback handles this. Code-review would be wrong because the user is not requesting a fresh review of their code."
+      "reasoning": "The word 'review' appears but the direction is inbound \u2014 the user received comments and needs to process them. Review-feedback handles this. Code-review would be wrong because the user is not requesting a fresh review of their code.",
+      "difficulty": "medium"
     },
     {
       "id": "review-direction-context-01",
@@ -88,9 +117,13 @@
       "boundary": "review-direction",
       "prompt": "Review this code.",
       "expected_skill": "code-review",
-      "common_mistakes": ["review-feedback", "audit"],
-      "context": "User is presenting their own code and asking for a review. No prior feedback exists — this is a request for review.",
-      "reasoning": "Same word 'review' but context determines direction. Here the user is requesting a review (outbound) — code-review. If the user had said 'I got a review on this code, help me address it', the direction would be inbound — review-feedback. Audit would be wrong because the user is asking for a targeted review, not a multi-lens adversarial subsystem audit."
+      "common_mistakes": [
+        "review-feedback",
+        "audit"
+      ],
+      "context": "User is presenting their own code and asking for a review. No prior feedback exists \u2014 this is a request for review.",
+      "reasoning": "Same word 'review' but context determines direction. Here the user is requesting a review (outbound) \u2014 code-review. If the user had said 'I got a review on this code, help me address it', the direction would be inbound \u2014 review-feedback. Audit would be wrong because the user is asking for a targeted review, not a multi-lens adversarial subsystem audit.",
+      "difficulty": "easy"
     },
     {
       "id": "adversarial-scope-direct-01",
@@ -98,29 +131,44 @@
       "boundary": "adversarial-scope",
       "prompt": "I just finished the design doc for the new notification service. Red-team it.",
       "expected_skill": "red-team",
-      "common_mistakes": ["audit", "quality-gate", "siege"],
+      "common_mistakes": [
+        "audit",
+        "quality-gate",
+        "siege"
+      ],
       "context": "Single artifact (design doc) ready for adversarial review. Not a full codebase review, not a security audit.",
-      "reasoning": "Red-team is for adversarial review of a single artifact (design doc, plan, code, PR). Audit reviews existing codebase subsystems through parallel lenses. Quality-gate iterates with fixes until clean. Siege is specifically security-focused. The key signal is 'red-team it' on a single artifact."
+      "reasoning": "Red-team is for adversarial review of a single artifact (design doc, plan, code, PR). Audit reviews existing codebase subsystems through parallel lenses. Quality-gate iterates with fixes until clean. Siege is specifically security-focused. The key signal is 'red-team it' on a single artifact.",
+      "difficulty": "easy"
     },
     {
       "id": "adversarial-scope-direct-02",
       "dimension": "direct",
       "boundary": "adversarial-scope",
-      "prompt": "The payment module has been in production for a year. I want a thorough review of the whole subsystem — correctness, robustness, architecture, everything.",
+      "prompt": "The payment module has been in production for a year. I want a thorough review of the whole subsystem \u2014 correctness, robustness, architecture, everything.",
       "expected_skill": "audit",
-      "common_mistakes": ["red-team", "code-review", "prospector"],
-      "context": "Existing codebase subsystem, multi-dimensional review requested. Not a single artifact — an entire subsystem with multiple files.",
-      "reasoning": "Audit dispatches parallel analysis agents across four lenses (correctness, robustness, consistency, architecture) on an existing subsystem. Red-team reviews a single artifact. Code-review is lighter-weight. Prospector looks for architectural friction across the whole codebase, not a specific subsystem."
+      "common_mistakes": [
+        "red-team",
+        "code-review",
+        "prospector"
+      ],
+      "context": "Existing codebase subsystem, multi-dimensional review requested. Not a single artifact \u2014 an entire subsystem with multiple files.",
+      "reasoning": "Audit dispatches parallel analysis agents across four lenses (correctness, robustness, consistency, architecture) on an existing subsystem. Red-team reviews a single artifact. Code-review is lighter-weight. Prospector looks for architectural friction across the whole codebase, not a specific subsystem.",
+      "difficulty": "medium"
     },
     {
       "id": "adversarial-scope-negative-01",
       "dimension": "negative",
       "boundary": "adversarial-scope",
-      "prompt": "We just assembled the full feature — auth, API routes, database migrations, and frontend. Hunt for cross-component bugs before we ship.",
+      "prompt": "We just assembled the full feature \u2014 auth, API routes, database migrations, and frontend. Hunt for cross-component bugs before we ship.",
       "expected_skill": "inquisitor",
-      "common_mistakes": ["audit", "red-team", "adversarial-tester"],
+      "common_mistakes": [
+        "audit",
+        "red-team",
+        "adversarial-tester"
+      ],
       "context": "Full feature assembled from multiple components. Need to find integration issues across component boundaries, not review a single artifact or existing subsystem.",
-      "reasoning": "Inquisitor runs 5 parallel adversarial dimensions against the complete implementation diff to find cross-component bugs. Audit reviews existing subsystems (this is new code). Red-team reviews single artifacts. Adversarial-tester finds edge cases in a single implementation, not cross-component integration issues."
+      "reasoning": "Inquisitor runs 5 parallel adversarial dimensions against the complete implementation diff to find cross-component bugs. Audit reviews existing subsystems (this is new code). Red-team reviews single artifacts. Adversarial-tester finds edge cases in a single implementation, not cross-component integration issues.",
+      "difficulty": "hard"
     },
     {
       "id": "adversarial-scope-context-01",
@@ -128,19 +176,27 @@
       "boundary": "adversarial-scope",
       "prompt": "Audit this for security vulnerabilities.",
       "expected_skill": "siege",
-      "common_mistakes": ["audit", "red-team"],
+      "common_mistakes": [
+        "audit",
+        "red-team"
+      ],
       "context": "Despite using the word 'audit', the focus is specifically on security. This narrows the scope from general audit to security audit.",
-      "reasoning": "Siege is the security-specific audit — dispatches 6 parallel agents across attacker perspectives, iterates until zero Critical + zero High findings. General audit covers correctness, robustness, consistency, architecture — broader but not security-deep. The 'security vulnerabilities' qualifier triggers siege over audit."
+      "reasoning": "Siege is the security-specific audit \u2014 dispatches 6 parallel agents across attacker perspectives, iterates until zero Critical + zero High findings. General audit covers correctness, robustness, consistency, architecture \u2014 broader but not security-deep. The 'security vulnerabilities' qualifier triggers siege over audit.",
+      "difficulty": "hard"
     },
     {
       "id": "completion-claims-direct-01",
       "dimension": "direct",
       "boundary": "completion-claims",
-      "prompt": "I just ran the tests and they all pass — here's the output:\n\n```\n$ npm test\n  12 passing (340ms)\n  0 failing\n```\n\nFeature works end-to-end. Let's create a PR and merge.",
+      "prompt": "I just ran the tests and they all pass \u2014 here's the output:\n\n```\n$ npm test\n  12 passing (340ms)\n  0 failing\n```\n\nFeature works end-to-end. Let's create a PR and merge.",
       "expected_skill": "finish",
-      "common_mistakes": ["verify", "code-review"],
+      "common_mistakes": [
+        "verify",
+        "code-review"
+      ],
       "context": "User has provided fresh test evidence in the current message. Verification is satisfied. This is now an integration decision.",
-      "reasoning": "Finish guides completion — presenting options for merge, PR, or cleanup. Verify gathers evidence, but the user just provided fresh evidence (test output in the current message). The remaining decision is how to integrate the work, which is finish's domain."
+      "reasoning": "Finish guides completion \u2014 presenting options for merge, PR, or cleanup. Verify gathers evidence, but the user just provided fresh evidence (test output in the current message). The remaining decision is how to integrate the work, which is finish's domain.",
+      "difficulty": "easy"
     },
     {
       "id": "completion-claims-direct-02",
@@ -148,9 +204,13 @@
       "boundary": "completion-claims",
       "prompt": "I think the migration is done. Can you confirm everything actually works?",
       "expected_skill": "verify",
-      "common_mistakes": ["finish", "test-coverage"],
+      "common_mistakes": [
+        "finish",
+        "test-coverage"
+      ],
       "context": "User is uncertain about completion. They need evidence, not an integration decision.",
-      "reasoning": "Verify runs verification commands and confirms output before any success claims — evidence before assertions. The user says 'I think' (uncertain) and 'confirm everything works' (needs evidence). Finish would be premature — the user has not yet confirmed the work is correct."
+      "reasoning": "Verify runs verification commands and confirms output before any success claims \u2014 evidence before assertions. The user says 'I think' (uncertain) and 'confirm everything works' (needs evidence). Finish would be premature \u2014 the user has not yet confirmed the work is correct.",
+      "difficulty": "easy"
     },
     {
       "id": "completion-claims-negative-01",
@@ -158,9 +218,12 @@
       "boundary": "completion-claims",
       "prompt": "Everything looks good to me. Ship it!",
       "expected_skill": "verify",
-      "common_mistakes": ["finish"],
+      "common_mistakes": [
+        "finish"
+      ],
       "context": "User claims completion but has not provided evidence of running tests or verification commands in the current session. 'Looks good to me' is a subjective claim, not verified evidence.",
-      "reasoning": "Despite the user's confidence, verify requires fresh evidence in the current session. 'Looks good to me' is not the same as 'tests pass and here is the output'. Verify must run before finish — the completion claim needs evidence backing."
+      "reasoning": "Despite the user's confidence, verify requires fresh evidence in the current session. 'Looks good to me' is not the same as 'tests pass and here is the output'. Verify must run before finish \u2014 the completion claim needs evidence backing.",
+      "difficulty": "hard"
     },
     {
       "id": "completion-claims-context-01",
@@ -168,9 +231,12 @@
       "boundary": "completion-claims",
       "prompt": "Tests pass, CI is green, and the PR has two approvals. What now?",
       "expected_skill": "finish",
-      "common_mistakes": ["verify"],
-      "context": "All verification signals present: tests pass, CI green, peer approvals received. The user is asking what the next step is — this is an integration decision.",
-      "reasoning": "Same completion-area prompt as other evals in this boundary, but context includes strong evidence (tests, CI, approvals). With evidence satisfied, the question 'what now?' is an integration decision — finish. If evidence were missing, verify would be correct. The distinguishing context is the presence of multiple verification signals."
+      "common_mistakes": [
+        "verify"
+      ],
+      "context": "All verification signals present: tests pass, CI green, peer approvals received. The user is asking what the next step is \u2014 this is an integration decision.",
+      "reasoning": "Same completion-area prompt as other evals in this boundary, but context includes strong evidence (tests, CI, approvals). With evidence satisfied, the question 'what now?' is an integration decision \u2014 finish. If evidence were missing, verify would be correct. The distinguishing context is the presence of multiple verification signals.",
+      "difficulty": "medium"
     },
     {
       "id": "bug-handling-direct-01",
@@ -178,9 +244,13 @@
       "boundary": "bug-handling",
       "prompt": "This endpoint returns 500 sometimes. Here's the error log showing a NullPointerException in the order handler.",
       "expected_skill": "debugging",
-      "common_mistakes": ["verify", "audit"],
+      "common_mistakes": [
+        "verify",
+        "audit"
+      ],
       "context": "Active failure with error evidence. This is a bug to investigate and fix, not a completion check or subsystem review.",
-      "reasoning": "Debugging handles active failures — bugs, test failures, unexpected behavior. The user has an error log showing a specific failure. Verify checks completion claims (no active failure here). Audit reviews subsystems (this is a specific bug, not a broad review)."
+      "reasoning": "Debugging handles active failures \u2014 bugs, test failures, unexpected behavior. The user has an error log showing a specific failure. Verify checks completion claims (no active failure here). Audit reviews subsystems (this is a specific bug, not a broad review).",
+      "difficulty": "easy"
     },
     {
       "id": "bug-handling-direct-02",
@@ -188,9 +258,13 @@
       "boundary": "bug-handling",
       "prompt": "The tests pass but users are reporting that search results are wrong. Something is off.",
       "expected_skill": "debugging",
-      "common_mistakes": ["verify", "test-coverage"],
-      "context": "Tests pass but behavior is wrong. This is a bug — the tests are insufficient or the bug is in an untested path.",
-      "reasoning": "Despite tests passing, there is unexpected behavior (wrong search results). This is a debugging scenario — investigate the root cause. Verify would just re-run the (already passing) tests. Test-coverage would audit test quality but not investigate the specific user-reported issue."
+      "common_mistakes": [
+        "verify",
+        "test-coverage"
+      ],
+      "context": "Tests pass but behavior is wrong. This is a bug \u2014 the tests are insufficient or the bug is in an untested path.",
+      "reasoning": "Despite tests passing, there is unexpected behavior (wrong search results). This is a debugging scenario \u2014 investigate the root cause. Verify would just re-run the (already passing) tests. Test-coverage would audit test quality but not investigate the specific user-reported issue.",
+      "difficulty": "medium"
     },
     {
       "id": "bug-handling-context-01",
@@ -198,39 +272,65 @@
       "boundary": "bug-handling",
       "prompt": "Something is wrong with the caching system.",
       "expected_skill": "debugging",
-      "common_mistakes": ["audit", "verify"],
-      "context": "User reports something is wrong — this is an active problem, not a proactive review. The phrasing indicates a current issue, not a desire for broad subsystem review.",
-      "reasoning": "'Something is wrong' signals an active problem — debugging territory. If the user said 'review the caching system for potential issues', that would be audit (proactive review). If they said 'verify the caching system works', that would be verify. The 'wrong' qualifier indicates a bug to investigate."
+      "common_mistakes": [
+        "audit",
+        "verify"
+      ],
+      "context": "User reports something is wrong \u2014 this is an active problem, not a proactive review. The phrasing indicates a current issue, not a desire for broad subsystem review.",
+      "reasoning": "'Something is wrong' signals an active problem \u2014 debugging territory. If the user said 'review the caching system for potential issues', that would be audit (proactive review). If they said 'verify the caching system works', that would be verify. The 'wrong' qualifier indicates a bug to investigate.",
+      "difficulty": "medium"
     },
     {
       "id": "cascade-ordering-01",
       "dimension": "cascade",
       "boundary": "review-direction",
       "prompt": "I want to add a webhook retry system with exponential backoff. Let's design it and build it properly.",
-      "expected_skill": ["design", "build"],
-      "common_mistakes": ["build", "planning"],
+      "expected_skill": [
+        "design",
+        "build"
+      ],
+      "common_mistakes": [
+        "build",
+        "planning"
+      ],
       "context": "New feature requiring both design exploration and implementation. The user wants the full pipeline. Tests design-before-build ordering discipline.",
-      "reasoning": "Design must come before build — 'design it and build it' is the correct sequence. Skipping design and going straight to build violates the design-before-build discipline. Planning alone is insufficient — it produces a task list but not the design exploration. The correct cascade is design (explored questions, investigated options) then build (implementation pipeline)."
+      "reasoning": "Design must come before build \u2014 'design it and build it' is the correct sequence. Skipping design and going straight to build violates the design-before-build discipline. Planning alone is insufficient \u2014 it produces a task list but not the design exploration. The correct cascade is design (explored questions, investigated options) then build (implementation pipeline).",
+      "difficulty": "medium"
     },
     {
       "id": "cascade-ordering-02",
       "dimension": "cascade",
       "boundary": "bug-handling",
       "prompt": "The payment processor is double-charging some customers. Fix it and make sure it's actually fixed before we deploy.",
-      "expected_skill": ["debugging", "verify"],
-      "common_mistakes": ["debugging", "finish"],
+      "expected_skill": [
+        "debugging",
+        "verify"
+      ],
+      "common_mistakes": [
+        "debugging",
+        "finish"
+      ],
       "context": "Active bug requiring investigation, fix, and verified confirmation before deployment.",
-      "reasoning": "Debugging investigates root cause and implements fix. Verify then confirms the fix actually works with fresh evidence. Skipping verify after debugging and going straight to finish (deploy) risks deploying an unverified fix. The correct cascade is debugging (find and fix) then verify (prove it works)."
+      "reasoning": "Debugging investigates root cause and implements fix. Verify then confirms the fix actually works with fresh evidence. Skipping verify after debugging and going straight to finish (deploy) risks deploying an unverified fix. The correct cascade is debugging (find and fix) then verify (prove it works).",
+      "difficulty": "medium"
     },
     {
       "id": "cascade-ordering-03",
       "dimension": "cascade",
       "boundary": "test-methodology",
       "prompt": "I need to add real-time notifications to the dashboard. Let's think through the design, plan the tasks, then build it.",
-      "expected_skill": ["design", "planning", "build"],
-      "common_mistakes": ["build", "design"],
+      "expected_skill": [
+        "design",
+        "planning",
+        "build"
+      ],
+      "common_mistakes": [
+        "build",
+        "design"
+      ],
       "context": "User explicitly requests the full pipeline: design exploration, task planning, then implementation.",
-      "reasoning": "The user spells out the three-phase cascade: design (explore options, investigate questions), planning (break into tasks with ordering), build (implement). Skipping to build alone misses design exploration. Design alone misses the planning phase that produces the task breakdown. The full sequence ensures each phase informs the next."
+      "reasoning": "The user spells out the three-phase cascade: design (explore options, investigate questions), planning (break into tasks with ordering), build (implement). Skipping to build alone misses design exploration. Design alone misses the planning phase that produces the task breakdown. The full sequence ensures each phase informs the next.",
+      "difficulty": "hard"
     }
   ]
 }

--- a/skills/skill-selection-evals/evals/evals.json
+++ b/skills/skill-selection-evals/evals/evals.json
@@ -136,11 +136,11 @@
       "id": "completion-claims-direct-01",
       "dimension": "direct",
       "boundary": "completion-claims",
-      "prompt": "Tests pass and the feature works. Let's create a PR and merge.",
+      "prompt": "I just ran the tests and they all pass — here's the output:\n\n```\n$ npm test\n  12 passing (340ms)\n  0 failing\n```\n\nFeature works end-to-end. Let's create a PR and merge.",
       "expected_skill": "finish",
       "common_mistakes": ["verify", "code-review"],
-      "context": "User has verified tests pass and wants to ship. This is an integration decision — how to get the work into the codebase.",
-      "reasoning": "Finish guides completion — presenting options for merge, PR, or cleanup. Verify gathers evidence (running tests, confirming output). The user has already gathered evidence ('tests pass'). The remaining decision is how to integrate the work, which is finish's domain."
+      "context": "User has provided fresh test evidence in the current message. Verification is satisfied. This is now an integration decision.",
+      "reasoning": "Finish guides completion — presenting options for merge, PR, or cleanup. Verify gathers evidence, but the user just provided fresh evidence (test output in the current message). The remaining decision is how to integrate the work, which is finish's domain."
     },
     {
       "id": "completion-claims-direct-02",
@@ -166,11 +166,11 @@
       "id": "completion-claims-context-01",
       "dimension": "context-dependent",
       "boundary": "completion-claims",
-      "prompt": "We're done here.",
-      "expected_skill": "verify",
-      "common_mistakes": ["finish"],
-      "context": "No test output or verification evidence has been presented in the conversation. The completion claim is unsupported.",
-      "reasoning": "Same completion signal but context matters. If tests had been run and confirmed passing earlier in the conversation, this would trigger finish (integration decision). Without evidence, 'we're done' should trigger verify first — evidence before assertions. The absence of prior verification is the distinguishing context."
+      "prompt": "Tests pass, CI is green, and the PR has two approvals. What now?",
+      "expected_skill": "finish",
+      "common_mistakes": ["verify"],
+      "context": "All verification signals present: tests pass, CI green, peer approvals received. The user is asking what the next step is — this is an integration decision.",
+      "reasoning": "Same completion-area prompt as other evals in this boundary, but context includes strong evidence (tests, CI, approvals). With evidence satisfied, the question 'what now?' is an integration decision — finish. If evidence were missing, verify would be correct. The distinguishing context is the presence of multiple verification signals."
     },
     {
       "id": "bug-handling-direct-01",
@@ -203,17 +203,17 @@
       "reasoning": "'Something is wrong' signals an active problem — debugging territory. If the user said 'review the caching system for potential issues', that would be audit (proactive review). If they said 'verify the caching system works', that would be verify. The 'wrong' qualifier indicates a bug to investigate."
     },
     {
-      "id": "cascade-direct-01",
+      "id": "cascade-ordering-01",
       "dimension": "cascade",
-      "boundary": "test-methodology",
+      "boundary": "review-direction",
       "prompt": "I want to add a webhook retry system with exponential backoff. Let's design it and build it properly.",
       "expected_skill": ["design", "build"],
       "common_mistakes": ["build", "planning"],
-      "context": "New feature requiring both design exploration and implementation. The user wants the full pipeline.",
+      "context": "New feature requiring both design exploration and implementation. The user wants the full pipeline. Tests design-before-build ordering discipline.",
       "reasoning": "Design must come before build — 'design it and build it' is the correct sequence. Skipping design and going straight to build violates the design-before-build discipline. Planning alone is insufficient — it produces a task list but not the design exploration. The correct cascade is design (explored questions, investigated options) then build (implementation pipeline)."
     },
     {
-      "id": "cascade-direct-02",
+      "id": "cascade-ordering-02",
       "dimension": "cascade",
       "boundary": "bug-handling",
       "prompt": "The payment processor is double-charging some customers. Fix it and make sure it's actually fixed before we deploy.",
@@ -223,9 +223,9 @@
       "reasoning": "Debugging investigates root cause and implements fix. Verify then confirms the fix actually works with fresh evidence. Skipping verify after debugging and going straight to finish (deploy) risks deploying an unverified fix. The correct cascade is debugging (find and fix) then verify (prove it works)."
     },
     {
-      "id": "cascade-direct-03",
+      "id": "cascade-ordering-03",
       "dimension": "cascade",
-      "boundary": "completion-claims",
+      "boundary": "test-methodology",
       "prompt": "I need to add real-time notifications to the dashboard. Let's think through the design, plan the tasks, then build it.",
       "expected_skill": ["design", "planning", "build"],
       "common_mistakes": ["build", "design"],


### PR DESCRIPTION
## Summary

- Adds 23 skill-selection evals testing whether the agent routes to the correct skill for a given prompt
- Covers all 5 highest-collision skill boundaries: test-methodology, review-direction, adversarial-scope, completion-claims, bug-handling
- Tests 4 eval dimensions: direct selection (11), negative selection (4), context-dependent (5), cascade ordering (3)
- Each eval includes difficulty rating (easy/medium/hard) for stratified baseline measurement
- Includes GRADING.md with baseline measurement protocol and integration guide

## Acceptance Criteria Verification

- [x] Eval format defined in `skills/skill-selection-evals/evals/evals.json`
- [x] 23 selection evals (>= 20 required)
- [x] All 5 boundaries covered with >= 3 evals each
- [x] 5 context-dependent evals (>= 3 required)
- [x] 3 cascade-ordering evals (>= 3 required)
- [x] Baseline measurement approach documented in GRADING.md
- [x] Results integration documented alongside existing execution metrics

## Quality Gate

- Verified all `expected_skill` and `common_mistakes` reference real skill names
- Fixed overly similar completion-claims evals (near-duplicate replaced)
- Strengthened completion-claims-direct-01 with concrete test output evidence
- Fixed misleading cascade eval boundary assignments and IDs

## Innovation

Added difficulty ratings (easy/medium/hard) to enable stratified analysis. Distribution: 9 easy, 8 medium, 6 hard.

Closes #86

## Test plan

- [ ] Validate JSON parses cleanly: `python3 -c "import json; json.load(open('skills/skill-selection-evals/evals/evals.json'))"`
- [ ] Run baseline measurement: present each eval prompt to agent, record selected skill
- [ ] Verify all common_mistakes reference real skills in `skills/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)