### PR TITLE
Improve/skill review optimization

### DIFF
--- a/.github/workflows/skill-preview.yml
+++ b/.github/workflows/skill-preview.yml
@@ -1,0 +1,13 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forge
-description: Use when a significant task completes and you need a retrospective, when starting a new task and want to consult past lessons, or when 10+ retrospectives have accumulated and skill improvements should be proposed
+description: "Runs structured post-mortem retrospectives after completed tasks, producing scored entries in memory/forge/retrospectives/ and updating patterns.md with aggregated lessons learned. Before new tasks, performs feed-forward review of accumulated patterns and chronicle signals to surface targeted warnings. When 10+ retrospectives accumulate with recurring deviations, generates concrete skill mutation proposals for human review. Use when: a task finishes and you need to reflect on what went wrong or what worked, when starting a task and want to review past lessons, when asking 'what did I learn', or when proposing skill improvements from accumulated data."
 ---
 
 # Forge
@@ -77,89 +77,10 @@ All data lives in the project memory directory:
 
 ## Trajectory Capture (Opt-In)
 
-Trajectory capture records structured data about real skill invocations for eval
-generation. It is OFF by default and requires explicit opt-in.
+Trajectory capture records structured data about real skill invocations for eval generation. It is OFF by default and requires explicit opt-in via `~/.claude/projects/<hash>/memory/trajectory-config.json`. If the file does not exist or `enabled` is false, skip all trajectory recording silently.
 
-### Configuration
+For full configuration, redaction rules, storage layout, and failure handling, see [`trajectory-capture.md`](./trajectory-capture.md).
 
-Check for `~/.claude/projects/<hash>/memory/trajectory-config.json` before any
-trajectory operation. If the file does not exist or `enabled` is false, skip all
-trajectory recording silently.
-
-Config schema:
-
-```json
-{
-  "enabled": false,
-  "max_entries": 500,
-  "include_prompt_summary": true,
-  "additional_redact_patterns": []
-}
-```
-
-- `enabled`: Master switch. Default false.
-- `max_entries`: Maximum entries per JSONL file before oldest are pruned. Default 500.
-- `include_prompt_summary`: Whether to include the one-line redacted prompt summary. If false, `prompt_summary` is set to "[omitted]". Default true.
-- `additional_redact_patterns`: List of regex strings for project-specific secret patterns applied during the redaction pass.
-
-### Storage
-
-All trajectory data lives alongside other forge data:
-
-```
-~/.claude/projects/<hash>/memory/trajectories/
-  trajectory_samples.jsonl     # Successful completions
-  failed_trajectories.jsonl    # Failures, partial completions, aborts
-```
-
-### First-Enable Notification
-
-When trajectory capture is first enabled (config file is created or `enabled` transitions
-from false to true), output to the user:
-
-"Trajectory capture is now enabled. Here is what this means:
-- After each significant skill invocation, a structured record is appended to
-  ~/.claude/projects/<hash>/memory/trajectories/
-- Records include: skill name, duration, tool call count, outcome, and a redacted
-  task summary. Raw prompts are NEVER stored.
-- A redaction pass runs before every write to strip file paths, secrets, and
-  sensitive content.
-- You can inspect the JSONL files at any time. They are human-readable.
-- To disable, set enabled: false in trajectory-config.json or delete the file."
-
-### Redaction Rules
-
-Before writing ANY trajectory entry, apply these redaction steps in order:
-
-1. **Prompt summary generation**: Do NOT copy the user's prompt. Instead, generate
-   a one-line summary that captures the task TYPE without revealing specific content.
-   Good: "Add authentication middleware to REST API"
-   Bad: "Add JWT auth to the Acme Corp billing API at /srv/acme/billing/api.py"
-   If `include_prompt_summary` is false in config, set `prompt_summary` to "[omitted]".
-
-2. **File path normalization**: Replace absolute paths with project-relative paths.
-   Replace home directory segments with `~`. Replace username segments with `[user]`.
-   Example: `/home/alice/projects/myapp/src/auth.py` becomes `~/projects/myapp/src/auth.py`
-   or `src/auth.py` if within the project root.
-
-3. **Secret pattern matching**: Scan all string fields for patterns matching:
-   - API keys (strings matching `[A-Za-z0-9_-]{20,}` preceded by key/token/secret/api)
-   - Connection strings (containing `://` with credentials)
-   - Environment variable references with values (`KEY=value` patterns)
-   - Bearer tokens, JWT strings (three dot-separated base64 segments)
-   Replace matches with `[REDACTED]`.
-
-4. **Custom patterns**: Apply each regex in `additional_redact_patterns` from the
-   config file against all string fields. Replace matches with `[REDACTED]`.
-
-5. **Set `redacted` flag**: Only set `redacted: true` after steps 1-4 complete
-   successfully. If any step fails, do NOT write the entry.
-
-### Redaction Failure
-
-If the redaction pass cannot complete (e.g., malformed config, regex error), log a
-warning and skip trajectory recording for this invocation. Do NOT write an unredacted
-entry. Trajectory capture is a nice-to-have — it must never leak sensitive data.
 ---
 
 ## Mode 1: Post-Task Retrospective
@@ -209,92 +130,9 @@ After any skill that completes a significant task reports success. The calling s
    "Extract decisions for cartographer" directive, alongside the module
    mapping from the build session's task list and design doc.
 8. **Trajectory recording** (if trajectory capture is enabled):
-   a. Check `~/.claude/projects/<hash>/memory/trajectory-config.json` — if missing
-      or `enabled: false`, skip this step entirely.
-   b. Construct the raw trajectory entry from execution data available in context:
-      - `trajectory_id`: Generate a UUID
-      - `timestamp`: ISO-8601 of when the skill invocation started
-      - `skill`: The Crucible skill that was invoked (build, debugging, audit, etc.)
-      - `completed`: Whether the skill ran to its natural completion
-      - `outcome`: Derived from the retrospective's `outcome` field (success/partial/failure)
-      - `duration_ms`: From pipeline status timestamps or session timing
-      - `tool_call_count`: Estimated from execution summary
-      - `error_recovery_events`: Count of error-then-retry sequences observed
-      - `user_acceptance`: Whether the user accepted the output (accepted/rejected/modified/unknown)
-      - `phases_reached`: For multi-phase skills, which phases completed
-      - `deviation_type`: From the retrospective entry
-      - `prompt_hash`: SHA-256 of the original user prompt
-      - `prompt_summary`: One-line redacted summary (if `include_prompt_summary` is true)
-      - `redacted`: Set to true only after step (c) completes
-      - `tags`: From the retrospective entry's tags
-   c. Run the redaction pass (see Redaction Rules above).
-   d. Append the entry as a single JSON line to the appropriate file:
-      - If `completed == true` AND `outcome == "success"`: append to `trajectory_samples.jsonl`
-      - Otherwise: append to `failed_trajectories.jsonl`
-   e. Check file size: if the target file exceeds `max_entries` lines, remove the
-      oldest entries (from the top of the file) to bring it back to `max_entries`.
+   Check config, construct the trajectory entry from execution data and retrospective output, run the redaction pass, and append to the appropriate JSONL file. See [`trajectory-capture.md`](./trajectory-capture.md) for the full entry schema, redaction rules, and file routing logic.
 8.5. **Chronicle signal** (always-on — runs regardless of trajectory capture config):
-   a. Construct signal entry from execution data already in context:
-      - `v`: 1 (schema version)
-      - `ts`: ISO-8601 completion timestamp
-      - `skill`: The Crucible skill that just completed
-      - `outcome`: From retrospective's outcome field (success/failure/partial)
-      - `duration_m`: Wall clock minutes from start to completion
-      - `branch`: Current git branch
-      - `files_touched`: Project-relative paths of files modified during the skill invocation
-      - `metrics`: Skill-specific metrics bag (see table below)
-   b. **Compute efficiency sub-object from manifest** (if enriched manifest data is available):
-      1. Locate the dispatch directory from the `.dispatch-active-*` marker in the pipeline's scratch directory, or from the metrics log.
-      2. Read `manifest.jsonl` from the dispatch directory.
-      3. Check whether any manifest entries have `input_chars` populated (non-null). If none do (pre-enrichment run), skip — do NOT include the `efficiency` sub-object (no zeros, no nulls).
-      4. If enriched entries exist, compute:
-         - `total_input_chars`: sum of all `input_chars` values (skip nulls)
-         - `total_output_chars`: sum of all `output_chars` values (skip nulls)
-         - `est_input_tokens`: `total_input_chars / 4` (rounded to nearest integer)
-         - `est_output_tokens`: `total_output_chars / 4` (rounded to nearest integer)
-         - `dispatches_by_tier`: count of dispatches grouped by `model_tier` (e.g., `{"opus": 5, "sonnet": 8, "haiku": 2}`) — skip null tiers
-         - `est_rework_tokens`: for any `seq` with a failed/errored entry followed by a retry, sum the retry's `(input_chars + output_chars) / 4`. `0` if no retries occurred.
-         - `rework_pct`: `est_rework_tokens / (est_input_tokens + est_output_tokens) * 100`, rounded to 1 decimal
-         - `active_work_m`: from existing metrics log computation (overlapping parallel intervals merged)
-         - `wall_clock_m`: from existing duration computation
-      5. Include as `metrics.efficiency` in the signal entry.
-   c. Append as a single JSON line to `~/.claude/projects/<hash>/memory/chronicle/signals.jsonl`
-   d. If the file or directory doesn't exist, create it
-   e. This step does NOT require redaction — signals contain no prompt content,
-      task descriptions, or secrets. Only operational facts.
-
-   **Example signal (with efficiency):**
-   ```jsonl
-   {"v":1,"ts":"2026-03-25T10:00:00Z","skill":"build","outcome":"success","duration_m":42,"branch":"feat/auth-refactor","files_touched":["src/auth/token.ts","src/auth/refresh.ts"],"metrics":{"mode":"feature","tasks":5,"tasks_passed":5,"qg_rounds":3,"review_rounds":2,"stagnation":false,"efficiency":{"total_input_chars":128400,"total_output_chars":82000,"est_input_tokens":32100,"est_output_tokens":20500,"est_rework_tokens":4200,"rework_pct":8.0,"dispatches_by_tier":{"opus":5,"sonnet":8,"haiku":2},"active_work_m":28,"wall_clock_m":42}}}
-   ```
-
-   **Example signal (without efficiency — pre-enrichment or no manifest data):**
-   ```jsonl
-   {"v":1,"ts":"2026-03-25T10:00:00Z","skill":"build","outcome":"success","duration_m":42,"branch":"feat/auth-refactor","files_touched":["src/auth/token.ts","src/auth/refresh.ts"],"metrics":{"mode":"feature","tasks":5,"tasks_passed":5,"qg_rounds":3,"review_rounds":2,"stagnation":false}}
-   ```
-
-   **Metrics bag by skill:**
-
-   | Skill | Metrics |
-   |-------|---------|
-   | build | mode, tasks, tasks_passed, qg_rounds, review_rounds, stagnation |
-   | debugging | hypotheses, root_cause_category, where_else_hits |
-   | quality-gate | artifact_type, rounds, fatals_found, stagnation |
-   | design | questions_investigated, auto_resolved |
-   | planning | task_count, review_rounds |
-   | audit | findings_count, lenses_dispatched |
-   | code-review | rounds, findings_by_severity |
-   | TDD | cycles, red_green_refactor_count |
-   | *all skills* | efficiency (optional sub-object, present only when enriched manifest data exists) |
-
-   **Signal scope rule:** Emit one signal per top-level skill invocation, not per
-   sub-skill dispatch. When build calls quality-gate internally, quality-gate does
-   NOT emit its own signal — its metrics are captured in build's metrics bag.
-   Standalone invocations of quality-gate, code-review, etc. DO emit signals.
-
-   This is self-enforcing: forge retrospective only runs at the end of a top-level
-   skill invocation, so Step 8.5 naturally fires once per top-level skill. Sub-skills
-   called within build do not trigger their own forge retrospective.
+   Construct a signal entry with skill name, outcome, duration, branch, files touched, and skill-specific metrics. Compute the efficiency sub-object from enriched manifest data if available. Append as a single JSON line to `~/.claude/projects/<hash>/memory/chronicle/signals.jsonl`. Emit one signal per top-level skill invocation only (sub-skills do not emit their own signals). See [`chronicle-signals.md`](./chronicle-signals.md) for the full signal schema, efficiency computation, metrics bag by skill, and examples.
 
 9. **Skill extraction check (all sessions):** Evaluate the just-produced
    retrospective entry against the following trigger heuristics. If ANY
@@ -359,34 +197,9 @@ If a skill extraction proposal was generated in step 9, notify the user:
 Do NOT prompt for immediate action. The notification is informational. The user
 decides when (or whether) to act on it.
 
-### Trajectory Recording Without Retrospective
+### Fallback Recording Without Retrospective
 
-Forge retrospective is RECOMMENDED but not REQUIRED. When a significant skill
-completes but no retrospective is triggered (user declines, session ending, quick
-task), trajectory data would be lost.
-
-To handle this, any skill that completes a significant task SHOULD write a
-minimal trajectory entry if:
-- Trajectory capture is enabled
-- No forge retrospective is expected to run in this session
-
-The minimal entry uses `deviation_type: "unknown"`, `tags: []`, and
-`outcome` based on the completion signal alone (success if the skill reported
-success, failure if it reported failure, partial otherwise). The entry still
-goes through the full redaction pass.
-
-This ensures trajectory data is captured even when forge does not run, at the
-cost of less-rich analytical fields. The skill-creator's eval generation pipeline
-handles entries with `deviation_type: "unknown"` by clustering on execution
-metrics alone.
-
-Similarly, any skill that completes a significant task SHOULD append a minimal
-chronicle signal if no forge retrospective is expected to run. The minimal signal
-uses `outcome` from the skill's own completion status, `files_touched` from
-`git diff --name-only`, and whatever metrics are available in context. Chronicle
-signals require no redaction (they contain no prompt content), so the fallback
-path is simpler than trajectory fallback. This ensures chronicle data is captured
-even when forge does not run.
+When a significant skill completes but no forge retrospective runs (user declines, session ending), skills SHOULD still write minimal trajectory entries and chronicle signals to avoid data loss. See [`trajectory-capture.md`](./trajectory-capture.md) and [`chronicle-signals.md`](./chronicle-signals.md) for fallback recording details.
 
 ---
 
@@ -404,20 +217,7 @@ Before `crucible:design`, `crucible:planning`, or `crucible:build` begins its co
 3.5. **Chronicle context** (always-on):
     a. Check if `~/.claude/projects/<hash>/memory/chronicle/signals.jsonl` exists
     b. If not found: skip (cold start — no chronicle data yet)
