### PR TITLE
feat(skills): anti-rationalization tables for build/spec/quality-gate/design (#176)

### DIFF
--- a/docs/plans/2026-04-16-anti-rationalization-tables-implementation-plan.md
+++ b/docs/plans/2026-04-16-anti-rationalization-tables-implementation-plan.md
@@ -35,8 +35,8 @@ table, verify).
 - **Verification:**
   1. `grep -n 'Anti-Rationalization' skills/build/SKILL.md` returns a line in
      the 47–50 range.
-  2. `grep -c '^| ' skills/build/SKILL.md` — count increases by the number of
-     data rows + 1 (header) + 1 (separator).
+  2. The awk block in the post-impl Verification Checklist (AC-2) reports
+     `5 ≤ data-row-count ≤ 8` for `skills/build/SKILL.md`.
 - **Rollback:** `git checkout -- skills/build/SKILL.md`.
 
 ### T2: Insert table into `skills/spec/SKILL.md`
@@ -96,12 +96,44 @@ table, verify).
 
 ## Verification Checklist (post-implementation)
 
-- [ ] AC-1: `for f in skills/{build,spec,quality-gate,design}/SKILL.md; do
+- [ ] AC-1: `for f in skills/build/SKILL.md skills/spec/SKILL.md skills/quality-gate/SKILL.md skills/design/SKILL.md; do
   grep -l 'Anti-Rationalization' "$f"; done` prints all 4 paths.
-- [ ] AC-2: Each table has ≥5 data rows (counted between the heading and the
-  next `## ` heading, subtracting 2 for header+separator).
-- [ ] AC-3: Each table is in `SKILL.md`, not a sidecar file.
-- [ ] AC-4: Each table precedes the first procedural section.
+- [ ] AC-2: For each of the 4 files, the awk block below prints a data-row
+  count of 5–8 (inclusive) between the `## Anti-Rationalization Table` heading
+  and the next `## ` heading:
+
+  ```bash
+  for f in skills/build/SKILL.md skills/spec/SKILL.md skills/quality-gate/SKILL.md skills/design/SKILL.md; do
+    awk '
+      /^## Anti-Rationalization Table/ {in_tbl=1; next}
+      in_tbl && /^## / {in_tbl=0}
+      in_tbl && /^\|/ {n++}
+      END {print FILENAME": "(n>=2?n-2:0)" data rows"}
+    ' "$f"
+  done
+  ```
+
+  (Subtracts 2 for the header row and the `|---|` separator row; asserts
+  `5 ≤ count ≤ 8` per DEC-5.)
+- [ ] AC-3: All 4 paths in AC-1 end in `SKILL.md` (not a sidecar file).
+- [ ] AC-4: For each file, the line number of `## Anti-Rationalization Table`
+  is less than the line number of the first procedural heading listed in
+  INV-4 of the contract. Quick check:
+
+  ```bash
+  for f in skills/build/SKILL.md skills/spec/SKILL.md skills/quality-gate/SKILL.md skills/design/SKILL.md; do
+    tbl=$(grep -n '^## Anti-Rationalization Table' "$f" | head -1 | cut -d: -f1)
+    proc=$(grep -nE '^## (The Process|Gate Ledger Protocol|Pipeline Status|Orchestration Flow|How It Works|Phase [0-9])' "$f" | head -1 | cut -d: -f1)
+    echo "$f: table@${tbl} proc@${proc}"
+    [ -n "$tbl" ] && [ -n "$proc" ] && [ "$tbl" -lt "$proc" ] || echo "  FAIL"
+  done
+  ```
+- [ ] AC-5 (heading format, load-bearing): exactly one match per file for the
+  em-dash heading — `grep -c '^## Anti-Rationalization Table — ' <file>`
+  returns `1` for all 4 files. ASCII `--` will fail this check, protecting
+  INV from accidental ASCII substitution.
+- [ ] INV-5 (additive-only): `git diff HEAD~N -- skills/*/SKILL.md` on the
+  #176 commits shows no deletions inside existing `## Red Flags` blocks.
 - [ ] Quality gate dispatched on the changed docs before commit (per
   `feedback_quality_gate_always`).
 - [ ] Innovate + red-team run on the final set (per `feedback_never_skip_gates`).

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -45,6 +45,18 @@ NEVER skip quality gate steps. Every artifact must pass its quality gate before 
 
 **If you find yourself about to skip a gate:** STOP. Re-read this section. The gate exists because skipping it has caused real production incidents and hours of wasted time. Run the gate.
 
