### PR TITLE
feat(skills): context trust hierarchy framework + TRUST markers (#180)

### DIFF
--- a/docs/plans/2026-04-16-context-trust-hierarchy-implementation-plan.md
+++ b/docs/plans/2026-04-16-context-trust-hierarchy-implementation-plan.md
@@ -36,6 +36,19 @@ Create the canonical framework doc. Must contain:
 - Conflict resolution rules (higher wins + per-level tie-breakers).
 - Annotation convention (`<!-- TRUST: ... -->` marker) with three example stanzas.
 - Short "When to re-verify" checklist.
+- **Canonical Markers for Crucible Load Points** — an authoritative table the T3–T6 annotators copy from verbatim. This keeps marker wording consistent across skills and makes INV-4 grep-deterministic. Table rows:
+
+  | Load point | Skill(s) | Canonical marker |
+  |---|---|---|
+  | Dispatch manifest consumption | /build | `<!-- TRUST: dispatch manifest is L2 — produced by prior pipeline stage; prefer most recent if conflicting. -->` |
+  | Implementer/subagent report | /build, /recon | `<!-- TRUST: subagent report is L4 — cross-check file paths and claims against L3 source before acting. -->` |
+  | WebFetch result | /build, /design, /source-driven-development | `<!-- TRUST: WebFetch result is L4 — verify against project source (L3) before acting; snippet may be stale. -->` |
+  | Recon brief consumption | /design | `<!-- TRUST: recon brief is L2 — prior-stage artifact; prefer L3 source on any code-behavior conflict. -->` |
+  | User-pasted / user-quoted snippet | /design | `<!-- TRUST: user-quoted snippet is L5 — confirm with user or re-fetch before acting. -->` |
+  | Scout dispatch report | /recon | `<!-- TRUST: scout report is L4 — cross-check paths against L3 before synthesis. -->` |
+  | Synthesis input | /recon | `<!-- TRUST: synthesis input is L4 until cross-verified against L3 source. -->` |
+
+  Annotators in T3–T6 SHOULD use these canonical strings. Deviation is allowed only when the load point is not listed; new rows must be added to this table in the same PR.
 
 **Verification:** `grep -c '^## L[1-5]' skills/getting-started/trust-hierarchy.md` returns 5.
 
@@ -48,9 +61,9 @@ Add a short new section ("Trust Hierarchy") near the bottom linking to `trust-hi
 ### T3 — Annotate `skills/build/SKILL.md`
 
 Add `<!-- TRUST: ... -->` markers at:
-- dispatch manifest consumption (L2)
-- implementer/subagent report consumption (L4)
-- any WebFetch reference (L4)
+- dispatch manifest consumption (L2) — use canonical string from T1 table.
+- implementer/subagent report consumption (L4) — use canonical string from T1 table.
+- WebFetch reference (L4) — only if one exists in the file today; skip silently if none. (Audit note: as of 2026-04-16 skills/build/SKILL.md contains no WebFetch reference, so this bullet is a no-op unless #177 or #176 lands first.)
 
 Add a one-line pointer near the top: "Trust framework: see `skills/getting-started/trust-hierarchy.md`."
 
@@ -112,5 +125,5 @@ All four are plain grep checks — suitable for quality-gate.
 ## Done When
 
 - 3 deliverable files (this design, this plan, contract) exist in `docs/plans/`.
-- T1–T5 complete; T6 complete or explicitly deferred with a note in #177's tracker; T7 complete.
-- INV-1, INV-2, INV-3 all pass.
+- T1–T5 complete; T6 complete or explicitly deferred with a note in #177's tracker; T7 complete (per fallback chain — expected resolution as of 2026-04-16 is option 3: satisfied-by-T2, since neither CLAUDE.md nor skills/README.md exists).
+- INV-1, INV-2, INV-3, INV-4 all pass.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -18,6 +18,8 @@ End-to-end development pipeline: interactive design, autonomous planning with ad
 
 **Guiding principle:** Quality over velocity. This pipeline produces correct, well-integrated, maintainable output — even if slower. Parallel execution is available for independent work, but sequential with quality gates is the default.
 
+<!-- Trust framework: see [skills/getting-started/trust-hierarchy.md](../getting-started/trust-hierarchy.md). -->
+
 ## Communication Requirement (Non-Negotiable)
 
 **Between every agent dispatch and every agent completion, output a status update to the user.** This is NOT optional — the user cannot see agent activity without your narration.
@@ -326,6 +328,7 @@ Output concise inline status alongside the status file write:
 
 After compaction, before re-writing the status file:
 0. Read the `## Compression State` section from `pipeline-status.md` — recover Goal, Key Decisions, Active Constraints, and Next Steps. If the section is absent (pre-update pipeline), skip to step 1.
+<!-- TRUST: dispatch manifest is L2 — produced by prior pipeline stage; prefer most recent if conflicting. -->
 0.5. Check for handoff manifests (`handoff-*-to-*.md`) in the scratch directory. If the most recent manifest exists, use its Inputs, Decisions, and Constraints to reconstruct state for the current phase — this supersedes the Compression State section for phase-boundary recovery. If no manifest exists, continue with CSB-based recovery.
 1. Read the rest of `pipeline-status.md` to recover `Started` timestamp and `Recent Events` buffer
 2. Reconstruct phase, health, and skill-specific body from internal state files
@@ -804,6 +807,7 @@ When a contract YAML exists for the current ticket (detected during Step 0 or pr
 
 #### De-Sloppify Cleanup
 
+<!-- TRUST: subagent report is L4 — cross-check file paths and claims against L3 source before acting. -->
 After the implementer reports completion and before dispatching the reviewer:
 
 **RECOMMENDED:** Use crucible:checkpoint — create checkpoint with reason "pre-cleanup-task-N" before dispatching the cleanup agent. If cleanup removes something needed, restore to this checkpoint.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -10,6 +10,8 @@ description: "You MUST use this before any creative work - creating features, bu
 <!-- CANONICAL: shared/dispatch-convention.md -->
 All subagent dispatches use disk-mediated dispatch. See `shared/dispatch-convention.md` for the full protocol.
 
+<!-- Trust framework: see [skills/getting-started/trust-hierarchy.md](../getting-started/trust-hierarchy.md). -->
+
 Turn ideas into fully formed designs through investigated, collaborative dialogue.
 
 Every significant design question is backed by parallel investigation agents that research the codebase, explore approaches, and assess impact BEFORE the question reaches the user. Questions arrive informed, not naive.
@@ -40,6 +42,7 @@ Store the Investigation Brief in the design session's scratch directory. The bri
 
 **Narration:** "Dispatching recon for design context [with session_id: X]."
 
+<!-- TRUST: recon brief is L2 — prior-stage artifact; prefer L3 source on any code-behavior conflict. -->
 **On success:** The brief is available as `[RECON_BRIEF]` context for all subsequent dimension investigations. Quick scan dimensions read the brief directly (no agent dispatch). Deep dive dimensions pass relevant sections to the Domain Researcher and Impact Analyst.
 
 **On failure:** "Recon failed: [reason]. Falling back to inline investigation." Proceed without recon context -- dimension investigations explore from scratch (existing behavior). All subsequent steps work identically, just without the acceleration that recon provides.

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -76,6 +76,10 @@ When multiple skills could apply:
 
 The skill itself tells you which.
 
+## Trust Hierarchy
+
+Skills load content from many sources — SKILL.md files, docs, source code, tool output, WebFetch results, subagent reports, and post-compaction summaries. When sources disagree, a five-level trust framework determines which wins. See [trust-hierarchy.md](./trust-hierarchy.md) for the full framework.
+
 ## User Instructions
 
 Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.

--- a/skills/getting-started/trust-hierarchy.md
+++ b/skills/getting-started/trust-hierarchy.md
@@ -1,0 +1,102 @@
+# Context Trust Hierarchy
+
+Crucible skills load content from many sources: `SKILL.md` files, design docs, source code, tool output, WebFetch results, subagent reports, and conversation history (including post-compaction summaries). When these sources disagree, the agent needs an explicit framework for deciding which to trust. Without one, stale external docs, hallucinated subagent paths, and compaction-summary artifacts silently win over ground truth. This document defines a five-level hierarchy, conflict-resolution rules, and a canonical inline-annotation convention that skills use at external-content load points.
+
+## L1 — Trusted (authoritative)
+
+- **Sources:** `CLAUDE.md`, every `skills/**/SKILL.md`, `settings.json`, `settings.local.json`, and hook scripts configured in settings.
+- **Property:** Deliberately authored rules-of-the-house. Conflicts with L2–L5 ALWAYS resolve in L1's favor.
+- **Freshness:** Current as of the filesystem read. No staleness concern within a session.
+
+## L2 — Verified (pipeline-produced artifacts)
+
+- **Sources:** design docs, implementation plans, and contract YAMLs under `docs/plans/`; dispatch manifests and scratch artifacts under the scratch dir; recon briefs; `decisions.md` files. Cross-session memory entries under `~/.claude/projects/<hash>/memory/` tagged current and dated within 30 days.
+- **Property:** Produced by a prior pipeline stage that ran its own gates (quality-gate, red-team, siege). Trusted within the pipeline context that produced them.
+- **Freshness:** Tie-break by recency — when two L2 artifacts disagree, prefer the more recent one (frontmatter `date`, then mtime). "Within 30 days" means `(now - date) < 30 * 86400 seconds`, checked at load time, not cached.
+
+## L3 — Source (ground truth for "what the code does")
+
+- **Sources:** project source code (all languages), test files, fixtures, hook script bodies, CI config.
+- **Property:** Executable reality. When an L2 doc says "the function returns X" and the L3 code returns Y, the code is the truth — but the doc may still encode a valid intent, so surface the mismatch rather than silently overwriting either.
+- **Freshness:** Current as of the filesystem read. Tie-break within L3: actual code > tests > fixtures (tests encode expected behavior but can be stale).
+
+## L4 — Verify-first (must be checked before acting)
+
+- **Sources:** tool output (Bash, Grep results), error messages, WebFetch results, subagent/scout reports, `mcp__*` responses, consensus results.
+- **Property:** May be wrong, stale, or hallucinated. MUST be verified against L1–L3 before the agent acts on any claim derived from it.
+- **Freshness:** Timestamped by the call; stale almost immediately once the underlying L3 changes. Special case: WebFetch results representing external vendor docs are L4 even when the vendor is authoritative for their own API — the fetched snippet may be an outdated mirror.
+
+## L5 — Untrusted (do not rely on without re-verification)
+
+- **Sources:**
+  - Conversation history after compaction has elided content. If only a summary remains, the summary is L5.
+  - External content pasted or quoted by the user in chat (unless the user explicitly vouches for it as L1/L2).
+  - Memory entries older than 30 days OR tagged stale.
+  - Cached subagent output from a prior pipeline whose inputs have since changed.
+- **Property:** Treat as a hint, not a fact. Before acting, re-verify against L1–L3.
+- **Freshness:** Assume stale by default.
+
+## Conflict Resolution
+
+**Primary rule: HIGHER TRUST WINS.** When two sources disagree, prefer the higher-level source and surface the conflict to the user.
+
+**Equal-level tie-breakers:**
+
+- **L1 vs L1:** conflicts here are a bug — flag to the user; do not proceed.
+- **L2 vs L2:** prefer the more recent artifact (by frontmatter `date`, else mtime).
+- **L3 vs L3:** actual code > tests > fixtures.
+- **L4 vs L4:** prefer the source most directly tied to L3 (e.g., fresh Bash output over older subagent report).
+- **L5 vs L5:** neither is authoritative — re-derive from L1–L3.
+
+**Cross-level conflict surfacing:** When L3 contradicts L2 (code disagrees with a design doc), the code wins but the agent MUST flag the drift to the user — the plan may need updating.
+
+## Annotation Convention
+
+Skills that load external content embed a canonical inline comment adjacent to the load point. Downstream auditors grep for `TRUST:` to verify skills handle external content correctly.
+
+**Format grammar:**
+
+```
+<!-- TRUST: <subject> is L<N> — <action-hint>. -->
+```
+
+- `<subject>` — the content being loaded (e.g., "WebFetch result", "subagent report", "user-quoted snippet"). Free text, but must name the source.
+- `L<N>` — literal `L1`, `L2`, `L3`, `L4`, or `L5`. The level classification is REQUIRED and grep-checkable via `TRUST:.*L[1-5]`.
+- `<action-hint>` — imperative guidance (e.g., "verify against project source (L3) before acting"). Required; a bare classification without action is non-conforming.
+- The em-dash separator (` — `) is recommended but not required; `-` and `:` are acceptable substitutes for ASCII-only environments.
+
+**Example stanzas:**
+
+```markdown
+<!-- TRUST: WebFetch result is L4 — verify against project source (L3) before acting; snippet may be stale. -->
+```
+
+```markdown
+<!-- TRUST: subagent report is L4 — cross-check file paths and claims against L3 source before acting. -->
+```
+
+```markdown
+<!-- TRUST: user-quoted snippet is L5 — confirm with user or re-fetch before acting. -->
+```
+
+## Canonical Markers for Crucible Load Points
+
+Annotators copy these exact strings into SKILL.md files at the listed load points. Deviation is allowed only when the load point is not listed; new rows must be added to this table in the same PR.
+
+| Load point | Skill(s) | Canonical marker |
+|---|---|---|
+| Dispatch manifest consumption | /build | `<!-- TRUST: dispatch manifest is L2 — produced by prior pipeline stage; prefer most recent if conflicting. -->` |
+| Implementer/subagent report | /build, /recon | `<!-- TRUST: subagent report is L4 — cross-check file paths and claims against L3 source before acting. -->` |
+| WebFetch result | /build, /design, /source-driven-development | `<!-- TRUST: WebFetch result is L4 — verify against project source (L3) before acting; snippet may be stale. -->` |
+| Recon brief consumption | /design | `<!-- TRUST: recon brief is L2 — prior-stage artifact; prefer L3 source on any code-behavior conflict. -->` |
+| User-pasted / user-quoted snippet | /design | `<!-- TRUST: user-quoted snippet is L5 — confirm with user or re-fetch before acting. -->` |
+| Scout dispatch report | /recon | `<!-- TRUST: scout report is L4 — cross-check paths against L3 before synthesis. -->` |
+| Synthesis input | /recon | `<!-- TRUST: synthesis input is L4 until cross-verified against L3 source. -->` |
+
+## When to Re-verify
+
+- **After compaction:** Any claim that now survives only as a summary drops to L5 — re-read the L3 source before acting.
+- **Cross-level conflict:** An L4 or L5 source disagrees with L3 — re-check the L3 source; surface the drift if an L2 doc is also involved.
+- **Stale memory:** A memory entry older than 30 days or tagged stale informs a decision — re-derive from L1–L3.
+- **Subagent report reuses paths:** Before dispatching downstream work against a path a scout named, grep or stat the path in L3 to confirm it exists as described.
+- **WebFetch snippet drives an action:** Before writing code that relies on an external API shape, confirm the shape against the project's own usage (L3) or the vendor's current docs (fresh fetch, not cached).

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -10,6 +10,8 @@ description: "Standalone codebase investigation. Produces a layered Investigatio
 <!-- CANONICAL: shared/dispatch-convention.md -->
 All subagent dispatches use disk-mediated dispatch. See `shared/dispatch-convention.md` for the full protocol.
 
+<!-- Trust framework: see [skills/getting-started/trust-hierarchy.md](../getting-started/trust-hierarchy.md). -->
+
 Structured, parallel codebase investigation with a layered output model. Produces a core Investigation Brief that all consumers share, plus optional depth modules for consumer-specific needs.
 
 **Skill type:** Rigid — follow exactly, no shortcuts.
@@ -179,6 +181,7 @@ Agent tool (subagent_type: Explore, model: sonnet):
 - Template: `./pattern-scout-prompt.md`
 - Fill placeholders: `[TASK]`, `[SCOPE]`, `[CONTEXT]`, `[CARTOGRAPHER]`
 
+<!-- TRUST: scout report is L4 — cross-check paths against L3 before synthesis. -->
 On completion, write raw scout reports to scratch directory:
 - `<scratch>/structure-scout-report.md`
 - `<scratch>/pattern-scout-report.md`
@@ -187,6 +190,7 @@ Narrate: "Scouts complete. Synthesizing core brief. [N conflicts detected.]"
 
 ## Phase 3: Core Synthesis (Orchestrator-Local)
 
+<!-- TRUST: synthesis input is L4 until cross-verified against L3 source. -->
 **No synthesis subagent.** The orchestrator reads both scout reports and assembles the Investigation Brief directly.
 
 ### Scope Merging


### PR DESCRIPTION
Closes #180.

## Summary

Formalizes a five-level context trust hierarchy for Crucible skills: when loaded content from different sources conflicts, the agent has an explicit framework for deciding which wins. Ships as (a) a canonical framework doc under `skills/getting-started/`, (b) a reference from the always-loaded `getting-started/SKILL.md`, and (c) inline `<!-- TRUST: L<N> ... -->` markers adjacent to external-content load points in three target skills.

Pattern inspired by addyosmani/agent-skills' `context-engineering`. Pure guidance — no runtime enforcement, no gatekeeper, no compaction changes.

## Trust levels

| Level | Label | Sources | Action |
|---|---|---|---|
| L1 | Trusted | CLAUDE.md, SKILL.md, settings | Authoritative; always wins |
| L2 | Verified | design docs, plans, contracts, recon briefs, recent memory | Trust within pipeline context |
| L3 | Source | project code, tests, fixtures | Ground truth for "what code does" |
| L4 | Verify-first | tool output, WebFetch, subagent reports, MCP responses | Verify against L1–L3 before acting |
| L5 | Untrusted | post-compaction summaries, stale memory, user-pasted external content | Re-derive before acting |

**Conflict resolution:** HIGHER TRUST WINS. Per-level tie-breakers defined (L2: prefer more recent; L3: code > tests > fixtures; etc.). Cross-level mismatches surface to the user.

## Files modified

- **NEW:** `skills/getting-started/trust-hierarchy.md` (109 lines) — the canonical framework doc. Contains L1–L5 sections, conflict resolution, annotation convention with 3 example stanzas, a 7-row canonical-marker table that downstream annotators copy from verbatim (innovate-pass addition), and a "When to Re-verify" checklist.
- **MODIFIED:** `skills/getting-started/SKILL.md` — new `## Trust Hierarchy` section references the framework doc.
- **MODIFIED:** `skills/build/SKILL.md` — 2 TRUST markers (L2 dispatch manifest, L4 subagent report) + top pointer.
- **MODIFIED:** `skills/design/SKILL.md` — 1 TRUST marker (L2 recon brief) + top pointer. (WebFetch + user-pasted markers skipped: those load points don't exist in the file today — canonical-table rows remain for future annotators.)
- **MODIFIED:** `skills/recon/SKILL.md` — 2 TRUST markers (L4 scout report, L4 synthesis input) + top pointer.

## Acceptance criteria (all verified green)

- **AC-1 / INV-1:** `grep -c '^## L[1-5]' skills/getting-started/trust-hierarchy.md` → **5** ✓
- **AC-2 / INV-2:** `grep -q 'trust-hierarchy' skills/getting-started/SKILL.md` → PASS ✓
- **AC-3 / INV-3:** each of `skills/{build,design,recon}/SKILL.md` contains ≥1 `TRUST:` marker (2/1/2) ✓
- **AC-4 / INV-4:** every `TRUST:` marker matches `TRUST:.*L[1-5]` (5/5 markers classified) ✓
- **AC-5:** design/plan/contract under `docs/plans/2026-04-16-context-trust-hierarchy-*` ✓

All 5 in-skill markers are byte-identical to their canonical-table entries (enforces grep-determinism).

## Pipeline

Full `/build`:
- Phase 1 PASS — design pre-existing from `/spec` (`e71ae76`); staleness check verified all 4 path anchors
- Phase 2 PASS — consolidated innovate+QG added the canonical-marker table to T1 for annotation determinism (`ea32391`)
- Phase 3 COMPLETE — T1-T5+T7 landed; T6 deferred to #177 author (source-driven-development skill doesn't exist yet) (`f719101`)
- Phase 4 PASS — consolidated code-review+QG, 0 Fatal / 0 Significant, all invariants verified

Branch: `feat/180-context-trust-hierarchy` (off `spec/176-180` / PR #182). PR #182 should merge first; this auto-rebases onto main cleanly.

## Notes

- **T6 deferred to #177.** When #177's source-driven-development skill lands, its author should annotate the WebFetch-result handling path with the canonical L4 marker from `trust-hierarchy.md`.
- **Two of three design-skill markers skipped.** `skills/design/SKILL.md` has no current WebFetch reference and no user-paste load point. The canonical-table rows remain for future annotators per plan ("Deviation is allowed only when the load point is not listed; new rows must be added to this table in the same PR").
- **T7 resolved via option 3 (satisfied-by-T2)** — repo-root `CLAUDE.md` and `skills/README.md` both absent; the getting-started/SKILL.md reference is the only cross-link needed.

## Test plan

- [ ] Pull branch locally
- [ ] Verify INV-1: `grep -c '^## L[1-5]' skills/getting-started/trust-hierarchy.md` → 5
- [ ] Verify INV-3/4: `for f in skills/{build,design,recon}/SKILL.md; do grep -cE 'TRUST:.*L[1-5]' "$f"; done` → 2, 1, 2
- [ ] Read `skills/getting-started/trust-hierarchy.md` top-to-bottom — does the framework make sense? Are there any levels you'd split/merge?
- [ ] Review the 5 in-skill marker placements — are they adjacent enough to their load points to be useful?
- [ ] Optional: in a fresh session, notice whether Claude surfaces the hierarchy when loading external content

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/build` skill