-    c. If found: compare `signals.jsonl` mtime with `chronicle/summary.md` mtime
-       - If `summary.md` doesn't exist OR `signals.jsonl` is newer: regenerate `summary.md`
-       - **Regeneration:** Read all signals from `signals.jsonl`, compute:
-         - **Hotspots:** Group `files_touched` by cartographer module (if module maps exist
-           in `memory/cartographer/modules/`) or by directory prefix. A module qualifies as
-           a hotspot when it has 3+ signals with friction indicators (`stagnation=true`,
-           `metrics.qg_rounds>2`, `skill="debugging"`, or `outcome="failure"/"stagnation"`).
-           Show top 5 hotspots sorted by signal count.
-         - **Skill Performance:** Aggregate runs, avg duration, avg QG rounds, stagnation
-           rate, success rate per skill. Cap at 8 rows.
-         - **Trends:** Compare last 10 signals vs prior 10 for key metrics.
-         - **Recent Friction:** Last 5 signals with friction indicators.
-         - **Hard cap at 100 lines** — drop Trends and Recent Friction sections first if needed.
-       - Write regenerated summary to `chronicle/summary.md`
+    c. If found: compare `signals.jsonl` mtime with `chronicle/summary.md` mtime. If `summary.md` doesn't exist or is stale, regenerate it (see [`chronicle-signals.md`](./chronicle-signals.md) for regeneration logic — computes hotspots, skill performance, trends, recent friction; hard cap 100 lines).
     d. Load `chronicle/summary.md` into context alongside `patterns.md`
     e. Pass both to the Feed-Forward Advisor in Step 4
 3.7. **Dead-end context** (if cartographer data exists):
@@ -510,82 +310,25 @@ descriptions from the skill directories to check for overlap.
 ## Red Flags
 
 **Never:**
-- Skip retrospective because "task was simple"
-- Let `patterns.md` exceed 200 lines
-- Auto-modify any skill file
+- Skip retrospective because "task was simple" — simple tasks reveal patterns too (2 min max)
+- Let `patterns.md` exceed 200 lines — prune entries not seen in last 10 retros
+- Auto-modify any skill file or auto-create skills — Iron Law: proposals only, humans decide
 - Load individual retrospective files into feed-forward (context bloat)
-- Run mutation analysis with fewer than 10 retrospectives
-- Treat feed-forward warnings as hard blockers (they are advisories)
-- Auto-create skills from extraction proposals (Iron Law applies to extraction too)
-- Dispatch skill-creator from within the forge pipeline
-- Generate skill proposals for trivial workflows (single-step, domain-specific)
-- Propose a new skill when an existing skill already covers the workflow
-- Store raw user prompts in trajectory files — only store prompt hashes and redacted summaries
-- Write a trajectory entry without completing the redaction pass
-- Auto-enable trajectory capture — it must be explicitly opted into via config file
-- Include prompt content or task descriptions in chronicle signals — signals are operational metrics only
+- Run mutation analysis with fewer than 10 retrospectives — below that, patterns are noise
+- Treat feed-forward warnings as hard blockers — they are bias adjustments, not constraints
+- Propose skills for trivial or project-specific workflows (single-step, domain-specific infra)
+- Store raw user prompts in trajectory files — only prompt hashes and redacted summaries
+- Write a trajectory entry without completing the full redaction pass
+- Include prompt content or task descriptions in chronicle signals — operational metrics only
 
 **Always:**
-- Run retrospective after significant tasks
-- Check for patterns.md before design/planning
-- Write mutation proposals to disk for human review
-- Handle cold start gracefully (no data = no feed-forward, just say so)
-- Check existing skill descriptions before flagging a workflow as "novel"
-- Include confidence level on every extraction proposal
-- Write proposals to disk before notifying the user
-- Check trajectory-config.json before any trajectory operation
-- Run the full redaction pass before writing any trajectory entry
-- Set `redacted: true` only after the redaction pass completes
+- Run retrospective after significant tasks — "I'll do it later" means never
+- Check for `patterns.md` before design/planning; handle cold start gracefully
+- Write mutation/extraction proposals to disk for human review before notifying
+- Check `trajectory-config.json` before any trajectory operation; never auto-enable
 - Append a chronicle signal after every significant task retrospective (Step 8.5)
-
-## Rationalization Prevention
-
-| Excuse | Reality |
-|--------|---------|
-| "Task was too simple for a retrospective" | Simple tasks reveal patterns too. 2 minutes max. |
-| "No time for retrospective" | Retrospective prevents the NEXT task from repeating the mistake. |
-| "Feed-forward data is stale" | Prune mechanism handles staleness. Read it anyway. |
-| "Mutation proposal is obviously correct, just apply it" | Iron Law: proposals only. Humans decide. |
-| "Only one data point, feed-forward is useless" | Even one warning is better than none. Report limited data. |
-| "I'll run the retrospective later" | Later never comes. Run it now, while context is fresh. |
-| "I already know what went wrong" | Knowing is not recording. Write it down so FUTURE sessions know too. |
-| "This workflow is obviously worth a skill, just create it" | Iron Law: proposals only. Humans decide. Even the best-looking workflow may be a one-off. |
-| "Every session has a skill-worthy pattern" | If >30% of retrospectives trigger proposals, the heuristics are too loose. Tighten them. |
-| "The proposal is low-confidence, not worth writing" | Low-confidence proposals are seeds. They become medium when they recur. Write them down. |
-| "Trajectory data is too noisy to be useful" | Even noisy data reveals patterns at scale. 10 failed trajectories with the same deviation type IS a signal. |
-| "I'll enable trajectory capture later" | Later means no data for the current project. Enable it now if you want eval generation from real usage. |
-| "The redaction pass is too conservative" | Conservative redaction protects the user. A missed eval scenario is cheaper than a leaked secret. |
-| "This task is too small to record" | Small tasks reveal patterns too. The trajectory entry is one JSON line — the cost is negligible. |
-
-## Common Mistakes
-
-**Bloating patterns.md**
-- Problem: patterns.md grows past 200 lines, consuming context budget
-- Fix: Prune patterns not seen in last 10 retros. Compress entries. Merge similar warnings.
-
-**Skipping feed-forward on cold start**
-- Problem: Announcing "no data" without checking the file path
-- Fix: Always check the file path. If missing, say so and proceed. If exists with 1 entry, use it.
-
-**Treating warnings as requirements**
-- Problem: Feed-forward says "watch for over-engineering" and agent refuses to build anything
-- Fix: Warnings are bias adjustments, not hard constraints. Note them and proceed.
-
-**Running mutation analysis too early**
-- Problem: 3 retrospectives, agent proposes sweeping skill changes
-- Fix: Minimum 10 retrospectives. Below that, patterns are noise.
-
-**Proposing skills for domain-specific workflows**
-- Problem: Agent proposes a skill for "deploying to our specific Kubernetes cluster" -- a workflow only useful for this one project
-- Fix: The extraction analyst must assess generalizability. Workflows that reference project-specific infrastructure, APIs, or conventions are positive patterns, not skill candidates.
-
-**Ignoring extraction proposals**
-- Problem: Proposals accumulate in skill-proposals/ and are never reviewed
-- Fix: During feed-forward, the advisor can surface pending proposals as a reminder: "N skill proposals awaiting review." Users should periodically review and accept/reject.
-
-**Duplicate proposals from extraction and mutation**
-- Problem: Mode 3 mutation analysis recommends a new skill that extraction already proposed
-- Fix: Mutation analyst cross-references skill-proposals/ before recommending new skills. If a proposal exists, add evidence to it.
+- Cross-reference `skill-proposals/` before generating new proposals to avoid duplicates
+- If `>30%` of retrospectives trigger extraction proposals, tighten the heuristics
 
 ## Prompt Templates
 

--- a/skills/forge/chronicle-signals.md
+++ b/skills/forge/chronicle-signals.md
@@ -1,0 +1,88 @@
+# Chronicle Signals Reference
+
+Chronicle signals are always-on operational metrics appended after every significant task retrospective (Step 8.5). They contain no prompt content or task descriptions — only operational facts. No redaction is required.
+
+## Signal Schema
+
+Each signal is a single JSON line appended to `~/.claude/projects/<hash>/memory/chronicle/signals.jsonl`:
+
+- `v`: 1 (schema version)
+- `ts`: ISO-8601 completion timestamp
+- `skill`: The Crucible skill that just completed
+- `outcome`: From retrospective's outcome field (success/failure/partial)
+- `duration_m`: Wall clock minutes from start to completion
+- `branch`: Current git branch
+- `files_touched`: Project-relative paths of files modified during the skill invocation
+- `metrics`: Skill-specific metrics bag (see table below)
+
+If the file or directory doesn't exist, create it.
+
+## Efficiency Sub-Object Computation
+
+The `metrics.efficiency` sub-object is computed from enriched manifest data when available. If no enriched manifest entries exist (pre-enrichment run), omit the sub-object entirely — no zeros, no nulls.
+
+When enriched entries exist:
+
+1. Locate the dispatch directory from the `.dispatch-active-*` marker in the pipeline's scratch directory, or from the metrics log.
+2. Read `manifest.jsonl` from the dispatch directory.
+3. Check whether any manifest entries have `input_chars` populated (non-null). If none do, skip.
+4. If enriched entries exist, compute:
+   - `total_input_chars`: sum of all `input_chars` values (skip nulls)
+   - `total_output_chars`: sum of all `output_chars` values (skip nulls)
+   - `est_input_tokens`: `total_input_chars / 4` (rounded to nearest integer)
+   - `est_output_tokens`: `total_output_chars / 4` (rounded to nearest integer)
+   - `dispatches_by_tier`: count of dispatches grouped by `model_tier` (e.g., `{"opus": 5, "sonnet": 8, "haiku": 2}`) — skip null tiers
+   - `est_rework_tokens`: for any `seq` with a failed/errored entry followed by a retry, sum the retry's `(input_chars + output_chars) / 4`. `0` if no retries occurred.
+   - `rework_pct`: `est_rework_tokens / (est_input_tokens + est_output_tokens) * 100`, rounded to 1 decimal
+   - `active_work_m`: from existing metrics log computation (overlapping parallel intervals merged)
+   - `wall_clock_m`: from existing duration computation
+5. Include as `metrics.efficiency` in the signal entry.
+
+## Signal Examples
+
+**With efficiency (enriched manifest data available):**
+```jsonl
+{"v":1,"ts":"2026-03-25T10:00:00Z","skill":"build","outcome":"success","duration_m":42,"branch":"feat/auth-refactor","files_touched":["src/auth/token.ts","src/auth/refresh.ts"],"metrics":{"mode":"feature","tasks":5,"tasks_passed":5,"qg_rounds":3,"review_rounds":2,"stagnation":false,"efficiency":{"total_input_chars":128400,"total_output_chars":82000,"est_input_tokens":32100,"est_output_tokens":20500,"est_rework_tokens":4200,"rework_pct":8.0,"dispatches_by_tier":{"opus":5,"sonnet":8,"haiku":2},"active_work_m":28,"wall_clock_m":42}}}
+```
+
+**Without efficiency (pre-enrichment or no manifest data):**
+```jsonl
+{"v":1,"ts":"2026-03-25T10:00:00Z","skill":"build","outcome":"success","duration_m":42,"branch":"feat/auth-refactor","files_touched":["src/auth/token.ts","src/auth/refresh.ts"],"metrics":{"mode":"feature","tasks":5,"tasks_passed":5,"qg_rounds":3,"review_rounds":2,"stagnation":false}}
+```
+
+## Metrics Bag by Skill
+
+| Skill | Metrics |
+|-------|---------|
+| build | mode, tasks, tasks_passed, qg_rounds, review_rounds, stagnation |
+| debugging | hypotheses, root_cause_category, where_else_hits |
+| quality-gate | artifact_type, rounds, fatals_found, stagnation |
+| design | questions_investigated, auto_resolved |
+| planning | task_count, review_rounds |
+| audit | findings_count, lenses_dispatched |
+| code-review | rounds, findings_by_severity |
+| TDD | cycles, red_green_refactor_count |
+| *all skills* | efficiency (optional sub-object, present only when enriched manifest data exists) |
+
+## Signal Scope Rule
+
+Emit one signal per top-level skill invocation, not per sub-skill dispatch. When build calls quality-gate internally, quality-gate does NOT emit its own signal — its metrics are captured in build's metrics bag. Standalone invocations of quality-gate, code-review, etc. DO emit signals.
+
+This is self-enforcing: forge retrospective only runs at the end of a top-level skill invocation, so Step 8.5 naturally fires once per top-level skill. Sub-skills called within build do not trigger their own forge retrospective.
+
+## Chronicle Signals Without Retrospective
+
+Any skill that completes a significant task SHOULD append a minimal chronicle signal if no forge retrospective is expected to run. The minimal signal uses `outcome` from the skill's own completion status, `files_touched` from `git diff --name-only`, and whatever metrics are available in context. Chronicle signals require no redaction (they contain no prompt content), so the fallback path is simpler than trajectory fallback. This ensures chronicle data is captured even when forge does not run.
+
+## Summary Regeneration (Feed-Forward Context)
+
+During feed-forward (Mode 2, Step 3.5), the chronicle summary is regenerated when `signals.jsonl` is newer than `summary.md`:
+
+1. Read all signals from `signals.jsonl`
+2. Compute:
+   - **Hotspots:** Group `files_touched` by cartographer module (if module maps exist) or by directory prefix. A module qualifies as a hotspot when it has 3+ signals with friction indicators (`stagnation=true`, `metrics.qg_rounds>2`, `skill="debugging"`, or `outcome="failure"/"stagnation"`). Show top 5 hotspots sorted by signal count.
+   - **Skill Performance:** Aggregate runs, avg duration, avg QG rounds, stagnation rate, success rate per skill. Cap at 8 rows.
+   - **Trends:** Compare last 10 signals vs prior 10 for key metrics.
+   - **Recent Friction:** Last 5 signals with friction indicators.
+3. **Hard cap at 100 lines** — drop Trends and Recent Friction sections first if needed.
+4. Write regenerated summary to `chronicle/summary.md`

