### PR TITLE
fix(spec): update cross-references after contract schema extraction (#173 QG-A)

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -807,7 +807,7 @@ For each task (or wave of parallel tasks):
 
 #### Contract-Aware Implementer Guidance
 
-When a contract YAML exists for the current ticket (detected during Step 0 or produced by `/spec`), the implementer receives the contract alongside the design doc and task description. The contract uses the schema defined in `crucible:spec` (version `1.0`). Implementers must treat contract elements as follows:
+When a contract YAML exists for the current ticket (detected during Step 0 or produced by `/spec`), the implementer receives the contract alongside the design doc and task description. The contract uses the schema defined in [`crucible:spec/contract-schema.md`](../spec/contract-schema.md) (version `1.0`). Implementers must treat contract elements as follows:
 
 1. **`api_surface` declarations are binding.** The implementer must match the declared function signatures, class interfaces, endpoint shapes, parameter names, types, and return types exactly. Deviations from the contract's API surface are implementation errors.
 
@@ -1358,4 +1358,4 @@ When a contract YAML exists for the current ticket, the quality gate adds contra
 - **crucible:source-driven-development** — Detect → Fetch → Implement → Cite loop for non-trivial external API usage (≥ 5 LOC touching a detected framework); invoked by the implementer prompt's Source Consultation block. Recommended — skipped for pure internal refactors or trivial edits.
 
 **Contract consumption:**
-- **crucible:spec** — Consumes contract YAML files produced by `/spec` (schema version 1.0). Contracts are read from `docs/plans/*-contract.yaml` and feed into pre-existing doc detection (Phase 1 Step 0), implementer dispatch (Phase 3), reviewer checks (Phase 3), and quality gate verification (all gate points). See the contract schema in `crucible:spec` for field definitions.
+- **crucible:spec** — Consumes contract YAML files produced by `/spec` (schema version 1.0). Contracts are read from `docs/plans/*-contract.yaml` and feed into pre-existing doc detection (Phase 1 Step 0), implementer dispatch (Phase 3), reviewer checks (Phase 3), and quality gate verification (all gate points). See [`crucible:spec/contract-schema.md`](../spec/contract-schema.md) for field definitions.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -280,6 +280,6 @@ This skill produces **design docs**. When used standalone, invoke `crucible:qual
 
 **Recon/Assay dispatch:** Recon is dispatched once at Phase 2 start (Step 0) with `modules: ["impact-analysis"]` and a session-level `session_id`. Assay is dispatched per Deep Dive dimension during synthesis (Step 5) with `decision_type: "architecture"`. Both include fallback to existing behavior on failure.
 
-**Contract schema:** Shared with `/spec` — see `skills/spec/SKILL.md` for the canonical contract YAML schema (version 1.0). Both `/design` and `/spec` emit contracts that `/build` consumes.
+**Contract schema:** Shared with `/spec` — see `skills/spec/contract-schema.md` for the canonical contract YAML schema (version 1.0). Both `/design` and `/spec` emit contracts that `/build` consumes.
 
 **Prompt templates:** `design/investigation-prompts.md`

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -456,11 +456,11 @@ Same frontmatter as design doc (`ticket`, `epic`, `title`, `date`, `source` fiel
 
 **c. Contract** (`YYYY-MM-DD-<topic>-contract.yaml`):
 
-See Contract Format section below for the full schema.
+See [`contract-schema.md`](contract-schema.md) for the full schema.
 
 ### Step 5: Contract Schema Validation
 
-After generating the contract YAML, validate against the schema:
+After generating the contract YAML, validate against the schema. The rules below must stay consistent with the field definitions in [`contract-schema.md`](contract-schema.md) — if the schema changes, update both.
 
 1. **Required fields present:** Verify `version`, `ticket`, `epic`, `title`, `date`, `api_surface`, and `invariants` all exist.
 2. **Field value validation:**

--- a/skills/spec/contract-schema.md
+++ b/skills/spec/contract-schema.md
@@ -1,8 +1,6 @@
 # Contract Schema (version 1.0)
 
-Machine-readable contracts solve the core challenge of two async agents communicating about interdependent work. Prose is ambiguous — two LLMs reading the same paragraph extract different implications. Contracts make the seams structural.
-
-This file is the canonical schema reference for `/spec` contracts. `/design` emits contracts using the same schema. `/build` consumes contracts via this schema.
+Machine-readable contracts solve the core challenge of two async agents communicating about interdependent work. Prose is ambiguous -- two LLMs reading the same paragraph extract different implications. Contracts make the seams structural.
 
 ## Schema
 


### PR DESCRIPTION
## Summary

Addresses 4 Significant findings from a retroactive quality-gate run on PR #189 (merged spec contract-schema extraction).

## QG findings addressed

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | Significant | `skills/design/SKILL.md:283` pointer landed on the now-stub `skills/spec/SKILL.md` section | Re-targeted directly at `skills/spec/contract-schema.md` |
| 2 | Significant | I silently added a second intro paragraph to `contract-schema.md` during a "relocation-only" refactor | Reverted the paragraph; restored the original `--` em-dash style on line 3 |
| 3 | Significant | `skills/spec/SKILL.md:459` said "Contract Format section below" but "below" is a stub | Replaced with a direct markdown link to `contract-schema.md` |
| 4 | Significant | Step 5 validation rules in `spec/SKILL.md` duplicated field defs from `contract-schema.md` — two sources of truth | Added a sync-note on line 463 so maintainers update both when the schema changes |

Also found and fixed two additional stale cross-references the QG caught but my original merge missed:
- `skills/build/SKILL.md:810` — "schema defined in `crucible:spec`" → now links to `../spec/contract-schema.md`
- `skills/build/SKILL.md:1361` — "See the contract schema in `crucible:spec`" → now links to `../spec/contract-schema.md`

## QG verification

Ran the QG red-team on this fix branch (single round, Opus). Result: **PASS** — 0 Fatal, 0 Significant, 2 Minor (both style polish out-of-scope for this fix). No new defects introduced.

## Test plan

- [x] Every old reference to `skills/spec/SKILL.md` for contract schema material now targets `skills/spec/contract-schema.md`
- [x] All 4 Significant findings addressed
- [x] Relative paths resolve (`../spec/contract-schema.md` from `skills/build/SKILL.md`)
- [x] QG re-review clean

Net: 4 files, 6 insertions, 8 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)