+## Anti-Rationalization Table — build
+
+| Rationalization | Rebuttal | Rule |
+|---|---|---|
+| "This task is small/simple/trivial, the quality gate would just find nits." | Small changes have the same bug density per line as large ones. QG has never run on a Crucible artifact without finding at least one real issue. | Run the quality gate on every phase artifact, regardless of size. |
+| "Phase N looks fine, I can skip the gate and move on." | Self-assessment of artifact quality is exactly the bias the gate exists to counter. "Looks fine" is the failure mode, not a pass criterion. | Phase transitions are BLOCKED without a verified PASS verdict marker for the prior phase. |
+| "The fix agent addressed the findings, so the gate is done." | Fixing is not passing. Fix rounds routinely introduce new issues or incompletely resolve old ones. A clean verification round is required. | The gate is only complete after a fresh red-team round returns 0 Fatal, 0 Significant. |
+| "The user said 'looks good' / 'move on' — that's approval to skip the gate." | General feedback is not skip approval. Only an unambiguous instruction that explicitly references the gate counts. | Require literal `SKIP GATE` (or equivalent explicit phrase) before recording `Status: SKIPPED`. |
+| "I can fix this one finding myself instead of dispatching a fix agent." | Orchestrator-applied fixes conflate coordination with remediation and bypass the fix journal. Every fix — even trivial — goes through a fix agent. | Orchestrator never edits the artifact directly; always dispatch the fix agent. |
+| "Innovate/red-team seem redundant on top of the quality gate, I'll skip them." | They are not redundant. Innovate is divergent; red-team is adversarial; QG is iterative remediation. Skipping any one of them is a documented regression (`feedback_never_skip_gates`). | Run innovate and red-team on every artifact, every time. |
+| "I'll just finish the task list and narrate at the end." | Long-running autonomous pipelines are invisible without narration. Silent runs prevent the user from intervening or learning. | Narrate before every dispatch and after every completion — non-negotiable. |
+
 ## Gate Ledger Protocol
 
 Tamper-evident audit trail for phase transitions and gate verdicts. This is defense-in-depth — it raises the cost of gate-skipping from zero to nonzero by requiring structured state to be maintained and verified. An external enforcement hook (`gate-ledger-guard.sh`) provides mechanical enforcement by blocking unauthorized PASS writes.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -14,6 +14,17 @@ Turn ideas into fully formed designs through investigated, collaborative dialogu
 
 Every significant design question is backed by parallel investigation agents that research the codebase, explore approaches, and assess impact BEFORE the question reaches the user. Questions arrive informed, not naive.
 
+## Anti-Rationalization Table — design
+
+| Rationalization | Rebuttal | Rule |
+|---|---|---|
+| "This decision is obvious, I can skip the hypothesis step." | The hypothesis step is a forcing function for noticing surprises — the most valuable output of investigation. Skipping it loses the contrast. | Write the hypothesis before dispatching investigation agents, even when the answer feels obvious. |
+| "One investigation agent is enough, I don't need the Challenger." | The Challenger catches assumption blind spots that the recommendation agent inherited. Skipping it is how bad designs ship. | Deep Dive dimensions always dispatch the Challenger (or multi-model consensus challenge when available). |
+| "Quick scan is fine for this data-model decision." | Data-model decisions always warrant Deep Dive — schema outlives the application. Quick scans have repeatedly missed grain/durability issues. | Any dimension touching schema/data model/persistent storage is Deep Dive, not Quick scan. |
+| "The recommendation is clear, I can skip presenting alternatives." | Presenting 2–3 options keeps the user in the decision loop. Auto-resolving without alternatives is only allowed when investigation proves a single viable path. | Present 2–3 options per dimension unless the investigation explicitly shows one viable path; record the justification. |
+| "The feature obviously belongs in this system, skip the scope absorption test." | The test is cheap (4 yes/no questions) and has repeatedly flagged features that didn't belong. | Run the scope absorption test whenever adding a feature to an existing system. |
+| "The user is still deliberating, I'll keep asking for more analysis." | After 2 non-resolving user responses, the stall-breaker protocol (eliminate / reversibility / ship-sooner) applies. | Activate the stall-breaker protocol on the 3rd user exchange on the same dimension without resolution. |
+
 ## The Process
 
 ### Phase 1: Context Gathering

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -96,6 +96,18 @@ would create non-deterministic stagnation behavior.
 - External review timeout or failure never blocks or delays the host red-team
   round.
 