--- a/skills/forge/trajectory-capture.md
+++ b/skills/forge/trajectory-capture.md
@@ -1,0 +1,131 @@
+# Trajectory Capture Reference
+
+Trajectory capture records structured data about real skill invocations for eval generation. It is OFF by default and requires explicit opt-in.
+
+## Configuration
+
+Check for `~/.claude/projects/<hash>/memory/trajectory-config.json` before any trajectory operation. If the file does not exist or `enabled` is false, skip all trajectory recording silently.
+
+Config schema:
+
+```json
+{
+  "enabled": false,
+  "max_entries": 500,
+  "include_prompt_summary": true,
+  "additional_redact_patterns": []
+}
+```
+
+- `enabled`: Master switch. Default false.
+- `max_entries`: Maximum entries per JSONL file before oldest are pruned. Default 500.
+- `include_prompt_summary`: Whether to include the one-line redacted prompt summary. If false, `prompt_summary` is set to "[omitted]". Default true.
+- `additional_redact_patterns`: List of regex strings for project-specific secret patterns applied during the redaction pass.
+
+## Storage
+
+All trajectory data lives alongside other forge data:
+
+```
+~/.claude/projects/<hash>/memory/trajectories/
+  trajectory_samples.jsonl     # Successful completions
+  failed_trajectories.jsonl    # Failures, partial completions, aborts
+```
+
+## First-Enable Notification
+
+When trajectory capture is first enabled (config file is created or `enabled` transitions from false to true), output to the user:
+
+"Trajectory capture is now enabled. Here is what this means:
+- After each significant skill invocation, a structured record is appended to
+  ~/.claude/projects/<hash>/memory/trajectories/
+- Records include: skill name, duration, tool call count, outcome, and a redacted
+  task summary. Raw prompts are NEVER stored.
+- A redaction pass runs before every write to strip file paths, secrets, and
+  sensitive content.
+- You can inspect the JSONL files at any time. They are human-readable.
+- To disable, set enabled: false in trajectory-config.json or delete the file."
+
+## Redaction Rules
+
+Before writing ANY trajectory entry, apply these redaction steps in order:
+
+1. **Prompt summary generation**: Do NOT copy the user's prompt. Instead, generate
+   a one-line summary that captures the task TYPE without revealing specific content.
+   Good: "Add authentication middleware to REST API"
+   Bad: "Add JWT auth to the Acme Corp billing API at /srv/acme/billing/api.py"
+   If `include_prompt_summary` is false in config, set `prompt_summary` to "[omitted]".
+
+2. **File path normalization**: Replace absolute paths with project-relative paths.
+   Replace home directory segments with `~`. Replace username segments with `[user]`.
+   Example: `/home/alice/projects/myapp/src/auth.py` becomes `~/projects/myapp/src/auth.py`
+   or `src/auth.py` if within the project root.
+
+3. **Secret pattern matching**: Scan all string fields for patterns matching:
+   - API keys (strings matching `[A-Za-z0-9_-]{20,}` preceded by key/token/secret/api)
+   - Connection strings (containing `://` with credentials)
+   - Environment variable references with values (`KEY=value` patterns)
+   - Bearer tokens, JWT strings (three dot-separated base64 segments)
+   Replace matches with `[REDACTED]`.
+
+4. **Custom patterns**: Apply each regex in `additional_redact_patterns` from the
+   config file against all string fields. Replace matches with `[REDACTED]`.
+
+5. **Set `redacted` flag**: Only set `redacted: true` after steps 1-4 complete
+   successfully. If any step fails, do NOT write the entry.
+
+## Redaction Failure
+
+If the redaction pass cannot complete (e.g., malformed config, regex error), log a
+warning and skip trajectory recording for this invocation. Do NOT write an unredacted
+entry. Trajectory capture is a nice-to-have — it must never leak sensitive data.
+
+## Trajectory Entry Schema (Step 8)
+
+When recording a trajectory after a retrospective:
+
+a. Check `~/.claude/projects/<hash>/memory/trajectory-config.json` — if missing
+   or `enabled: false`, skip entirely.
+b. Construct the raw trajectory entry from execution data available in context:
+   - `trajectory_id`: Generate a UUID
+   - `timestamp`: ISO-8601 of when the skill invocation started
+   - `skill`: The Crucible skill that was invoked (build, debugging, audit, etc.)
+   - `completed`: Whether the skill ran to its natural completion
+   - `outcome`: Derived from the retrospective's `outcome` field (success/partial/failure)
+   - `duration_ms`: From pipeline status timestamps or session timing
+   - `tool_call_count`: Estimated from execution summary
+   - `error_recovery_events`: Count of error-then-retry sequences observed
+   - `user_acceptance`: Whether the user accepted the output (accepted/rejected/modified/unknown)
+   - `phases_reached`: For multi-phase skills, which phases completed
+   - `deviation_type`: From the retrospective entry
+   - `prompt_hash`: SHA-256 of the original user prompt
+   - `prompt_summary`: One-line redacted summary (if `include_prompt_summary` is true)
+   - `redacted`: Set to true only after redaction pass completes
+   - `tags`: From the retrospective entry's tags
+c. Run the redaction pass (see Redaction Rules above).
+d. Append the entry as a single JSON line to the appropriate file:
+   - If `completed == true` AND `outcome == "success"`: append to `trajectory_samples.jsonl`
+   - Otherwise: append to `failed_trajectories.jsonl`
+e. Check file size: if the target file exceeds `max_entries` lines, remove the
+   oldest entries (from the top of the file) to bring it back to `max_entries`.
+
+## Trajectory Recording Without Retrospective
+
+Forge retrospective is RECOMMENDED but not REQUIRED. When a significant skill
+completes but no retrospective is triggered (user declines, session ending, quick
+task), trajectory data would be lost.
+
+To handle this, any skill that completes a significant task SHOULD write a
+minimal trajectory entry if:
+- Trajectory capture is enabled
+- No forge retrospective is expected to run in this session
+
+The minimal entry uses `deviation_type: "unknown"`, `tags: []`, and
+`outcome` based on the completion signal alone (success if the skill reported
+success, failure if it reported failure, partial otherwise). The entry still
+goes through the full redaction pass.
+
+This ensures trajectory data is captured even when forge does not run, at the
+cost of less-rich analytical fields. The skill-creator's eval generation pipeline
+handles entries with `deviation_type: "unknown"` by clustering on execution
+metrics alone.

--- a/skills/prospector/REFERENCE.md
+++ b/skills/prospector/REFERENCE.md
@@ -474,3 +474,106 @@ Trajectory status directly informs the cost-of-inaction assessment:
 - ACCELERATING overrides the "Defensible — low-activity code" inaction rule if the acceleration trend shows the code becoming high-activity
 - STABLE across 3+ runs suggests the friction is permanent without intervention
 - DECLINING may make a finding eligible for Track Only even if current metrics are above the threshold
+
+---
+
+## Convergence Logic
+
+Detailed merge and split criteria used by the orchestrator in Phase 2.5 when collapsing friction points that share a root cause.
+
+### Merge Threshold
+
+Two friction points merge only when they share the same root cause type AND their root cause statements describe the same underlying architectural decision or missing pattern. Overlapping symptoms or co-located files alone are not sufficient.
+
+### Split Criterion
+
+Before merging, ask: "Would a single design change plausibly fix BOTH friction points?" If no, do not merge even if root cause type and statement match.
+
+### Merge Confidence
+
+- **High confidence:** Same root cause type, same architectural decision, AND a single design change would plausibly fix both. High-confidence merges auto-approve (no user confirmation needed).
+- **Low confidence:** Same root cause type and similar statements, but unclear whether a single design change covers both (e.g., similar root causes in different subsystems). Low-confidence merges require explicit user confirmation.
+
+### Medium/Low Finding Overlap Check
+
+Before writing the draft, the orchestrator also checks whether any Medium/Low-severity finding (which did not receive a root cause agent) has symptom descriptions and file locations that overlap with a High-severity finding's root cause scope. Overlaps are flagged as Low-confidence potential merges for user confirmation.
+
+---
+
+## Candidate Presentation Format
+
+The format used by the orchestrator when presenting ranked candidates at the Phase 4 user gate.
+
+### Structure
+
+Active candidates are ranked by `leverage_score x modification_friction_score`. Candidates where inaction is defensible appear in a separate "Track Only" section below, not as low-scoring entries in the main list.
+
+### Data Quality Tags
+
+- **`[Full analysis]`** — High-severity finding that received a dedicated root cause agent. Framework check is based on code-level investigation.
+- **`[Limited -- no root cause]`** — Medium/Low-severity finding that did not receive a root cause agent. Framework check is based on Phase 0.5 hint only.
+
+### Example
+
+```
+### Prospector Candidates
+
+#### Active Candidates (ranked by leverage x modification_friction)
+
+1. **[Score: 9] [Effort: Medium] [Full analysis] Payment processing cluster**
+   - Friction: Understanding payment flow requires reading 8 files across 3 directories
+   - Root cause: Missing or underused pattern -- no aggregate module, each concern handled individually
+   - Origin: Incomplete Migration (commit abc123)
+   - Comprehension: High | Modification: High | Leverage: High
+   - Framework check: None identified
+   - Cost of inaction: Modified weekly, 4 bug-fix commits in 6 months. Not defensible.
+   - Trajectory: STABLE (2 runs)
+
+2. **[Score: 6] [Effort: Low] [Limited -- no root cause] Auth middleware duplication**
+   - Friction: Auth checks duplicated across 4 route handlers
+   - Root cause: Root cause not analyzed -- severity below threshold
+   - Origin: Accretion (no single commit)
+   - Comprehension: Medium | Modification: High | Leverage: Medium
+   - Framework check: Express middleware pattern (framework hint only -- pattern usage not verified)
+   - Cost of inaction: Modified weekly, 2 bug-fix commits in 6 months. Not defensible.
+   - Trajectory: NEW
+
+---
+
+#### Track Only (inaction defensible -- low modification friction or low leverage)
+
+3. **[Score: 3] [Effort: Low] [Limited -- no root cause] GameBootstrap god-class**
+   - Friction: Hard to read (2,393 lines) but modification pattern is clear (~5 lines per change)
+   - Root cause: Missing or underused pattern -- no self-registration, but modification cost is low
+   - Comprehension: High | Modification: Low | Leverage: Low
+   - Framework check: VContainer IInitializable would solve this (framework hint only -- pattern usage not verified)
+   - Cost of inaction: Modified monthly, 0 bug-fix commits. Defensible -- rarely modified, clear patterns.
+   - Trajectory: STABLE (4 runs)
+```
+
+---
+
+## Trajectory JSONL Schema
+
+Each approved friction point (from the exploration review gate) is recorded as one JSONL line in `trajectory.jsonl`.
+
+### Example Record
+
+```json
+{"timestamp": "2026-03-23T14:30:00", "fingerprint": {"files": ["src/GameBootstrap.cs", "src/Services/"], "friction_type": "Coupling / shotgun surgery", "root_cause_type": "Missing or underused pattern"}, "metrics": {"change_freq": "weekly", "bug_fix_count": 4, "modification_friction": "High", "leverage": "High"}, "disposition": "selected-for-design", "run_id": "2026-03-23T14-30-00"}
+```
+
+### Field Definitions
+
+- **timestamp:** ISO 8601 timestamp of the run.
+- **fingerprint:** Used for cross-run matching.
+  - **files:** Primary file paths (sorted, normalized).
+  - **friction_type:** Classification from the friction taxonomy.
+  - **root_cause_type:** Included for context but not required for fingerprint matching.
+- **metrics:** From Phase 3 analysis output.
+  - **change_freq:** Change frequency classification (monthly/weekly/daily).
+  - **bug_fix_count:** Number of bug-fix commits in the analysis window.
+  - **modification_friction:** High/Medium/Low.
+  - **leverage:** High/Medium/Low.
+- **disposition:** What happened to this finding: `selected-for-design` | `track-only` | `pruned-by-user`.
+- **run_id:** Links back to the scratch directory for full details.

--- a/skills/prospector/SKILL.md
+++ b/skills/prospector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prospector
-description: "Explore a codebase for architectural friction and propose competing redesigns. Triggers on 'prospector', 'find improvements', 'architecture friction', 'what should I refactor', 'where are the structural problems', or any task requesting discovery of codebase improvement opportunities."
+description: "Explores a codebase for architectural friction — identifies coupling hotspots, detects circular dependencies, flags god classes, and proposes competing redesigns with trade-off analysis. Triggers on 'prospector', 'find improvements', 'architecture friction', 'what should I refactor', 'where are the structural problems', or any task requesting discovery of codebase improvement opportunities."
 ---
 
 # Prospector
@@ -15,6 +15,8 @@ Explores a codebase organically, surfaces architectural friction, and proposes c
 **Skill type:** Rigid -- follow exactly, no shortcuts.
 
 **Purpose:** Discover structural improvement opportunities in a codebase. Distinct from audit (which finds bugs in a specific subsystem) -- prospector finds what could be better across the entire codebase. Audit finds what's broken. Prospector finds what could be better.
+
+**Write-on-complete convention:** Every agent's output is written to the scratch directory immediately upon completion. Do not hold results in context memory only — always persist to disk. Specific paths are listed in the Scratch Directory section.
 
 **Model:** Opus (orchestrator, organic explorer, competing design agents). Sonnet (genealogists, structured analysis). If the orchestrator session is not running Opus, warn: "Prospector requires Opus-level reasoning for exploration and design phases. Results may be degraded."
 