+## Anti-Rationalization Table — quality-gate
+
+| Rationalization | Rebuttal | Rule |
+|---|---|---|
+| "This finding is minor, I'll just fix it inline instead of dispatching a fix agent." | Orchestrator-applied fixes break separation of concerns and corrupt the fix journal. Fix-agent overhead for trivial fixes is negligible; the risk of conflation is not. | All fixes route through the fix agent — no exceptions, no matter how small. |
+| "Round N fixed everything, I can return PASS without another red-team round." | Fixing is not passing. A fresh red-team round is the verification step. Skipping it is a skip disguised as a pass. | The gate is only PASS after a fresh red-team round returns 0 Fatal, 0 Significant. |
+| "The red-team finding is wrong / overblown, I'll mark it resolved without a fix." | Rationalizing away findings defeats the point of adversarial review. If a finding is wrong, the fix agent explicitly justifies dismissal in the fix journal — the orchestrator does not dismiss findings unilaterally. | Every Fatal/Significant finding is either fixed or documented as dismissed by the fix agent with reasoning. |
+| "The score went up but I can tell it's close, skip the stagnation judge." | Stagnation detection uses weighted score, not orchestrator intuition. Score-based inline judgment is the exact failure the judge exists to catch. | Dispatch the stagnation judge whenever score is not strictly lower than the prior round. |
+| "Round 15 hit — I'll squeeze in one more round, surely the next will pass." | The 15-round limit is a circuit breaker, not a suggestion. Exceeding it silently is how runaway loops happen. | At round 15, escalate to the user with full round history — never silently continue. |
+| "Pre-flight dependency audit is noise for this artifact, skip it." | The audit only runs on `code` artifacts, and on code artifacts it's mandatory. Dependency drift is a documented source of shipped bugs. | Run the dependency audit on every `code` artifact; skip silently only for non-code types. |
+| "The user said 'move on', that's approval to skip the gate." | General feedback is never skip approval. Skip requires an unambiguous instruction specifically referencing the gate. | Only an explicit, gate-referencing instruction counts as skip approval. |
+
 ## How It Works
 
 1. Receives: artifact content, artifact type, project context

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -37,6 +37,17 @@ Every status update must include:
 **Example of GOOD narration:**
 > "Wave 2 complete. 3/3 tickets committed. 1 medium-confidence alert on #45 (chose Redis over Postgres for session store). #67 re-queued to Wave 3 (new dependency on #45 discovered). Overall: 7/12 tickets done, 5 remaining across 2 waves."
 
+## Anti-Rationalization Table — spec
+
+| Rationalization | Rebuttal | Rule |
+|---|---|---|
+| "This ticket is small, I can skip the per-document quality gate." | Ticket size does not predict specification defects. Small tickets frequently hide ambiguity that only QG surfaces. | Run the quality gate on every design doc and every implementation plan, regardless of ticket size. |
+| "All per-document gates passed, the integration check is unnecessary." | Per-document PASS does not imply cross-ticket consistency. Contracts drift between tickets even when each is individually clean. | Always run the end-of-run integration quality gate after the per-ticket gates pass. |
+| "The ticket body looks clear, I can skip the investigation and go straight to writing." | Ticket bodies consistently under-specify. Without investigation, autonomous decisions are made without grounding and surface as block-confidence alerts downstream. | Investigate the codebase before writing any design content; cite investigation artifacts in the design doc. |
+| "The decision looks obvious, I'll record it as high-confidence without alternatives." | Listing alternatives is a forcing function for honest confidence calibration. Skipping it hides the fact that no alternatives were considered. | Every decision logs ≥1 alternative or is explicitly marked `no-alternatives: true` with justification. |
+| "I can save state in context memory instead of the scratch directory." | Context is lost on compaction. Scratch-directory state is load-bearing for recovery. | Every orchestrator state change writes to the scratch directory before narrating. |
+| "The user's general 'looks good' counts as approval to skip a gate." | Only an unambiguous instruction specifically referencing the gate is skip approval. | Record `Status: SKIPPED` only after explicit gate-referencing skip instruction. |
+
 ## Pipeline Status
 
 Write a status file to `~/.claude/projects/<hash>/memory/pipeline-status.md` at every narration point. This file is overwritten (not appended) and provides ambient awareness for the user in a second terminal.


### PR DESCRIPTION
Closes #176.

## Summary

Inserts a `## Anti-Rationalization Table` section into four high-impact skills (`build`, `spec`, `quality-gate`, `design`). Each table is a 3-column `Rationalization | Rebuttal | Rule` markdown block, co-loaded with the skill (inline SKILL.md, not a sidecar reference file).

This is the **preventive** layer that pairs with the existing **detective** layer (Red Flags sections + quality gates). Red Flags catch skipped steps after the fact; the anti-rationalization table intercepts the excuse before the agent commits to the shortcut. Additive-only — no existing sections modified.

Pattern inspired by [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills).

## Files modified

- `skills/build/SKILL.md` (7 rows): size-based skip, self-assessment pass, fix≠pass, SKIP GATE literal, orchestrator-as-fixer, skip innovate/red-team, narration-at-end
- `skills/spec/SKILL.md` (6 rows): small ticket skip, integration-check skip, no-investigation, decision-without-alternatives, context-not-scratch, ambiguous-skip-approval
- `skills/quality-gate/SKILL.md` (7 rows): inline-fix-instead-of-agent, fix≠PASS, dismiss-finding, skip-stagnation-judge, round-15-bypass, skip-dep-audit, ambiguous-skip-approval
- `skills/design/SKILL.md` (6 rows): skip-hypothesis, skip-Challenger, quick-scan-data-model, skip-alternatives, skip-scope-absorption, infinite-stall

All tables placed between the skill's non-negotiable preamble and its procedural walkthrough (top-of-attention region).

## Rows pre-authored in the design doc

Implementation was a mechanical paste — no row-authoring at implementation time (DEC-2, `design-doc:Pre-Authored Tables`). Rows seeded from:
- Each skill's existing `## Red Flags` section
- User memory: `feedback_quality_gate_always` ("just 31 lines", "it's only a prompt") and `feedback_never_skip_gates`
- Each skill's own process text (for `design/`)

## Verification

Runnable verification block from `docs/plans/2026-04-16-anti-rationalization-tables-implementation-plan.md` executed green:
- **AC-1** (`grep -l 'Anti-Rationalization'`): 4/4 files match
- **AC-2** (row counts 5 ≤ n ≤ 8): 7/6/7/6
- **AC-4** (table line < first procedural section): all 4 PASS
- **AC-5** (em-dash heading format): 1 match per file (ASCII `--` would fail)
- **INV-5** (additive-only): `git diff` shows zero deletions in Red Flags / Key Principles sections

## Pipeline

Full `/build` pipeline:
- Phase 1 PASS — design doc pre-existing from `/spec` (commit `e71ae76`); inline staleness check confirmed all 4 line-number anchors still valid
- Phase 2 PASS — innovate pass added a runnable verification block + switched T1 row-count to absolute (commit `0f7f355`)
- Phase 3 COMPLETE — 4 tasks (Tier 1 mechanical paste, inline by orchestrator); all ACs/INV verified (commit `399d0bb`)
- Phase 4 PASS — consolidated code-review + QG, 0 Fatal / 0 Significant / 2 Minor (non-blocking)

Branch: `feat/176-anti-rationalization-tables` (off `spec/176-180` which is PR #182 — waiting to merge).

## Test plan

- [ ] Pull branch locally
- [ ] Run verification block (AC-1/AC-2/AC-4/AC-5):
  ```bash
  for f in skills/{build,spec,quality-gate,design}/SKILL.md; do grep -l 'Anti-Rationalization' "$f"; done
  for f in skills/{build,spec,quality-gate,design}/SKILL.md; do
    awk '/^## Anti-Rationalization Table/{i=1;next} i&&/^## /{i=0} i&&/^\|/{n++} END{print FILENAME": "(n>=2?n-2:0)" rows"}' "$f"
  done
  ```
- [ ] Review the rationalizations — are any clearly off-target? (QG flagged 2 Minor phrasings as borderline but non-blocking — see review agent report)
- [ ] Optional: invoke /build or /spec on a trivial task and observe whether the table surfaces in the agent's self-check behavior

## Notes

- Depends structurally on PR #182 (the `/spec` artifacts) since this branch is off `spec/176-180`. PR #182 should merge first; this will auto-rebase onto main cleanly.
- Same pattern can extend to more skills later — intentionally scoped to 4 per ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/build` skill (full pipeline: design→plan→execute→QG→PR)