@@ -185,8 +187,6 @@ The explorer outputs a structured list of friction points (capped at **top 8**, 
 - **Severity:** How much this friction would slow down a developer working in this area (High/Medium/Low)
 - **Frequency estimate:** How often a developer would hit this friction (daily, weekly, rarely)
 
-**Write-on-complete:** The orchestrator writes the explorer's output to `scratch/<run-id>/explorer-findings.md` immediately upon agent completion. Do not hold results in context memory only — always persist to disk.
-
 ### Explorer Context Budget
 
 The explorer should target 50% of its context window for exploration, reserving the remainder for output generation. For large codebases:
@@ -254,8 +254,6 @@ Each agent classifies the friction's origin:
 
 **Graceful degradation:** Genealogy enriches when available but is never required. If git history is too shallow or all results are Indeterminate, downstream phases proceed without genealogy data.
 
-**Write-on-complete:** The orchestrator writes each genealogist's output to `scratch/<run-id>/genealogy-<n>.md` immediately upon agent completion.
-
 ## Phase 2: Root Cause Analysis
 
 Root cause analysis runs in parallel with genealogy. Root cause looks at code structure ("why is this designed this way?"), genealogy traces git history ("how did it get this way?"). Both feed into Phase 2.5 convergence, then Phase 3.
@@ -295,8 +293,6 @@ Each agent uses the competing causal hypotheses method: generates 2-3 plausible 
 - **Codebase boundary:** If hypothesis testing leads outside the codebase (into framework internals, language runtime, or third-party library code), stop at the codebase boundary. Record the external dependency as the terminal cause.
 - **Hypothesis count:** 2-3 hypotheses per friction point. Stop when one hypothesis survives falsification, or when all hypotheses have been tested.
 
-**Write-on-complete:** The orchestrator writes each root cause agent's output to `scratch/<run-id>/root-cause-<n>.md` immediately upon agent completion.
-
 ## Phase 2.5: Root Cause Convergence
 
 After all root cause agents and genealogy agents complete, the orchestrator checks whether multiple friction points share the same root cause. When they do, it collapses them into a single "friction cluster" with a unified remediation scope. This prevents producing interfering partial fixes for what is really a single architectural problem.
@@ -307,22 +303,13 @@ After all root cause agents and genealogy agents complete, the orchestrator chec
 
 1. Read all `root-cause-<n>.md` outputs
 2. Group by: same root cause type AND surviving hypothesis root cause statements describe the same architectural decision (semantic match, not string equality)
-3. **Merge threshold:** Two friction points merge only when they share the same root cause type AND their root cause statements describe the same underlying architectural decision or missing pattern. Overlapping symptoms or co-located files alone are not sufficient.
-4. **Split criterion:** Before merging, ask: "Would a single design change plausibly fix BOTH friction points?" If no, do not merge even if root cause type and statement match.
-
-### Merge Confidence
-
-- **High confidence:** Same root cause type, same architectural decision, AND a single design change would plausibly fix both. High-confidence merges auto-approve (no user confirmation needed).
-- **Low confidence:** Same root cause type and similar statements, but unclear whether a single design change covers both (e.g., similar root causes in different subsystems). Low-confidence merges require explicit user confirmation.
-
-### Medium/Low Finding Overlap Check
-
-Before writing the draft, the orchestrator also checks whether any Medium/Low-severity finding (which did not receive a root cause agent) has symptom descriptions and file locations that overlap with a High-severity finding's root cause scope. Overlaps are flagged as Low-confidence potential merges for user confirmation.
+3. Apply merge threshold and split criterion rules (see [REFERENCE.md](REFERENCE.md) — Convergence Logic section)
+4. Also check whether any Medium/Low-severity finding overlaps with a High-severity finding's root cause scope — flag overlaps as Low-confidence merges
 
 ### Two-Step Convergence (Compaction-Safe)
 
-1. **Draft step:** Write proposed groupings to `scratch/<run-id>/convergence-draft.md`. Each proposed merge includes its confidence rating (High/Low) and the split criterion assessment. This is a checkpoint — if compaction occurs, the draft survives.
-2. **Confirmation step:** Present the draft to the user. High-confidence merges auto-approve; the user decides on Low-confidence merges (approve or split). The user may also split any auto-approved merge or force-merge missed connections. After confirmation, write the final `scratch/<run-id>/convergence.md`.
+1. **Draft step:** Write proposed groupings to `scratch/<run-id>/convergence-draft.md` with confidence ratings (High/Low) and split criterion assessments. This is a checkpoint — survives compaction.
+2. **Confirmation step:** Present draft to user. High-confidence merges auto-approve; user decides on Low-confidence merges (approve or split). User may also split auto-approved merges or force-merge missed connections. Write final `scratch/<run-id>/convergence.md`.
 
 ### Downstream Impact
 
@@ -350,101 +337,23 @@ The trajectory status and a one-line metric summary ("change freq: monthly→wee
 
 **Track Only resurfacing:** If a friction point was previously `track-only` but its trajectory is now ACCELERATING, the orchestrator flags it for the user at the exploration review gate: "Friction point [X] was Track Only in the last run but is now accelerating. Recommend upgrading to High severity for root cause analysis."
 
-Each analysis agent receives:
-- The friction point description and file locations (or cluster of merged friction points with combined scope)
-- Genealogy classification and key commits (if available)
-- Root cause summary (max 10 lines, mechanically extracted — see below)
-- Framework context block (from Phase 0.5)
-- Change metrics from genealogy (change frequency and bug-fix commit counts, aggregated per Git Metrics Aggregation rules)
-- Relevant source files (subject to 2000-line hard cap — increased from 1500 to accommodate four new output sections)
-- The relevant REFERENCE.md section for the friction type being analyzed
+Each analysis agent receives: friction point description and file locations (or merged cluster with combined scope), genealogy classification and key commits, root cause summary (max 10 lines, mechanically extracted), framework context block, change metrics (aggregated per Git Metrics Aggregation rules), relevant source files (2000-line hard cap), and the relevant REFERENCE.md section for the friction type.
 
 ### Root Cause Summary Extraction
 
-The orchestrator produces the root cause summary by extracting four fields **verbatim** from the root cause agent's output — no summarization, no paraphrasing:
-
-1. **Root cause type** (1 line) — copied verbatim from "Type:" field
-2. **Root cause statement** (1 line) — copied verbatim from "Root cause statement:" field
-3. **Pattern-level fix** (1-2 lines) — copied verbatim from "Pattern-level fix:" field
-4. **Framework-native solution** (1-2 lines) — copied verbatim from "Framework-native solution:" field
-
-For convergence clusters, append: "Cluster scope: merged from friction points #X, #Y, #Z — addresses shared root cause as a unit."
-
-For Medium/Low-severity findings without a dedicated root cause agent: use either a one-line note from a neighboring High-severity finding (if applicable) or "Root cause not analyzed -- severity below threshold."
+The orchestrator extracts four fields **verbatim** from the root cause agent's output (no summarization): root cause type, root cause statement, pattern-level fix, and framework-native solution. For convergence clusters, append cluster scope. For Medium/Low findings: use a one-line note from a neighboring High-severity finding or "Root cause not analyzed -- severity below threshold." See `./analysis-prompt.md` for the full extraction format.
 
 ### Source Prioritization for Convergence Clusters
 
-When an analysis agent processes a convergence cluster:
-1. **Full source** for the highest-severity constituent finding's files
-2. **Interface-only excerpts** (function signatures, class declarations, public API surfaces) for other constituent findings' files
-3. If the cluster still exceeds the 2000-line cap after prioritization, the orchestrator **splits the cluster** into sub-clusters that each fit. The orchestrator warns the user: "Cluster [X] exceeds context budget and was split into sub-clusters. This partially reduces the convergence benefit." The decision journal logs the split and rationale. Sub-cluster analysis results are re-merged in the Phase 4 candidate presentation.
+Full source for the highest-severity constituent finding's files; interface-only excerpts for others. If the cluster exceeds the 2000-line cap, split into sub-clusters (warn user, log to decision journal, re-merge results in Phase 4).
 
-Each analysis agent outputs:
-- **Friction type classification** — which category from the reference doc
-- **Applicable philosophy/framework** — which architectural philosophy best explains this friction
-- **Causal origin** — from genealogy (if available), factored into effort estimate
-- **Cluster:** Which modules/concepts are involved
-- **Why they're coupled:** Shared types, call patterns, co-ownership
-- **Dependency category:** In-process, local-substitutable, remote-but-owned, or true external
-- **Estimated improvement impact:** High/Medium/Low
-- **Estimated effort:** High/Medium/Low — refined by genealogy
-- **Friction dimensions** — comprehension friction (High/Medium/Low), modification friction (High/Medium/Low), primary dimension
-- **ROI assessment** — leverage score with justification, change frequency, bug correlation
-- **Framework check** — framework patterns available, pattern evidence source, applicability
-- **Cost of inaction** — change frequency (hottest file + range), bug origin rate, blocking planned work, inaction assessment
-- **Interface surface summary** — current public API
-- **Top caller patterns** — 3-5 most common usage patterns
-- **Structural summary** — module boundaries, data flow direction, dependency graph fragment
+### Analysis Output
 
-The last three fields form the **design brief** consumed by Phase 6 competing design agents.
-
-**Write-on-complete:** The orchestrator writes each analysis agent's output to `scratch/<run-id>/analysis-<n>.md` immediately upon agent completion. (Analysis agents are Task tool dispatches — they return text to the orchestrator, who persists it.)
+Each agent outputs: friction type classification, applicable philosophy, causal origin, cluster scope, coupling rationale, dependency category, impact/effort estimates, friction dimensions (comprehension + modification), ROI assessment, framework check, and cost of inaction. The last three output fields — **interface surface summary**, **top caller patterns**, and **structural summary** — form the design brief consumed by Phase 6. See `./analysis-prompt.md` for the complete field specification.
 
 The orchestrator reads all analysis results from disk and synthesizes into a ranked candidate list using the formula `leverage_score x modification_friction_score` (High=3, Medium=2, Low=1). Ties are broken by comprehension friction score. Effort is shown separately as a cost indicator, not included in the ranking formula. Candidates where inaction is defensible are demoted to a "Track Only" section. Writes to `scratch/<run-id>/candidates.md`.
 
-**USER GATE: Candidate Selection** — Present candidates to the user. Do not proceed until user picks one:
-
-```
-### Prospector Candidates
-
-#### Active Candidates (ranked by leverage x modification_friction)
-
-1. **[Score: 9] [Effort: Medium] [Full analysis] Payment processing cluster**
-   - Friction: Understanding payment flow requires reading 8 files across 3 directories
-   - Root cause: Missing or underused pattern -- no aggregate module, each concern handled individually
-   - Origin: Incomplete Migration (commit abc123)
-   - Comprehension: High | Modification: High | Leverage: High
-   - Framework check: None identified
-   - Cost of inaction: Modified weekly, 4 bug-fix commits in 6 months. Not defensible.
-   - Trajectory: STABLE (2 runs)
-
-2. **[Score: 6] [Effort: Low] [Limited -- no root cause] Auth middleware duplication**
-   - Friction: Auth checks duplicated across 4 route handlers
-   - Root cause: Root cause not analyzed -- severity below threshold
-   - Origin: Accretion (no single commit)
-   - Comprehension: Medium | Modification: High | Leverage: Medium
-   - Framework check: Express middleware pattern (framework hint only -- pattern usage not verified)
-   - Cost of inaction: Modified weekly, 2 bug-fix commits in 6 months. Not defensible.
-   - Trajectory: NEW
-
----
-
-#### Track Only (inaction defensible -- low modification friction or low leverage)
-
-3. **[Score: 3] [Effort: Low] [Limited -- no root cause] GameBootstrap god-class**
-   - Friction: Hard to read (2,393 lines) but modification pattern is clear (~5 lines per change)
-   - Root cause: Missing or underused pattern -- no self-registration, but modification cost is low
-   - Comprehension: High | Modification: Low | Leverage: Low
-   - Framework check: VContainer IInitializable would solve this (framework hint only -- pattern usage not verified)
-   - Cost of inaction: Modified monthly, 0 bug-fix commits. Defensible -- rarely modified, clear patterns.
-   - Trajectory: STABLE (4 runs)
-```
-
-### Data Quality Indicators
-
-Each candidate is tagged with:
-- **`[Full analysis]`** — High-severity finding that received a dedicated root cause agent. Framework check is based on code-level investigation.
-- **`[Limited -- no root cause]`** — Medium/Low-severity finding that did not receive a root cause agent. Framework check is based on Phase 0.5 hint only.
+**USER GATE: Candidate Selection** — Present candidates to the user. Do not proceed until user picks one. Each candidate shows: score (leverage x modification_friction), effort, data quality tag (`[Full analysis]` or `[Limited -- no root cause]`), friction summary, root cause, origin, friction dimensions, framework check, cost of inaction, and trajectory status. Active candidates are ranked by score; candidates where inaction is defensible appear in a separate "Track Only" section below. See [REFERENCE.md](REFERENCE.md) for the full candidate presentation format and example.
 
 ### Constraint-Driven Root Cause Warning
 
@@ -475,19 +384,7 @@ Write to `scratch/<run-id>/problem-frame.md`.
 
 ### Constraint Selection
 
-The orchestrator selects 3 design constraints from a deterministic mapping in [REFERENCE.md](REFERENCE.md). The mapping is keyed by friction type classification (from Phase 3 analysis). Each friction type has exactly 3 associated constraints — the orchestrator looks up the friction type and uses its constraints. This is a **routing decision, not a creative one.**
-
-**Friction-type-to-constraint mapping (canonical, in REFERENCE.md):**
-
-| Friction Type | Constraint 1 | Constraint 2 | Constraint 3 |
-|--------------|--------------|--------------|--------------|
-| Shallow modules | Minimize interface (1-3 entry points) | Optimize for most common caller | Hide maximum implementation detail |
-| Coupling/shotgun surgery | Consolidate into single module | Introduce facade pattern | Extract shared abstraction with clean boundary |
-| Leaky abstraction | Seal the abstraction (hide all internals) | Replace with simpler direct approach | Ports & adapters (injectable boundary) |
-| Testability barrier | Boundary-test-friendly interface | Dependency-injectable design | Pure-function extraction with integration wrapper |
-| Scattered domain | Aggregate into domain module | Event-driven decoupling | Layered with clear ownership per layer |
-
-If a friction point doesn't match any defined type, the orchestrator falls back to a generic set: "Minimize interface," "Maximize flexibility," "Optimize for most common caller." The decision journal must log which constraint set was selected and why.
+The orchestrator selects 3 design constraints from the deterministic friction-type-to-constraint mapping in [REFERENCE.md](REFERENCE.md) (see Constraint Menu section). The mapping is keyed by friction type classification (from Phase 3 analysis). Each friction type has exactly 3 associated constraints — the orchestrator looks up the friction type and uses its constraints. This is a **routing decision, not a creative one.** If a friction point doesn't match any defined type, the orchestrator falls back to the generic constraint set in REFERENCE.md. The decision journal must log which constraint set was selected and why.
 
 ### Dynamic Constraint Overrides
 
@@ -530,8 +427,6 @@ Each agent receives (subject to 2000-line hard cap):
 - Framework context block (from Phase 0.5)
 - Its assigned design constraint
 - The applicable architectural philosophy and why it applies
-
-**Write-on-complete:** The orchestrator writes each design agent's output to `scratch/<run-id>/design-<n>.md` immediately upon agent completion.
 
 Each agent outputs:
 1. **Interface signature** — types, methods, params
@@ -587,16 +482,7 @@ At the end of every run — regardless of whether the user proceeds to build, fi
 
 **File:** `~/.claude/projects/<project-hash>/memory/prospector/trajectory.jsonl`
 
-Each approved friction point (from the exploration review gate) becomes one JSONL line:
-
-~~~json
-{"timestamp": "2026-03-23T14:30:00", "fingerprint": {"files": ["src/GameBootstrap.cs", "src/Services/"], "friction_type": "Coupling / shotgun surgery", "root_cause_type": "Missing or underused pattern"}, "metrics": {"change_freq": "weekly", "bug_fix_count": 4, "modification_friction": "High", "leverage": "High"}, "disposition": "selected-for-design", "run_id": "2026-03-23T14-30-00"}
-~~~
-
-Fields:
-- **fingerprint:** Primary file paths (sorted, normalized) + friction type + root cause type. Used for cross-run matching.
-- **metrics:** Change frequency, bug-fix count, modification friction, leverage — from Phase 3 analysis.
-- **disposition:** `selected-for-design` | `track-only` | `pruned-by-user` — what happened to this finding.
+Each approved friction point becomes one JSONL line containing: fingerprint (file paths + friction type + root cause type), metrics (change frequency, bug-fix count, modification friction, leverage), disposition (`selected-for-design` | `track-only` | `pruned-by-user`), and run ID. See [REFERENCE.md](REFERENCE.md) for the full JSONL schema and field definitions.
 - **run_id:** Links back to the scratch directory for full details.
 
 Fingerprint matching across runs uses: same friction type AND overlapping file paths (>50% overlap). Root cause type is included for context but not required to match (root cause classification may evolve as the codebase changes).
@@ -629,21 +515,7 @@ Delete `scratch/<run-id>/` after all Phase 8 actions are complete (design doc sa
 
 After Phase 8, dispatch `crucible:cartographer` (record mode) with the user-approved friction points from the exploration review gate. Record only friction point locations and classifications — not raw explorer observations or unconfirmed speculation.
 
-## Dependency Categories
-
-Classification system for the target code's dependencies:
-
-### 1. In-Process
-Pure computation, in-memory state, no I/O. Always improvable — merge modules and test directly.
-
-### 2. Local-Substitutable
-Dependencies with local test stand-ins (e.g., SQLite for Postgres, in-memory filesystem). Improvable if the stand-in exists.
-
-### 3. Remote but Owned (Ports & Adapters)
-Your own services across a network boundary. Define a port at the module boundary; inject transport. Tests use an in-memory adapter.
-
-### 4. True External (Mock)
-Third-party services you don't control (Stripe, Twilio, etc.). Mock at the boundary via injected port.
+**Dependency Categories:** See [REFERENCE.md](REFERENCE.md) for the four dependency categories (In-Process, Local-Substitutable, Remote but Owned, True External) and their testing implications.
 
 ## Compaction Recovery
 
@@ -727,4 +599,4 @@ After context compaction:
 - `./root-cause-prompt.md` — Phase 2 competing causal hypotheses agent dispatch
 - `./analysis-prompt.md` — Phase 3 structured friction analysis dispatch (enhanced with ROI, friction dimensions, framework check, cost of inaction)
 - `./design-competitor-prompt.md` — Phase 6 competing design agent dispatch (enhanced with root cause integration)
-- `./REFERENCE.md` — Friction taxonomy, philosophy mappings, constraint menu, dependency categories, origin type definitions, root cause type taxonomy, ROI scoring, framework check guidance, cost-of-inaction criteria
+- `./REFERENCE.md` — Friction taxonomy, philosophy mappings, constraint menu, dependency categories, origin type definitions, root cause type taxonomy, ROI scoring, framework check guidance, cost-of-inaction criteria, convergence logic, candidate presentation format, trajectory JSONL schema

--- a/skills/recon/INTEGRATION.md
+++ b/skills/recon/INTEGRATION.md
@@ -1,0 +1,54 @@
+# Integration and Cost Reference
+
+## Behavior Matrix
+
+| Configuration | Behavior |
+|---|---|
+| With task | Scouts focus on task-relevant areas |
+| With context | Prior decisions passed to scouts alongside task |
+| Without task | Full repo recon for audit/project-init cold starts |
+| With scope | Explicit scope overrides scout suggestions |
+| With modules | Depth agents dispatched after core synthesis |
+| No modules | Core layer only — cheapest possible recon |
+| With session_id | Structure Scout cached, Pattern Scout always fresh |
+
+## Cost Profile
+
+| Configuration | Agents | Models | Relative Cost |
+|---|---|---|---|
+| Core only | 2 | 2x Sonnet | Low |
+| Core + 1 mechanical module | 3 | 3x Sonnet | Low |
+| Core + 1 judgment module | 3 | 2x Sonnet + 1x Opus | Medium |
+| Core + 2 modules (mixed) | 4 | 2-3x Sonnet + 1-2x Opus | Medium-High |
+| Full repo, no task | 2 | 2x Sonnet | Low (but slower) |
+
+## Dispatches
+
+- `structure-scout-prompt.md` — Structure Scout (Sonnet, Explore)
+- `pattern-scout-prompt.md` — Pattern Scout (Sonnet, Explore)
+- `impact-analyst-prompt.md` — Impact Analyst (Opus)
+- `consumer-mapper-prompt.md` — Consumer Mapper (Sonnet)
+- `friction-scanner-prompt.md` — Friction Scanner (Opus)
+- `manifest-builder-prompt.md` — Manifest Builder (Sonnet)
+- `diagnostic-gatherer-prompt.md` — Diagnostic Gatherer (Opus)
+- `readiness-checker-prompt.md` — Readiness Checker (Sonnet)
+
+## Consults
+
+`crucible:cartographer` (consult mode — direct file read of `map.md`)
+
+## Records to
+
+`crucible:cartographer` (recorder dispatch after investigation, using `skills/cartographer-skill/recorder-prompt.md`)
+
+## Called by
+
+`/design` (Phase 2 context + impact-analysis), `/spec` (per-ticket investigation + impact-analysis), `/migrate` (Phase 0 + consumer-registry), `/audit` (Phase 1 code scoping + subsystem-manifest)
+
+## Not called by (investigated, not a fit)
+
+`/debugging` (specialized investigation pipeline), `/build` (inherits via /design), `/prospector` (organic exploration is different), `/project-init` (bootstraps cartographer, complementary purpose). See #147 for rationale.
+
+## Pairs with
+
+`/assay` (sequential — recon produces evidence, assay evaluates options)

--- a/skills/recon/SCHEMA.md
+++ b/skills/recon/SCHEMA.md
@@ -1,0 +1,19 @@
+# Brief Schema Stability
+
+The Investigation Brief is consumed by 6+ skills. Section headers are the contract surface — consumers parse by header to extract relevant sections.
+
+**Stable (changing requires updating all consumer templates):**
+- Brief metadata fields: `Brief version`, `Task`, `Scope`, `Depth modules`, `Cartographer state`, `Commit`
+- Core section headers: `## Project Structure`, `## Existing Patterns`, `## Scope Boundaries`, `## Prior Art`, `## Conflicts`
+
+**Semi-stable (additive, consumers opt-in):**
+- `## Open Questions` — present when scouts report unknowns. Consumers that need it parse for it; consumers that don't can ignore it. Not yet validated by consumer integration — promoted to stable once 2+ consumers confirm they consume it.
+
+**Semi-stable (consumers that request specific modules depend on these):**
+- Depth module section headers: `## Impact Analysis`, `## Consumer Registry`, `## Friction Scan`, `## Subsystem Manifest`, `## Diagnostic Context`, `## Execution Readiness`
+- Execution Readiness structured subfields: `Test command`, `Lint command`, `CI checks`, `Manual verification` — parsed by `/build`, must not be renamed without updating consumers
+
+**Unstable (internal content, not parsed by header):**
+- Content within sections — formatting, subheadings, bullet structure may evolve
+
+**Process:** Any change to a stable or semi-stable header is a breaking change. The PR must update all consumer skill templates that reference the changed header. Adding new depth modules is non-breaking.

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recon
-description: "Standalone codebase investigation. Produces a layered Investigation Brief with core findings (structure, patterns, scope, prior art) plus optional depth modules. Dispatches parallel scouts, synthesizes findings, and feeds cartographer. Use before any task requiring codebase understanding."
+description: "Explores and analyzes a codebase to produce a structured Investigation Brief covering repository structure, code patterns, scope boundaries, and prior art. Dispatches parallel scouts to map project layout and discover conventions, then synthesizes findings into a layered report. Use when you need to understand how a repository is organized, analyze code architecture before making changes, get a repository overview for onboarding, or explore code structure for design and migration tasks."
 ---
 
 # Recon
@@ -35,64 +35,17 @@ Structured, parallel codebase investigation with a layered output model. Produce
 
 ### Parameters
 
-**`task`** (optional)
-Free-text description of the task being investigated. Scouts focus exploration on task-relevant areas. Omit for a full repository scan.
+**`task`** (optional) — Free-text task description. Scouts focus on task-relevant areas. Omit for full repo scan.
 
-**`context`** (optional)
-Structured prior decisions from a parent skill (e.g., accumulated design choices from `/design`'s dimension loop). Passed to scouts alongside the task. Scouts consider these decisions during investigation — avoiding areas already decided, focusing on interfaces affected by prior choices.
+**`context`** (optional) — Structured prior decisions from a parent skill. Passed to scouts alongside the task. Budget: 4,000 tokens default; total scout input (task + context + cartographer) should stay under 8,000 tokens. Recognized keys: `decisions`, `constraints`, `target` (for `consumer-registry`, falls back to `task:` if absent).
 
-- **Input budget:** 4,000 tokens default. Parent skills should compact decisions before passing — each decision as a key-value pair with one-sentence rationale plus affected interfaces.
-- **Exceeding budget:** Orchestrator warns but does not reject. Caller proceeds at the cost of reduced scout context budget.
-- **Total scout input:** task + context + cartographer should stay under 8,000 tokens for effective exploration.
+**`session_id`** (optional) — Enables cross-invocation caching. Structure Scout report is cached and reused on subsequent invocations with the same session_id. Pattern Scout always runs fresh.
 
-Distinct from `task:` which describes *what* to investigate; `context:` describes *what's already been decided*.
+**`modules`** (optional) — Depth modules to produce after core synthesis: `impact-analysis` (Opus), `consumer-registry` (Sonnet), `friction-scan` (Opus), `subsystem-manifest` (Sonnet), `diagnostic-context` (Opus), `execution-readiness` (Sonnet). Most invocations request 0-1 modules.
 
-**Recognized context keys:**
-- `decisions` — list of prior design/implementation decisions
-- `constraints` — list of constraints affecting investigation
-- `target` — specific symbol/module for `consumer-registry` depth module (used by `/migrate`). Falls back to the `task:` string if absent.
+**`scope`** (optional) — Directory constraint. Overrides scout scope suggestions entirely.
 
-**`session_id`** (optional)
-Enables cross-invocation caching within a session. When provided, the Structure Scout report is cached and reused on subsequent invocations with the same session_id. Pattern Scout always runs fresh (its output varies with cascading context). Parent skills generate the session_id (e.g., `/design` uses its run timestamp). Without a session_id, no caching occurs.
-
-**`modules`** (optional)
-List of depth modules to produce after core synthesis. Valid values:
-
-| Module | Agent | Model | Primary Consumer |
-|---|---|---|---|
-| `impact-analysis` | Impact Analyst | Opus | `/design`, `/build` |
-| `consumer-registry` | Consumer Mapper | Sonnet | `/migrate` |
-| `friction-scan` | Friction Scanner | Opus | `/prospector` |
-| `subsystem-manifest` | Manifest Builder | Sonnet | `/audit` |
-| `diagnostic-context` | Diagnostic Gatherer | Opus | `/debugging` |
-| `execution-readiness` | Readiness Checker | Sonnet | `/build` |
-
-Most invocations request 0-1 depth modules. Omit for core-only output (cheapest).
-
-**`scope`** (optional)
-Directory constraint. When provided, overrides scout scope suggestions entirely — scouts constrain exploration to the given path(s). Cheaper, faster.
-
-### Behavior Matrix
-
-| Configuration | Behavior |
-|---|---|
-| With task | Scouts focus on task-relevant areas |
-| With context | Prior decisions passed to scouts alongside task |
-| Without task | Full repo recon for audit/project-init cold starts |
-| With scope | Explicit scope overrides scout suggestions |
-| With modules | Depth agents dispatched after core synthesis |
-| No modules | Core layer only — cheapest possible recon |
-| With session_id | Structure Scout cached, Pattern Scout always fresh |
-
-### Cost Profile
-
-| Configuration | Agents | Models | Relative Cost |
-|---|---|---|---|
-| Core only | 2 | 2x Sonnet | Low |
-| Core + 1 mechanical module | 3 | 3x Sonnet | Low |
-| Core + 1 judgment module | 3 | 2x Sonnet + 1x Opus | Medium |
-| Core + 2 modules (mixed) | 4 | 2-3x Sonnet + 1-2x Opus | Medium-High |
-| Full repo, no task | 2 | 2x Sonnet | Low (but slower) |
+See `INTEGRATION.md` for the full behavior matrix and cost profile.
 
 ## Communication Requirements (Non-Negotiable)
 
@@ -232,8 +185,6 @@ When scouts report `cartographer-conflict` findings, apply this adjudication tab
 | Both agree, no supporting evidence | Yes | Neither | **Unresolved** — agreement alone insufficient (correlated input priors) |
 | Deletion from cartographer | Yes or No | Any | **Always unresolved** — requires user confirmation |
 | Single scout only | No | Any | **Unresolved** — prevents single-scout hallucination |
-
-**Why agreement alone is insufficient:** Both scouts receive the same cartographer context and task description as input. Their exploration is correlated, not independent. Two correlated errors do not constitute independent verification. Auto-update requires agreement PLUS verifiable evidence.
 
 For auto-update actions: queue the update for Phase 5 (Cartographer Feedback).
 For unresolved actions: surface in the `## Conflicts` section of the brief.
@@ -505,33 +456,7 @@ File presence is the completion signal — no health state machine needed.
 
 ## Brief Schema Stability
 
-The Investigation Brief is consumed by 6+ skills. Section headers are the contract surface — consumers parse by header to extract relevant sections.
-
-**Stable (changing requires updating all consumer templates):**
-- Brief metadata fields: `Brief version`, `Task`, `Scope`, `Depth modules`, `Cartographer state`, `Commit`
-- Core section headers: `## Project Structure`, `## Existing Patterns`, `## Scope Boundaries`, `## Prior Art`, `## Conflicts`
-
-**Semi-stable (additive, consumers opt-in):**
-- `## Open Questions` — present when scouts report unknowns. Consumers that need it parse for it; consumers that don't can ignore it. Not yet validated by consumer integration — promoted to stable once 2+ consumers confirm they consume it.
-
-**Semi-stable (consumers that request specific modules depend on these):**
-- Depth module section headers: `## Impact Analysis`, `## Consumer Registry`, `## Friction Scan`, `## Subsystem Manifest`, `## Diagnostic Context`, `## Execution Readiness`
-- Execution Readiness structured subfields: `Test command`, `Lint command`, `CI checks`, `Manual verification` — parsed by `/build`, must not be renamed without updating consumers
-
-**Unstable (internal content, not parsed by header):**
-- Content within sections — formatting, subheadings, bullet structure may evolve
-
-**Process:** Any change to a stable or semi-stable header is a breaking change. The PR must update all consumer skill templates that reference the changed header. Adding new depth modules is non-breaking.
-
-## Design Principles
-
-- **Read-only** — `/recon` never modifies the codebase
-- **Cartographer-aware** — consults first, feeds back after
-- **Layered** — core is cheap and universal; depth is on-demand and consumer-specific
-- **Evidence-grounded** — produces constraints and evidence, not opinions
-- **Prior art is first-class** — finding existing patterns to follow is the single biggest quality lever
-- **Assumptions are explicit** — annotated inline on relevant findings, not in a standalone block
-- **Token-efficient** — structured markdown, no JSON boilerplate, Sonnet for mechanical work
+See `SCHEMA.md` for the full schema stability contract (stable, semi-stable, and unstable headers).
 
 ## Guardrails / Red Flags
 
@@ -544,22 +469,4 @@ The Investigation Brief is consumed by 6+ skills. Section headers are the contra
 
 ## Integration
 
-**Dispatches:**
-- `structure-scout-prompt.md` — Structure Scout (Sonnet, Explore)
-- `pattern-scout-prompt.md` — Pattern Scout (Sonnet, Explore)
-- `impact-analyst-prompt.md` — Impact Analyst (Opus)
-- `consumer-mapper-prompt.md` — Consumer Mapper (Sonnet)
-- `friction-scanner-prompt.md` — Friction Scanner (Opus)
-- `manifest-builder-prompt.md` — Manifest Builder (Sonnet)
-- `diagnostic-gatherer-prompt.md` — Diagnostic Gatherer (Opus)
-- `readiness-checker-prompt.md` — Readiness Checker (Sonnet)
-
-**Consults:** `crucible:cartographer` (consult mode — direct file read of `map.md`)
-
-**Records to:** `crucible:cartographer` (recorder dispatch after investigation, using `skills/cartographer-skill/recorder-prompt.md`)
-
-**Called by:** `/design` (Phase 2 context + impact-analysis), `/spec` (per-ticket investigation + impact-analysis), `/migrate` (Phase 0 + consumer-registry), `/audit` (Phase 1 code scoping + subsystem-manifest)
-
-**Not called by (investigated, not a fit):** `/debugging` (specialized investigation pipeline), `/build` (inherits via /design), `/prospector` (organic exploration is different), `/project-init` (bootstraps cartographer, complementary purpose). See #147 for rationale.
-
-**Pairs with:** `/assay` (sequential — recon produces evidence, assay evaluates options)
+See `INTEGRATION.md` for the full integration map (dispatches, consumers, cost profile, and behavior matrix).

--- a/skills/siege/SKILL.md
+++ b/skills/siege/SKILL.md
@@ -16,28 +16,6 @@ Full-lifecycle security audit. Dispatches 6 parallel Opus agents across distinct
 <!-- CANONICAL: shared/dispatch-convention.md -->
 All subagent dispatches use disk-mediated dispatch. See `shared/dispatch-convention.md` for the full protocol.
 
-## Why This Exists
-
-Audit finds bugs, robustness gaps, and architecture issues. Quality-gate iterates artifacts to convergence. Inquisitor hunts cross-component integration bugs. None of these operate from an attacker's perspective. Security is a discipline -- it requires threat modeling, attack surface enumeration, exploitation scenario analysis, and chain-of-vulnerability reasoning that generalist review skills are not equipped to perform. A robustness finding ("missing input validation") and a security finding ("this missing validation enables SQL injection via the /api/users endpoint, escalating to full database read") are categorically different in blast radius, urgency, and remediation strategy.
-
-## Distinction from Related Skills
-
-| Skill | Perspective | Scope | Output | Security Depth |
-|-------|-------------|-------|--------|----------------|
-| audit | Code quality reviewer | Existing subsystems | Findings report (no fixes) | Incidental: flags missing validation, not exploitation chains |
-| inquisitor | Integration tester | Cross-component diffs | Executable tests | None: tests functional correctness, not attacker behavior |
-| red-team | Devil's advocate | Single artifact | Written findings per round | Surface: flags "consider auth" without modeling attack paths |
-| quality-gate | Iterative reviewer | Any artifact | Converged artifact | None: quality convergence, not security convergence |
-| **siege** | 6 distinct attackers | Design docs, plans, AND code | Threat model + verified findings + accepted-risks log | Full: exploitation scenarios, blast radius, chain analysis, persistent threat model |
-
-**What Siege catches that others cannot:**
-- Multi-step attack chains spanning multiple components
-- Trust boundary violations that require attacker-perspective reasoning
-- Threat model drift (new surfaces introduced since last audit)
-- Supply chain and dependency vulnerabilities via live intelligence
-- Insider threat scenarios (authorized user abusing legitimate access)
-- TOCTOU and race-condition exploits (distinct from correctness race conditions -- these require attacker-controlled timing)
-
 ## Activation Heuristic
 
 <!-- CANONICAL: shared/security-signals.md — consumption-optimized keyword lists for build/spec/audit -->
@@ -173,88 +151,16 @@ Before agents are dispatched, enumerate the application's externally reachable e
 
 **Artifact-type guard:** Step 2.5 requires source files to grep. Skip entirely for `design` and `plan` artifact types (no code to scan). Run only for `code` and `mixed`. Note in scope limitations: "Attack surface enumeration skipped -- artifact type [design|plan] has no source files to scan."
 
-**Sub-step A -- Framework Detection:**
+**Sub-steps A-C:** Detect frameworks, enumerate routes/endpoints via grep patterns, classify auth status, and build an exposure map cross-referenced against the manifest. See `siege-attack-surface-reference.md` for framework detection tables, grep patterns, auth-signal heuristics, limitations, and exposure map format.
 
-Scan manifest files and project configuration to detect which web framework(s) the project uses:
-
-| Signal | Framework |
-|--------|-----------|
-| `package.json` with `express` dependency | Express.js |
-| `package.json` with `fastify` dependency | Fastify |
-| `package.json` with `@nestjs/core` dependency | NestJS |
-| `package.json` with `next` dependency | Next.js |
-| `requirements.txt` or `pyproject.toml` with `flask` | Flask |
-| `requirements.txt` or `pyproject.toml` with `fastapi` | FastAPI |
-| `requirements.txt` or `pyproject.toml` with `django` | Django |
-| `*.csproj` with `Microsoft.AspNetCore` | ASP.NET Core |
-| `Gemfile` with `rails` | Rails |
-| `pom.xml` or `build.gradle` with `spring-boot` | Spring Boot |
-| `go.mod` with `gin-gonic/gin` | Gin (Go) |
-| `go.mod` with `gorilla/mux` | Gorilla Mux (Go) |
-| `Cargo.toml` with `actix-web` | Actix Web (Rust) |
-
-If no framework is detected, skip the rest of Step 2.5 and note in scope limitations: "No recognized web framework detected -- attack surface enumeration skipped." Multiple frameworks: enumerate all.
-
-**Sub-step B -- Route/Endpoint Enumeration:**
-
-For each detected framework, grep project files using these patterns to extract registered routes:
-
-| Framework | Grep Pattern | Example Match |
-|-----------|-------------|---------------|
-| Express.js | `(app\|router)\.(get\|post\|put\|patch\|delete\|all\|use)\s*\(` | `app.get('/api/users', ...)` |
-| Fastify | `(fastify\|server)\.(get\|post\|put\|patch\|delete\|all)\s*\(` | `fastify.post('/login', ...)` |
-| NestJS | `@(Get\|Post\|Put\|Patch\|Delete\|All)\s*\(` | `@Get('users/:id')` |
-| Next.js | Files under `app/` or `pages/api/` (convention-based routing) | `app/api/users/route.ts` |
-| Flask | `@(app\|blueprint)\.(route\|get\|post\|put\|delete)\s*\(` | `@app.route('/login', methods=['POST'])` |
-| FastAPI | `@(app\|router)\.(get\|post\|put\|patch\|delete)\s*\(` | `@router.get('/items/{id}')` |
-| Django | `path\(\s*['"]` or `url\(\s*['"]` in `urls.py` files | `path('api/users/', views.user_list)` |
-| ASP.NET Core | `\[Http(Get\|Post\|Put\|Patch\|Delete)\]` or `\[Route\(` or `Map(Get\|Post\|Put\|Delete)\(` | `[HttpGet("api/users/{id}")]` |
-| Rails | `(get\|post\|put\|patch\|delete\|resources\|resource)\s` in `config/routes.rb` | `resources :users` |
-| Spring Boot | `@(GetMapping\|PostMapping\|PutMapping\|PatchMapping\|DeleteMapping\|RequestMapping)\s*\(` | `@GetMapping("/api/users")` |
-| Gin (Go) | `(r\|router\|group)\.(GET\|POST\|PUT\|PATCH\|DELETE\|Any)\s*\(` | `r.GET("/api/users", ...)` |
-| Gorilla Mux (Go) | `(r\|router)\.HandleFunc\s*\(` | `r.HandleFunc("/api/users", handler)` |
-| Actix Web (Rust) | `\.(route\|resource)\s*\(` or `#\[(get\|post\|put\|patch\|delete)\]` | `#[get("/api/users")]` |
-
-For each match, extract: HTTP method (or "ANY" if indeterminate), route path (raw string), source file path, line number, framework name.
-
-**Auth-signal heuristic (best-effort):** For each endpoint, scan surrounding context (same file, same route registration block) for auth middleware or decorator patterns: `[Authorize]`, `@RequireAuth`, `authenticate`, `isAuthenticated`, `requireLogin`, `@login_required`, `@permission_required`, `auth_guard`, `AuthGuard`, `before_action :authenticate`. Classify each endpoint as `auth: yes | no | unknown`. This is approximate -- false negatives are expected (auth applied at router level may not appear near the route). The classification feeds the exposure map's "Auth" column and helps prioritize: `auth: no` endpoints are highest priority for Boundary Attacker partitioning.
-
-**Limitations (documented in exposure map):**
-- Dynamic route registration (method/path from variables) is not captured
-- Middleware-only mounts (e.g., `app.use('/api', ...)`) are recorded as "middleware mount", not individual endpoints
-- Convention-based routing (Next.js file-based, Rails `resources` expansion) produces approximate routes
-- Auth-signal heuristic is best-effort: router-level or middleware-chain auth may not appear near the route definition, producing false `auth: unknown` classifications
-
-**Sub-step C -- Exposure Map and Cross-Reference:**
-
-Build the exposure map and cross-reference with `manifest.md`:
+**Exposure map cross-reference logic:**
 
 1. For each enumerated endpoint, check if its source file appears in the manifest
 2. Endpoints whose source file is NOT in the manifest are flagged as **coverage gaps**
-3. Gap files are automatically appended to `manifest.md` with the tag `[attack-surface-gap]`. Log each addition: "Attack surface gap: added [file] to manifest ([N] endpoints not in original scope)." This is post-USER-GATE, so the user sees what changed before agent dispatch.
-4. Write the full exposure map to `scratch/<run-id>/exposure-map.md`:
+3. Gap files are automatically appended to `manifest.md` with the tag `[attack-surface-gap]`. Log each addition: "Attack surface gap: added [file] to manifest ([N] endpoints not in original scope)."
+4. Write the full exposure map to `scratch/<run-id>/exposure-map.md` (format in `siege-attack-surface-reference.md`)
 
-```markdown
-# Attack Surface Exposure Map
-**Framework(s):** [detected frameworks]
-**Enumeration method:** Static pattern matching
-**Endpoint count:** [N]
-
-## Endpoints
-| # | Method | Route | File | Line | Auth | In Manifest |
-|---|--------|-------|------|------|------|-------------|
-| 1 | GET | /api/users | src/controllers/UserController.ts | 42 | yes | Yes |
-| 2 | DELETE | /admin/purge | src/admin/maintenance.ts | 88 | no | NO -- GAP |
-
-## Coverage Gaps
-- `/admin/purge` (src/admin/maintenance.ts:88) -- file not in Siege manifest
-[list all gaps]
-
-## Scope Limitations
-[framework-specific limitations from sub-step B]
-```
-
-**Line budget:** The exposure map summary appended to Tier 1 context (Step 1 of Automated Context Assembly) is capped at **15 lines**: endpoint count, gap count, and the gap list. The full endpoint table remains in `scratch/<run-id>/exposure-map.md` only.
+**Line budget:** The exposure map summary appended to Tier 1 context is capped at **15 lines**: endpoint count, gap count, and the gap list. The full endpoint table remains in `scratch/<run-id>/exposure-map.md` only.
 
 ### Step 3: Load Persistent Threat Model
 
@@ -530,101 +436,9 @@ If the fix agent or user identifies a finding as a false positive:
 
 ## Finding Format
 
-### Initial Findings (Per-Agent Output) -- 5 Lines Max
+All finding templates (5-line per-agent format, structured dedup fields, full report format for Critical/High, and final report template) are in `siege-formats.md`.
 
-```
-**[ID]** [severity] [Active|Hardening] -- [title]
-File: [path]:[line_range] | Agent: [agent_name]
-Attack: [1-sentence exploitation scenario]
-Evidence: [specific code reference or design element]
-Verification: [concrete test or check that confirms the vulnerability]
-```
-
-Agents output findings in this format only. No blast radius, no extended analysis. This keeps per-agent output under 30 lines for a typical 5-finding set.
-
-### Structured Dedup Fields
-
-For mechanical deduplication before steel-manning, each finding also includes structured metadata as a comment block:
-
-```
-<!-- dedup: file=[path] line=[start-end] cwe=[CWE-ID] agent=[agent_name] -->
-```
-
-The orchestrator uses these fields for first-pass mechanical dedup: same file + overlapping line range + same CWE = merge. Steel-man-then-kill runs only on the deduplicated set, reducing synthesis cost.
-
-### Full Report Findings (Critical and High Only) -- Phase 3 Output
-
-Critical and High findings are expanded in the Phase 3 report:
-
-```
-### [ID]: [title]
-**Severity:** [Critical|High] | **Exploitability:** [Active|Hardening] | **Agent:** [agent_name] | **Chain:** [yes/no]
-**File:** [path]:[line_range]
-
-**Exploitation Scenario:**
-[2-4 sentences: who attacks, how, what they gain]
-
-**Blast Radius:**
-- Data exposure: [what data is at risk]
-- User impact: [how many users, what they experience]
-- System impact: [lateral movement, persistence, escalation potential]
-
-**Verification Criteria:**
-1. [Concrete test or reproduction step]
-2. [Expected result that confirms the fix]
-
-**Steel-Man (why this might not be exploitable):**
-[1-2 sentences: strongest case for false positive, and why it was rejected]
-```
-
-Medium and Low findings remain in the 5-line initial format in the final report.
-
-## Output Format (Final Report)
-
-Written to `scratch/<run-id>/report.md` and presented to the user.
-
-```markdown
-# Siege Security Audit Report
-**Target:** [subsystem/artifact name]
-**Commit Anchor:** [full SHA]
-**Date:** [ISO-8601]
-**Intelligence:** [sources consulted, gaps noted]
-**Artifact Type:** [design|plan|code|mixed]
-
-## Scope Limitations
-[What Siege cannot detect -- see Known Limitations. Always present.]
-
-## Attack Chains
-[Multi-step chains identified by Chain Analyst, with full exploitation narrative. Chains are the highest-signal output — present them first so the reviewer sees composed threats before individual findings.
-Chains inherit exploitability from their weakest link: if ANY step in the chain requires a future change to become exploitable, the entire chain is Hardening. A chain is Active only when every step is independently exploitable today.]
-
-## Critical Findings
-### Active Vulnerabilities
-[Full report format for each, or "None"]
-### Hardening
-[Full report format for each, or "None"]
-
-## High Findings
-### Active Vulnerabilities
-[Full report format for each, or "None"]
-### Hardening
-[Full report format for each, or "None"]
-
-## Medium Findings
-[Initial 5-line format for each, or "None". Medium and Low use the compact 5-line format which includes the exploitability tag per-finding. No Active/Hardening sub-grouping — these severities do not block the gate, so triage ordering is less critical.]
-
-## Low Findings
-[Initial 5-line format for each, or "None"]
-
-## Accepted Risks
-[Any findings the user acknowledged with rationale, or "None"]
-
-## Threat Model Delta
-[New surfaces, retired surfaces, drift from prior model]
-
-## Agent Coverage
-[Which agents examined which files -- partition summary]
-```
+Key rules: Agents output 5-line initial format only. Critical/High findings are expanded in Phase 3. Medium/Low stay in compact format. Each finding includes a `<!-- dedup: ... -->` comment for mechanical dedup.
 
 ## Persistence
 
@@ -741,64 +555,9 @@ The `<run-id>` is a timestamp generated at the start of Phase 1 (e.g., `2026-03-
 
 **Tool constraint:** All scratch directory operations (create, read, list, delete) must use Write, Read, and Glob tools — NOT Bash. Safety hooks block Bash commands referencing `.claude/` paths.
 
-### File Inventory
+### File Inventory, Recovery Procedure, and Checkpoint Timing
 
-| File | Written When | Purpose |
-|------|-------------|---------|
-| `commit-anchor.md` | Phase 1 start | TOCTOU prevention |
-| `manifest.md` | Phase 1 Step 2 | Scoped file list |
-| `exposure-map.md` | Phase 1 Step 2.5 | Enumerated endpoints with manifest cross-reference |
-| `gate-approved.md` | User confirms scope | Compaction recovery marker |
-| `intelligence-summary.md` | Phase 1 Step 1 | Pre-fetched intelligence (50 lines) |
-| `<agent>-partition.md` | Before each agent dispatch | Files sent as full source |
-| `<agent>-findings.md` | On agent completion | Per-agent findings |
-| `coverage-map.md` | Before Chain Analyst dispatch | Agent coverage for chain analysis |
-| `tier1-context.md` | Phase 2 Step 1 | Shared Tier 1 context block |
-| `dedup-summary.md` | Phase 3 Step 4 | Raw → deduplicated finding counts and merge log |
-| `report.md` | Phase 3 | Synthesized findings |
-| `fix-journal.md` | Phase 4, per fix round | Cumulative fix history |
-| `round-N-score.md` | Phase 4, per round | Weighted score snapshot |
-| `round-N-findings.md` | Phase 4, per round | Findings per gate round |
-| `round-N-comparison.md` | Phase 4, when judge dispatched | Stagnation judge output |
-| `accepted-risks.md` | Phase 4, on user override | Accepted findings with rationale |
-| `expected-head.md` | Phase 4, after each fix commit | Current expected HEAD SHA after fix rounds |
-| `round-N-verification.md` | Phase 4, after every fix round | Fix verification results per round |
-
-### Recovery Procedure
-
-After compaction:
-1. Glob for `active-run-*.md` to locate scratch directory
-2. Read `commit-anchor.md`. If `round-N-score.md` files exist (Phase 4 in progress), read `expected-head.md` and verify HEAD against that instead. If no Phase 4 files exist, verify HEAD against commit-anchor.md. Mismatch = abort.
-3. Determine phase from file presence:
-   - No `gate-approved.md` -> re-present manifest
-   - `<agent>-findings.md` files -> count completed agents, dispatch remaining
-   - `coverage-map.md` without `chain-analyst-findings.md` -> dispatch Chain Analyst
-   - `report.md` without `round-1-score.md` -> enter Phase 4
-   - `round-N-score.md` files -> resume gate at round N+1
-4. Read `pipeline-status.md` to recover Started timestamp and Recent Events
-5. Output status to user before continuing
-
-### Checkpoint Timing
-
-Emit a Compression State Block at each of the following points:
-- Phase transitions (1→2, 2→3, 3→4, 4→5)
-- Every 2 gate rounds in Phase 4
-- Before stagnation judge dispatch
-- On health transitions (GREEN→YELLOW, YELLOW→RED, etc.)
-
-**Block content:**
-```
-## Compression State
-- Goal: [current siege objective]
-- Skill: siege
-- Phase: [current phase and step]
-- Health: [GREEN|YELLOW|RED]
-- Key Decisions: [severity judgments from Phase 3, accepted risks, stagnation outcomes]
-- Active Constraints: [commit anchor SHA, expected-head SHA, gate round, score trajectory]
-- Next Steps: [immediate next action]
-```
-
-**Recovery step 0:** Before file-based recovery (Recovery Procedure step 1), read the Compression State from `pipeline-status.md` to re-establish context.
+See `siege-recovery.md` for the complete file inventory table, recovery procedure after compaction, and compression state block timing/format.
 
 ### Session Tracking
 

--- a/skills/siege/siege-attack-surface-reference.md
+++ b/skills/siege/siege-attack-surface-reference.md
@@ -1,0 +1,81 @@
+# Attack Surface Reference
+
+Reference material for Siege Phase 1 Step 2.5 (Attack Surface Enumeration).
+
+## Framework Detection
+
+Scan manifest files and project configuration to detect which web framework(s) the project uses:
+
+| Signal | Framework |
+|--------|-----------|
+| `package.json` with `express` dependency | Express.js |
+| `package.json` with `fastify` dependency | Fastify |
+| `package.json` with `@nestjs/core` dependency | NestJS |
+| `package.json` with `next` dependency | Next.js |
+| `requirements.txt` or `pyproject.toml` with `flask` | Flask |
+| `requirements.txt` or `pyproject.toml` with `fastapi` | FastAPI |
+| `requirements.txt` or `pyproject.toml` with `django` | Django |
+| `*.csproj` with `Microsoft.AspNetCore` | ASP.NET Core |
+| `Gemfile` with `rails` | Rails |
+| `pom.xml` or `build.gradle` with `spring-boot` | Spring Boot |
+| `go.mod` with `gin-gonic/gin` | Gin (Go) |
+| `go.mod` with `gorilla/mux` | Gorilla Mux (Go) |
+| `Cargo.toml` with `actix-web` | Actix Web (Rust) |
+
+If no framework is detected, skip the rest of Step 2.5 and note in scope limitations: "No recognized web framework detected -- attack surface enumeration skipped." Multiple frameworks: enumerate all.
+
+## Route/Endpoint Enumeration Grep Patterns
+
+For each detected framework, grep project files using these patterns to extract registered routes:
+
+| Framework | Grep Pattern | Example Match |
+|-----------|-------------|---------------|
+| Express.js | `(app\|router)\.(get\|post\|put\|patch\|delete\|all\|use)\s*\(` | `app.get('/api/users', ...)` |
+| Fastify | `(fastify\|server)\.(get\|post\|put\|patch\|delete\|all)\s*\(` | `fastify.post('/login', ...)` |
+| NestJS | `@(Get\|Post\|Put\|Patch\|Delete\|All)\s*\(` | `@Get('users/:id')` |
+| Next.js | Files under `app/` or `pages/api/` (convention-based routing) | `app/api/users/route.ts` |
+| Flask | `@(app\|blueprint)\.(route\|get\|post\|put\|delete)\s*\(` | `@app.route('/login', methods=['POST'])` |
+| FastAPI | `@(app\|router)\.(get\|post\|put\|patch\|delete)\s*\(` | `@router.get('/items/{id}')` |
+| Django | `path\(\s*['"]` or `url\(\s*['"]` in `urls.py` files | `path('api/users/', views.user_list)` |
+| ASP.NET Core | `\[Http(Get\|Post\|Put\|Patch\|Delete)\]` or `\[Route\(` or `Map(Get\|Post\|Put\|Delete)\(` | `[HttpGet("api/users/{id}")]` |
+| Rails | `(get\|post\|put\|patch\|delete\|resources\|resource)\s` in `config/routes.rb` | `resources :users` |
+| Spring Boot | `@(GetMapping\|PostMapping\|PutMapping\|PatchMapping\|DeleteMapping\|RequestMapping)\s*\(` | `@GetMapping("/api/users")` |
+| Gin (Go) | `(r\|router\|group)\.(GET\|POST\|PUT\|PATCH\|DELETE\|Any)\s*\(` | `r.GET("/api/users", ...)` |
+| Gorilla Mux (Go) | `(r\|router)\.HandleFunc\s*\(` | `r.HandleFunc("/api/users", handler)` |
+| Actix Web (Rust) | `\.(route\|resource)\s*\(` or `#\[(get\|post\|put\|patch\|delete)\]` | `#[get("/api/users")]` |
+
+For each match, extract: HTTP method (or "ANY" if indeterminate), route path (raw string), source file path, line number, framework name.
+
+**Auth-signal heuristic (best-effort):** For each endpoint, scan surrounding context (same file, same route registration block) for auth middleware or decorator patterns: `[Authorize]`, `@RequireAuth`, `authenticate`, `isAuthenticated`, `requireLogin`, `@login_required`, `@permission_required`, `auth_guard`, `AuthGuard`, `before_action :authenticate`. Classify each endpoint as `auth: yes | no | unknown`. This is approximate -- false negatives are expected (auth applied at router level may not appear near the route). The classification feeds the exposure map's "Auth" column and helps prioritize: `auth: no` endpoints are highest priority for Boundary Attacker partitioning.
+
+**Limitations (documented in exposure map):**
+- Dynamic route registration (method/path from variables) is not captured
+- Middleware-only mounts (e.g., `app.use('/api', ...)`) are recorded as "middleware mount", not individual endpoints
+- Convention-based routing (Next.js file-based, Rails `resources` expansion) produces approximate routes
+- Auth-signal heuristic is best-effort: router-level or middleware-chain auth may not appear near the route definition, producing false `auth: unknown` classifications
+
+## Exposure Map Format
+
+Write the full exposure map to `scratch/<run-id>/exposure-map.md`:
+
+```markdown
+# Attack Surface Exposure Map
+**Framework(s):** [detected frameworks]
+**Enumeration method:** Static pattern matching
+**Endpoint count:** [N]
+
+## Endpoints
+| # | Method | Route | File | Line | Auth | In Manifest |
+|---|--------|-------|------|------|------|-------------|
+| 1 | GET | /api/users | src/controllers/UserController.ts | 42 | yes | Yes |
+| 2 | DELETE | /admin/purge | src/admin/maintenance.ts | 88 | no | NO -- GAP |
+
+## Coverage Gaps
+- `/admin/purge` (src/admin/maintenance.ts:88) -- file not in Siege manifest
+[list all gaps]
+
+## Scope Limitations
+[framework-specific limitations from sub-step B]
+```
+
+**Line budget:** The exposure map summary appended to Tier 1 context (Step 1 of Automated Context Assembly) is capped at **15 lines**: endpoint count, gap count, and the gap list. The full endpoint table remains in `scratch/<run-id>/exposure-map.md` only.

--- a/skills/siege/siege-formats.md
+++ b/skills/siege/siege-formats.md
@@ -1,0 +1,99 @@
+# Siege Finding and Report Formats
+
+Templates for findings output and final report structure.
+
+## Initial Findings (Per-Agent Output) -- 5 Lines Max
+
+```
+**[ID]** [severity] [Active|Hardening] -- [title]
+File: [path]:[line_range] | Agent: [agent_name]
+Attack: [1-sentence exploitation scenario]
+Evidence: [specific code reference or design element]
+Verification: [concrete test or check that confirms the vulnerability]
+```
+
+Agents output findings in this format only. No blast radius, no extended analysis. This keeps per-agent output under 30 lines for a typical 5-finding set.
+
+### Structured Dedup Fields
+
+For mechanical deduplication before steel-manning, each finding also includes structured metadata as a comment block:
+
+```
+<!-- dedup: file=[path] line=[start-end] cwe=[CWE-ID] agent=[agent_name] -->
+```
+
+The orchestrator uses these fields for first-pass mechanical dedup: same file + overlapping line range + same CWE = merge. Steel-man-then-kill runs only on the deduplicated set, reducing synthesis cost.
+
+## Full Report Findings (Critical and High Only) -- Phase 3 Output
+
+Critical and High findings are expanded in the Phase 3 report:
+
+```
+### [ID]: [title]
+**Severity:** [Critical|High] | **Exploitability:** [Active|Hardening] | **Agent:** [agent_name] | **Chain:** [yes/no]
+**File:** [path]:[line_range]
+
+**Exploitation Scenario:**
+[2-4 sentences: who attacks, how, what they gain]
+
+**Blast Radius:**
+- Data exposure: [what data is at risk]
+- User impact: [how many users, what they experience]
+- System impact: [lateral movement, persistence, escalation potential]
+
+**Verification Criteria:**
+1. [Concrete test or reproduction step]
+2. [Expected result that confirms the fix]
+
+**Steel-Man (why this might not be exploitable):**
+[1-2 sentences: strongest case for false positive, and why it was rejected]
+```
+
+Medium and Low findings remain in the 5-line initial format in the final report.
+
+## Final Report Template
+
+Written to `scratch/<run-id>/report.md` and presented to the user.
+
+```markdown
+# Siege Security Audit Report
+**Target:** [subsystem/artifact name]
+**Commit Anchor:** [full SHA]
+**Date:** [ISO-8601]
+**Intelligence:** [sources consulted, gaps noted]
+**Artifact Type:** [design|plan|code|mixed]
+
+## Scope Limitations
+[What Siege cannot detect -- see Known Limitations. Always present.]
+
+## Attack Chains
+[Multi-step chains identified by Chain Analyst, with full exploitation narrative. Chains are the highest-signal output — present them first so the reviewer sees composed threats before individual findings.
+Chains inherit exploitability from their weakest link: if ANY step in the chain requires a future change to become exploitable, the entire chain is Hardening. A chain is Active only when every step is independently exploitable today.]
+
+## Critical Findings
+### Active Vulnerabilities
+[Full report format for each, or "None"]
+### Hardening
+[Full report format for each, or "None"]
+
+## High Findings
+### Active Vulnerabilities
+[Full report format for each, or "None"]
+### Hardening
+[Full report format for each, or "None"]
+
+## Medium Findings
+[Initial 5-line format for each, or "None". Medium and Low use the compact 5-line format which includes the exploitability tag per-finding. No Active/Hardening sub-grouping — these severities do not block the gate, so triage ordering is less critical.]
+
+## Low Findings
+[Initial 5-line format for each, or "None"]
+
+## Accepted Risks
+[Any findings the user acknowledged with rationale, or "None"]
+
+## Threat Model Delta
+[New surfaces, retired surfaces, drift from prior model]
+
+## Agent Coverage
+[Which agents examined which files -- partition summary]
+```

--- a/skills/siege/siege-recovery.md
+++ b/skills/siege/siege-recovery.md
@@ -1,0 +1,62 @@
+# Siege Recovery Reference
+
+Recovery procedures, file inventory, and checkpoint timing for compaction resilience.
+
+## File Inventory
+
+| File | Written When | Purpose |
+|------|-------------|---------|
+| `commit-anchor.md` | Phase 1 start | TOCTOU prevention |
+| `manifest.md` | Phase 1 Step 2 | Scoped file list |
+| `exposure-map.md` | Phase 1 Step 2.5 | Enumerated endpoints with manifest cross-reference |
+| `gate-approved.md` | User confirms scope | Compaction recovery marker |
+| `intelligence-summary.md` | Phase 1 Step 1 | Pre-fetched intelligence (50 lines) |
+| `<agent>-partition.md` | Before each agent dispatch | Files sent as full source |
+| `<agent>-findings.md` | On agent completion | Per-agent findings |
+| `coverage-map.md` | Before Chain Analyst dispatch | Agent coverage for chain analysis |
+| `tier1-context.md` | Phase 2 Step 1 | Shared Tier 1 context block |
+| `dedup-summary.md` | Phase 3 Step 4 | Raw -> deduplicated finding counts and merge log |
+| `report.md` | Phase 3 | Synthesized findings |
+| `fix-journal.md` | Phase 4, per fix round | Cumulative fix history |
+| `round-N-score.md` | Phase 4, per round | Weighted score snapshot |
+| `round-N-findings.md` | Phase 4, per round | Findings per gate round |
+| `round-N-comparison.md` | Phase 4, when judge dispatched | Stagnation judge output |
+| `accepted-risks.md` | Phase 4, on user override | Accepted findings with rationale |
+| `expected-head.md` | Phase 4, after each fix commit | Current expected HEAD SHA after fix rounds |
+| `round-N-verification.md` | Phase 4, after every fix round | Fix verification results per round |
+
+## Recovery Procedure
+
+After compaction:
+1. Glob for `active-run-*.md` to locate scratch directory
+2. Read `commit-anchor.md`. If `round-N-score.md` files exist (Phase 4 in progress), read `expected-head.md` and verify HEAD against that instead. If no Phase 4 files exist, verify HEAD against commit-anchor.md. Mismatch = abort.
+3. Determine phase from file presence:
+   - No `gate-approved.md` -> re-present manifest
+   - `<agent>-findings.md` files -> count completed agents, dispatch remaining
+   - `coverage-map.md` without `chain-analyst-findings.md` -> dispatch Chain Analyst
+   - `report.md` without `round-1-score.md` -> enter Phase 4
+   - `round-N-score.md` files -> resume gate at round N+1
+4. Read `pipeline-status.md` to recover Started timestamp and Recent Events
+5. Output status to user before continuing
+
+**Recovery step 0:** Before file-based recovery (Recovery Procedure step 1), read the Compression State from `pipeline-status.md` to re-establish context.
+
+## Checkpoint Timing
+
+Emit a Compression State Block at each of the following points:
+- Phase transitions (1->2, 2->3, 3->4, 4->5)
+- Every 2 gate rounds in Phase 4
+- Before stagnation judge dispatch
+- On health transitions (GREEN->YELLOW, YELLOW->RED, etc.)
+
+**Block content:**
+```
+## Compression State
+- Goal: [current siege objective]
+- Skill: siege
+- Phase: [current phase and step]
+- Health: [GREEN|YELLOW|RED]
+- Key Decisions: [severity judgments from Phase 3, accepted risks, stagnation outcomes]
+- Active Constraints: [commit anchor SHA, expected-head SHA, gate round, score trajectory]
+- Next Steps: [immediate next action]
+```

--- a/skills/stocktake/EFFICIENCY.md
+++ b/skills/stocktake/EFFICIENCY.md
@@ -1,0 +1,108 @@
+# Efficiency Report — Detailed Flow
+
+Reference document for the stocktake skill's efficiency report mode. See [SKILL.md](./SKILL.md) for the main skill definition.
+
+## Step 1: Load Chronicle Data
+
+1. Read `~/.claude/projects/<hash>/memory/chronicle/signals.jsonl`
+2. If the file is missing or empty: report "No efficiency data available. Run a pipeline with enriched manifest tracking to begin collecting data." and stop.
+3. Filter to signals that have a `metrics.efficiency` sub-object.
+4. If fewer than 3 signals have efficiency data: report available data with caveat: "Insufficient data for trend analysis. N signals available, 3+ recommended for meaningful comparison."
+5. Report: "N of M total signals include efficiency data." (where M is total signals, N is signals with efficiency).
+
+## Step 2: Per-Skill Summary
+
+Group filtered signals by `skill`. For each skill, compute:
+- **Runs**: count of signals
+- **Avg Est. Tokens (in+out)**: average of `(est_input_tokens + est_output_tokens)` across runs
+- **Avg Duration**: average `duration_m`
+- **Avg Dispatches**: average total dispatches (sum of `dispatches_by_tier` values)
+- **Rework %**: average `rework_pct` across runs. If `rework_pct` is missing (pre-rework-tracking signal), display "—"
+- **Trend**: compare last 3 runs vs prior 3 runs — "improving" (fewer tokens), "stable" (within 10%), or "increasing" (more tokens). "insufficient data" if fewer than 4 runs.
+
+If any skill has average rework >30%, append a note: "**[skill]**: rework >30% — consider reviewing dispatch templates or quality-gate prompts for this skill."
+
+Output:
+
+```
+## Skill Efficiency Report
+**Period:** <oldest signal date> to <newest signal date>
+**Tracked runs:** N
+**Disclaimer:** Estimates based on dispatch file sizes (chars/4). Actual token consumption may vary +/-30%.
+
+### Per-Skill Summary
+| Skill | Runs | Avg Est. Tokens (in+out) | Rework % | Avg Duration | Avg Dispatches | Trend |
+|-------|------|--------------------------|----------|--------------|----------------|-------|
+```
+
+## Step 3: Dispatch Breakdown
+
+For each skill, compute dispatch tier distribution and categorize dispatches as review vs. implementation:
+- **Opus/Sonnet/Haiku %**: from `dispatches_by_tier` averaged across runs
+- **Review %**: dispatches with role containing "reviewer", "red-team", "quality-gate", "adversarial" as a percentage of total
+- **Impl %**: remaining dispatches as a percentage of total
+
+Note: Review vs. implementation breakdown requires reading manifest entries (role field). If manifests are not available (only chronicle signals), report "N/A" for these columns.
+
+Output:
+
+```
+### Dispatch Breakdown
+| Skill | Opus % | Sonnet % | Haiku % | Review % | Impl % |
+|-------|--------|----------|---------|----------|--------|
+```
+
+## Step 4: Structural Efficiency
+
+For each skill, compute:
+- **Avg Input/Dispatch**: average `total_input_chars / total dispatches` — measures context per subagent
+- **Context Distribution**: qualitative assessment — "focused" (<5000 chars avg/dispatch), "moderate" (5000-15000), "heavy" (>15000)
+- **Quality Overhead %**: `review dispatches / total dispatches * 100` — what fraction of work is quality assurance (requires manifest data; "N/A" if unavailable)
+
+Output:
+
+```
+### Structural Efficiency
+| Skill | Avg Input/Dispatch | Context Distribution | Quality Overhead % |
+|-------|--------------------|-----------------------|--------------------|
+```
+
+## Step 5: Baseline Comparison (Structural)
+
+For each skill with sufficient data (3+ runs):
+- **Avg Total Context**: average `(total_input_chars + total_output_chars)` per run — total context the pipeline touched
+- **Avg Input/Dispatch**: average `total_input_chars / total dispatches` per run — how much context each subagent receives on average
+- **Context Focus Ratio**: `avg input per dispatch / avg total context` — lower values mean each subagent sees a smaller slice of the total, indicating effective context distribution
+- **Quality Investment**: `review dispatches / total dispatches` — fraction of dispatches dedicated to quality assurance (requires manifest data; "N/A" if only chronicle signals available)
+
+Output:
+
+```
+### Baseline Comparison (Structural)
+| Skill | Avg Total Context | Avg Input/Dispatch | Context Focus Ratio | Quality Investment |
+|-------|-------------------|--------------------|---------------------|--------------------|
+
+**Interpretation:** Context focus ratio measures how much of the total pipeline context each
+subagent receives. Lower values mean more focused dispatches. Quality investment shows the
+fraction of dispatches dedicated to review, red-team, and quality gates. These are structural
+comparisons, not cost savings claims — they measure how the skill distributes work, not what
+a monolithic alternative would cost.
+```
+
+## Step 6: Cache Results
+
+Save efficiency report data to `skills/stocktake/results.json` under a new `efficiency` key (separate from the skill verdict cache):
+
+```json
+{
+  "efficiency": {
+    "computed_at": "2026-04-07T10:00:00Z",
+    "signals_with_efficiency": 15,
+    "total_signals": 42,
+    "per_skill": {
+      "build": { "runs": 8, "avg_est_tokens": 52600, "avg_duration_m": 45, "trend": "stable" },
+      "debugging": { "runs": 5, "avg_est_tokens": 25000, "avg_duration_m": 22, "trend": "improving" }
+    }
+  }
+}
+```

--- a/skills/stocktake/SKILL.md
+++ b/skills/stocktake/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: stocktake
-description: Audits all crucible skills for overlap, staleness, broken references, and quality. Quick scan or full evaluation modes.
-origin: crucible
+description: "Audits all crucible skills for overlap, staleness, broken references, and quality. Use when the user wants to check my skills, run a skill review, find duplicate skills, perform skill cleanup, do skill maintenance, or get a skill health check. Supports quick scan, full stocktake, and efficiency report modes."
 ---
 
 # Skill Stocktake
@@ -41,14 +40,11 @@ Audits all crucible skills for overlap, staleness, broken references, and qualit
 ### Phase 1 — Inventory
 
 Enumerate all skill directories under `skills/`. For each:
-- Read SKILL.md frontmatter (name, description, origin)
+- Read SKILL.md frontmatter (name, description)
 - Collect file mtime
 - Note file count and total line count
 
-Present inventory table:
-
-| Skill | Files | Lines | Last Modified | Description |
-|-------|-------|-------|---------------|-------------|
+Present inventory as a table with columns: Skill, Files, Lines, Last Modified, Description.
 
 ### Phase 2 — Quality Evaluation
 
@@ -61,14 +57,7 @@ Each skill is evaluated against:
 - [ ] Actionability — concrete steps vs vague advice
 - [ ] Cross-references — do `crucible:` links resolve to existing skills?
 
-Each skill gets a verdict:
-
-| Verdict | Meaning |
-|---------|---------|
-| Keep | Useful and current |
-| Improve | Worth keeping, specific improvements needed |
-| Retire | Low quality, stale, or cost-asymmetric |
-| Merge into [X] | Substantial overlap with another skill; name the merge target |
+Each skill gets a verdict: **Keep** (useful and current), **Improve** (worth keeping, specific improvements needed), **Retire** (low quality, stale, or cost-asymmetric), or **Merge into [X]** (substantial overlap with another skill; name the merge target).
 
 **Reason quality requirements** — the `reason` field must be self-contained and decision-enabling:
 - For **Retire**: state (1) what specific defect was found, (2) what covers the same need instead
@@ -76,13 +65,11 @@ Each skill gets a verdict:
 - For **Improve**: describe the specific change needed (what section, what action)
 - For **Keep**: restate the core evidence for the verdict
 
-### Phase 3 — Summary Table
+### Phase 3 — Summary & Consolidation
 
-| Skill | Verdict | Reason |
-|-------|---------|--------|
+Present a summary table with columns: Skill, Verdict, Reason.
 
-### Phase 4 — Consolidation
-
+Then consolidate:
 1. **Retire / Merge**: present detailed justification per skill before confirming with user
 2. **Improve**: present specific improvement suggestions with rationale
 3. Save results to `skills/stocktake/results.json`
@@ -91,110 +78,15 @@ Each skill gets a verdict:
 
 Triggered by `/stocktake efficiency` or by forge feed-forward when 10+ chronicle signals with efficiency data exist.
 
-### Step 1: Load Chronicle Data
+Analyzes chronicle signal data to produce per-skill efficiency metrics including token estimates, dispatch breakdowns, structural efficiency, and baseline comparisons. Full step-by-step flow is documented in [EFFICIENCY.md](./EFFICIENCY.md).
 
-1. Read `~/.claude/projects/<hash>/memory/chronicle/signals.jsonl`
-2. If the file is missing or empty: report "No efficiency data available. Run a pipeline with enriched manifest tracking to begin collecting data." and stop.
-3. Filter to signals that have a `metrics.efficiency` sub-object.
-4. If fewer than 3 signals have efficiency data: report available data with caveat: "Insufficient data for trend analysis. N signals available, 3+ recommended for meaningful comparison."
-5. Report: "N of M total signals include efficiency data." (where M is total signals, N is signals with efficiency).
-
-### Step 2: Per-Skill Summary
-
-Group filtered signals by `skill`. For each skill, compute:
-- **Runs**: count of signals
-- **Avg Est. Tokens (in+out)**: average of `(est_input_tokens + est_output_tokens)` across runs
-- **Avg Duration**: average `duration_m`
-- **Avg Dispatches**: average total dispatches (sum of `dispatches_by_tier` values)
-- **Rework %**: average `rework_pct` across runs. If `rework_pct` is missing (pre-rework-tracking signal), display "—"
-- **Trend**: compare last 3 runs vs prior 3 runs — "improving" (fewer tokens), "stable" (within 10%), or "increasing" (more tokens). "insufficient data" if fewer than 4 runs.
-
-If any skill has average rework >30%, append a note: "**[skill]**: rework >30% — consider reviewing dispatch templates or quality-gate prompts for this skill."
-
-Output:
-
-```
-## Skill Efficiency Report
-**Period:** <oldest signal date> to <newest signal date>
-**Tracked runs:** N
-**Disclaimer:** Estimates based on dispatch file sizes (chars/4). Actual token consumption may vary +/-30%.
-
-### Per-Skill Summary
-| Skill | Runs | Avg Est. Tokens (in+out) | Rework % | Avg Duration | Avg Dispatches | Trend |
-|-------|------|--------------------------|----------|--------------|----------------|-------|
-```
-
-### Step 3: Dispatch Breakdown
-
-For each skill, compute dispatch tier distribution and categorize dispatches as review vs. implementation:
-- **Opus/Sonnet/Haiku %**: from `dispatches_by_tier` averaged across runs
-- **Review %**: dispatches with role containing "reviewer", "red-team", "quality-gate", "adversarial" as a percentage of total
-- **Impl %**: remaining dispatches as a percentage of total
-
-Note: Review vs. implementation breakdown requires reading manifest entries (role field). If manifests are not available (only chronicle signals), report "N/A" for these columns.
-
-Output:
-
-```
-### Dispatch Breakdown
-| Skill | Opus % | Sonnet % | Haiku % | Review % | Impl % |
-|-------|--------|----------|---------|----------|--------|
-```
-
-### Step 4: Structural Efficiency
-
-For each skill, compute:
-- **Avg Input/Dispatch**: average `total_input_chars / total dispatches` — measures context per subagent
-- **Context Distribution**: qualitative assessment — "focused" (<5000 chars avg/dispatch), "moderate" (5000-15000), "heavy" (>15000)
-- **Quality Overhead %**: `review dispatches / total dispatches * 100` — what fraction of work is quality assurance (requires manifest data; "N/A" if unavailable)
-
-Output:
-
-```
-### Structural Efficiency
-| Skill | Avg Input/Dispatch | Context Distribution | Quality Overhead % |
-|-------|--------------------|-----------------------|--------------------|
-```
-
-### Step 5: Baseline Comparison (Structural)
-
-For each skill with sufficient data (3+ runs):
-- **Avg Total Context**: average `(total_input_chars + total_output_chars)` per run — total context the pipeline touched
-- **Avg Input/Dispatch**: average `total_input_chars / total dispatches` per run — how much context each subagent receives on average
-- **Context Focus Ratio**: `avg input per dispatch / avg total context` — lower values mean each subagent sees a smaller slice of the total, indicating effective context distribution
-- **Quality Investment**: `review dispatches / total dispatches` — fraction of dispatches dedicated to quality assurance (requires manifest data; "N/A" if only chronicle signals available)
-
-Output:
-
-```
-### Baseline Comparison (Structural)
-| Skill | Avg Total Context | Avg Input/Dispatch | Context Focus Ratio | Quality Investment |
-|-------|-------------------|--------------------|---------------------|--------------------|
-
-**Interpretation:** Context focus ratio measures how much of the total pipeline context each
-subagent receives. Lower values mean more focused dispatches. Quality investment shows the
-fraction of dispatches dedicated to review, red-team, and quality gates. These are structural
-comparisons, not cost savings claims — they measure how the skill distributes work, not what
-a monolithic alternative would cost.
-```
-
-### Step 6: Cache Results
-
-Save efficiency report data to `skills/stocktake/results.json` under a new `efficiency` key (separate from the skill verdict cache):
-
-```json
-{
-  "efficiency": {
-    "computed_at": "2026-04-07T10:00:00Z",
-    "signals_with_efficiency": 15,
-    "total_signals": 42,
-    "per_skill": {
-      "build": { "runs": 8, "avg_est_tokens": 52600, "avg_duration_m": 45, "trend": "stable" },
-      "debugging": { "runs": 5, "avg_est_tokens": 25000, "avg_duration_m": 22, "trend": "improving" }
-    }
-  }
-}
-```
+**Summary of steps:**
+1. **Load chronicle data** — read and filter signals from `signals.jsonl`
+2. **Per-skill summary** — compute runs, avg tokens, duration, dispatches, rework %, and trend
+3. **Dispatch breakdown** — tier distribution (Opus/Sonnet/Haiku) and review vs. implementation split
+4. **Structural efficiency** — avg input per dispatch, context distribution, quality overhead
+5. **Baseline comparison** — context focus ratio and quality investment metrics
+6. **Cache results** — save to `results.json` under the `efficiency` key
 
 ## Results File Schema
 


### PR DESCRIPTION
Hey @raddue 👋

41 skills with blind A/B evals showing a +29% delta on Opus 4.6. That's the most rigorous skill quality measurement I've seen in any collection. The quality-gate loop alone (68% delta, 0% process expectation without the skill) makes the case that structured methodology isn't optional. I'd like to contribute some improvements to a few of the skill files.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="910" alt="score_card" src="https://github.com/user-attachments/assets/9e62bbf7-076b-4e6c-b03e-e8cd192bee59" />


Changes:

forge (60% → 85%)
- Rewrote frontmatter description with concrete actions, outputs, and natural trigger terms
- Extracted Trajectory Capture and Chronicle Signal details into reference files
- Merged Rationalization Prevention + Common Mistakes + Red Flags into compact section
- Reduced SKILL.md from 597 to 340 lines (43% reduction)

recon (65% → 94%)
- Replaced internal jargon with natural user terms in description
- Extracted Brief Schema Stability into SCHEMA.md, Integration into INTEGRATION.md
- Removed Design Principles section and explanatory paragraphs Claude can infer
- Reduced SKILL.md from 566 to 473 lines (16% reduction)

siege (84% → 84%)
- Description already scored 100% — left untouched
- Extracted framework detection tables, finding formats, and recovery procedures into reference files
- Removed meta-documentation sections
- Reduced SKILL.md from 939 to 698 lines (26% reduction)

prospector (80% → 84%)
- Enhanced description with concrete actions (coupling hotspots, circular dependencies, god classes)
- Consolidated repeated Write-on-complete patterns
- Extracted constraint mapping, convergence logic, trajectory schema into REFERENCE.md
- Reduced SKILL.md from 731 to 603 lines (18% reduction)

stocktake (66% → 94%)
- Added explicit "Use when..." clause with natural trigger terms
- Removed unknown frontmatter key
- Extracted Efficiency Report flow into EFFICIENCY.md reference file
- Reduced SKILL.md from 234 to 126 lines (46% reduction)

Honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

I also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

This means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide (https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @yogesh-tessl (https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