### PR TITLE
fix(finish): harden pre-push validation + post-push CI monitoring (#165)

### DIFF
--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -161,10 +161,10 @@ Silently-missing tools are NOT a pass — they are an "unknown." Either run the 
 | TypeScript/Node | `npx tsc --noEmit` (if `tsconfig.json`) | `npm run lint` / `pnpm lint` / `biome check` (whichever the repo configures) | `prettier --check .` / `biome format --check` (whichever configured) | `npm test` / `pnpm test` / `vitest run` / `jest` |
 | Rust | `cargo check --all-targets --all-features` | `cargo clippy --all-targets --all-features -- -D warnings` | `cargo fmt -- --check` | `cargo test --workspace --all-features` |
 | Python | `mypy` or `pyright` (if configured) | `ruff check` / `flake8` (whichever configured) | `ruff format --check` / `black --check` (whichever configured) | `pytest` |
-| Go | (compiler via `go build ./...`) | `go vet ./...` (add `golangci-lint run` if configured) | `gofmt -l .` (output must be empty) | `go test ./...` |
+| Go | (compiler via `go build ./...`) | `go vet ./...` (add `golangci-lint run` if configured) | `test -z "$(gofmt -l .)"` (fails non-zero on drift) | `go test ./...` |
 | .NET | `dotnet build -warnaserror` (covers type + warnings-as-errors) | Roslyn analyzers via `-warnaserror` + any configured analyzer package | `dotnet format --verify-no-changes` | `dotnet test` |
-| Ruby | (runtime only) | `bundle exec rubocop` | `bundle exec rubocop --only Layout` or `bundle exec standardrb` (whichever configured) | `bundle exec rspec` / `bundle exec rake test` |
-| Java/Kotlin | (compiler via `./gradlew build`) | `./gradlew check` (runs linters + tests) or `./mvnw verify` | `./gradlew spotlessCheck` (if configured) | covered by `check` / `verify` |
+| Ruby | (runtime only) | `bundle exec rubocop` (covers Layout + Style + Lint) | covered by Lint (or `bundle exec standardrb` if configured instead of rubocop) | `bundle exec rspec` / `bundle exec rake test` |
+| Java/Kotlin | (compiler via `./gradlew build`) | `./gradlew checkstyleMain spotbugsMain` or `./mvnw spotbugs:check` (if configured) | `./gradlew spotlessCheck` (if configured) | `./gradlew test` or `./mvnw test` |
 
 For ecosystems not in this matrix, extend it: manifest → type-check → lint → format-check → test. Do not skip an ecosystem because it isn't listed.
 
@@ -227,22 +227,33 @@ EOF
 gh pr checks <pr-number> --watch
 ```
 
-**Fallback (if `--watch` cannot run):** poll until all checks reach a terminal state, then assert the bucket set is a subset of `{pass, skipping}`. The `bucket` field is the GitHub-normalized coalescence of raw states — use it instead of raw `state` values to avoid missing edge states like `NEUTRAL`, `ACTION_REQUIRED`, or lowercase legacy commit-status values.
+**Fallback (if `--watch` cannot run):** poll until all checks reach a terminal state, then assert the bucket set is a subset of `{pass, skipping}` (allow-list, not deny-list — an unknown future bucket value must fail closed). Use gh's normalized `bucket` field, not raw `state` values, to avoid missing edge states like `NEUTRAL`, `ACTION_REQUIRED`, or lowercase legacy commit-status values. Capture `gh`'s own exit code and interpret it per its documented contract (0 = all terminal, 8 = at least one pending, other non-zero = gh itself errored).
 
 ```bash
 while true; do
   BUCKETS=$(gh pr checks <pr-number> --json bucket --jq '[.[].bucket] | unique')
+  RC=$?
   echo "$BUCKETS"
+  if [ "$RC" -ne 0 ] && [ "$RC" -ne 8 ]; then
+    echo "gh pr checks errored (rc=$RC) — cannot determine CI state"; exit 1
+  fi
   echo "$BUCKETS" | grep -q '"pending"' || break
   sleep 20
 done
-# Assert the final bucket set is only {pass, skipping}
-echo "$BUCKETS" | grep -qE '"fail"|"cancel"' && { echo "CI failed"; exit 1; }
+
+# Three terminal cases: empty (no CI), all allow-list (green), or anything else (red).
+if [ "$BUCKETS" = "[]" ]; then
+  echo "No CI checks configured — record in final report and recommend adding CI"
+elif echo "$BUCKETS" | jq -e 'all(. == "pass" or . == "skipping")' >/dev/null; then
+  echo "CI green"
+else
+  echo "CI not all-green: $BUCKETS"; exit 1
+fi
 ```
 
-If the exit is non-zero (either via `--watch` or the explicit assertion): diagnose from CI logs (`gh run view <run-id> --log-failed` or `gh pr checks <pr-number>`), dispatch a fix, push, and re-watch. Do NOT report success on a red PR. Do NOT leave the watch running while moving on to another task — CI failure is an actionable blocker that takes precedence.
+If the exit is non-zero (either via `--watch` or the explicit assertion): diagnose from CI logs (`gh run view <run-id> --log-failed` or `gh pr checks <pr-number>`), dispatch a fix, **re-run Step 5.5's full validation matrix** (the fix can regress local checks), push, and re-watch. Do NOT report success on a red PR. Do NOT leave the watch running while moving on to another task — CI failure is an actionable blocker that takes precedence.
 
-If checks are entirely absent (repo has no CI configured): record that in the final report so the user knows local validation was the only gate, and recommend they add CI.
+If the block exits with the "No CI checks configured" message, record that in the final report so the user knows local validation was the only gate, and recommend they add CI.
 
 Then: If using a worktree, clean it up (Step 7)
 

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -162,7 +162,7 @@ Silently-missing tools are NOT a pass — they are an "unknown." Either run the 
 | Rust | `cargo check --all-targets --all-features` | `cargo clippy --all-targets --all-features -- -D warnings` | `cargo fmt -- --check` | `cargo test --workspace --all-features` |
 | Python | `mypy` or `pyright` (if configured) | `ruff check` / `flake8` (whichever configured) | `ruff format --check` / `black --check` (whichever configured) | `pytest` |
 | Go | (compiler via `go build ./...`) | `go vet ./...` (add `golangci-lint run` if configured) | `test -z "$(gofmt -l .)"` (fails non-zero on drift) | `go test ./...` |
-| .NET | `dotnet build -warnaserror` (covers type + warnings-as-errors) | Roslyn analyzers via `-warnaserror` + any configured analyzer package | `dotnet format --verify-no-changes` | `dotnet test` |
+| .NET | `dotnet build -p:TreatWarningsAsErrors=true` (portable across Linux/macOS/Windows; covers type + warnings-as-errors) | Roslyn analyzers via the same `-p:TreatWarningsAsErrors=true` + any configured analyzer package | `dotnet format --verify-no-changes` | `dotnet test` |
 | Ruby | (runtime only) | `bundle exec rubocop` (covers Layout + Style + Lint) | covered by Lint (or `bundle exec standardrb` if configured instead of rubocop) | `bundle exec rspec` / `bundle exec rake test` |
 | Java/Kotlin | (compiler via `./gradlew build`) | `./gradlew checkstyleMain spotbugsMain` or `./mvnw spotbugs:check` (if configured) | `./gradlew spotlessCheck` (if configured) | `./gradlew test` or `./mvnw test` |
 
@@ -233,12 +233,12 @@ gh pr checks <pr-number> --watch
 while true; do
   BUCKETS=$(gh pr checks <pr-number> --json bucket --jq '[.[].bucket] | unique')
   RC=$?
-  echo "$BUCKETS"
-  if [ "$RC" -ne 0 ] && [ "$RC" -ne 8 ]; then
-    echo "gh pr checks errored (rc=$RC) — cannot determine CI state"; exit 1
-  fi
-  echo "$BUCKETS" | grep -q '"pending"' || break
-  sleep 20
+  echo "CI buckets: $BUCKETS"
+  case "$RC" in
+    0) break ;;                                   # all terminal — exit loop
+    8) sleep 20 ;;                                # at least one pending — keep polling
+    *) echo "gh pr checks errored (rc=$RC) — cannot determine CI state"; exit 1 ;;
+  esac
 done
 
 # Three terminal cases: empty (no CI), all allow-list (green), or anything else (red).

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -208,37 +208,39 @@ If the repo is public: scan the PR title, body, and commit messages for propriet
 # Push branch
 git push -u origin <feature-branch>
 
-# Create PR
-gh pr create --title "<title>" --body "$(cat <<'EOF'
+# Create PR and capture the URL gh emits (the PR it just created).
+# This is the only deterministic PR reference — using `gh pr view`
+# instead would use branch-to-PR mapping, which breaks on repos
+# with multiple open PRs per branch.
+PR_URL=$(gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Summary
 <2-3 bullets of what changed>
 
 ## Test Plan
 - [ ] <verification steps>
 EOF
-)"
+)")
+PR_NUMBER="${PR_URL##*/}"
 ```
 
-**Post-Push CI Monitoring (Non-Negotiable):** after `gh pr create` returns, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done." BLOCK on the watch + empty-check assertion below.
-
-First, capture the PR number deterministically — `gh pr create` emits a URL, not an integer, and relying on branch-to-PR mapping is fragile on repos with multiple open PRs per branch:
-
-```bash
-PR_NUMBER=$(gh pr view --json number -q .number)
-```
-
-Then watch the checks:
+**Post-Push CI Monitoring (Non-Negotiable):** after `gh pr create` returns, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done." BLOCK on the watch + empty-check assertion below. Fail closed on any non-zero result that isn't the "no CI configured" case:
 
 ```bash
 # Primary: --watch streams status and returns aggregate exit code.
-# Exit 0 = all terminal passes OR no checks configured (must disambiguate below).
-# Non-zero = at least one failure/cancellation.
+# Exit 0 = all terminal passes OR no checks configured (must disambiguate).
+# Non-zero = at least one check failed/cancelled.
 gh pr checks "$PR_NUMBER" --watch
+WATCH_RC=$?
 
-# --watch on a PR with zero checks exits 0 silently — guard against
-# vacuously satisfying the "CI passed" requirement.
-if [ "$(gh pr checks "$PR_NUMBER" --json bucket --jq 'length')" = "0" ]; then
+# Disambiguate the no-CI case from real success.
+CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json bucket --jq 'length')
+
+if [ "$CHECK_COUNT" = "0" ]; then
   echo "No CI checks configured — record in final report and recommend adding CI"
+elif [ "$WATCH_RC" -ne 0 ]; then
+  echo "CI failed (watch exit $WATCH_RC)"; exit 1
+else
+  echo "CI green"
 fi
 ```
 

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -143,28 +143,48 @@ Which option?
 
 ## MANDATORY CHECKPOINT - DO NOT SKIP
 
-### Step 5.5: Pre-Push Validation
+### Step 5.5: Pre-Push Validation (Non-Negotiable)
 
-**Before pushing code (Option 2) or merging (Option 1), validate locally:**
+**BLOCK semantics:** you CANNOT proceed to Option 1 (merge) or Option 2 (push + PR) until local validation passes. A failing check is a hard stop. Do not push "then fix in CI"; do not merge "then fix on main."
+
+**Detect the project's toolchain once** (read `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, etc. before running anything). Run only the checks that actually apply. Silently-missing tools are NOT a pass — they are an "unknown" that must be resolved by either running the real tool or explicitly documenting its absence. Never use `2>/dev/null || true` patterns that hide failures.
+
+**Validation matrix (run every applicable check; each must exit 0):**
+
+| Ecosystem | Type-check | Lint | Tests |
+|---|---|---|---|
+| TypeScript/Node | `npx tsc --noEmit` (if `tsconfig.json` present) | `npm run lint` or `pnpm lint` or `biome check` (whichever the repo configures) | `npm test` / `pnpm test` / `vitest run` / `jest` |
+| Rust | (compiler via test) | `cargo clippy --all-targets -- -D warnings` | `cargo test --all` |
+| Python | `mypy` or `pyright` (if configured) | `ruff check` or `flake8` (whichever is configured) | `pytest` |
+| Go | (compiler via test) | `go vet ./...` | `go test ./...` |
+
+**If a check is not configured for this repo, say so explicitly in the narration** ("no type-check configured — skipping") rather than silencing the command. If uncertain whether a check is configured, ask the user; do not assume.
+
+**On ANY non-zero exit code: STOP.** Report the failure, dispatch a fix, and re-run the full matrix from scratch. Do not partially re-run — a fix in one layer can regress another.
+
+### Step 5.6: Post-Push CI Monitoring (Option 2 only)
+
+**BLOCK semantics:** after `gh pr create` returns the PR URL, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done."
 
 ```bash
-# Run type-check (if applicable)
-npx tsc --noEmit 2>/dev/null || echo "No TypeScript"
-
-# Run linter (if applicable)  
-npx eslint . 2>/dev/null || npm run lint 2>/dev/null || echo "No linter configured"
-
-# Run test suite
-npm test || cargo test || pytest || go test ./...
+# Watch checks to completion — blocks until all checks resolve
+gh pr checks <pr-number> --watch
 ```
 
-**If any validation fails:** STOP. Fix the issues before pushing. Never push code that fails local validation.
+`--watch` streams check status and exits with the final aggregate code (0 = all pass, non-zero = at least one failure/cancellation). If `--watch` is unavailable in the installed `gh` version, poll:
 
-**After pushing (Option 2 only):** Check CI status immediately:
 ```bash
-gh pr checks <pr-number>
+while true; do
+  STATUS=$(gh pr checks <pr-number> --json state --jq '[.[] | .state] | unique')
+  echo "$STATUS"
+  echo "$STATUS" | grep -qE '"PENDING"|"QUEUED"|"IN_PROGRESS"' || break
+  sleep 20
+done
 ```
-Wait for results. If CI fails, diagnose and fix before reporting success to the user. Do NOT push and move on.
+
+**If any check fails:** diagnose the failure from CI logs (`gh run view <run-id> --log-failed` or `gh pr checks <pr-number>`), dispatch a fix, push, and re-watch. Do NOT report success on a red PR, and do NOT leave the watch running while moving on to another task — CI failure is an actionable blocker that takes precedence.
+
+**If checks are entirely absent** (repo has no CI configured): record that in the final report so the user knows local validation was the only gate, and recommend they add CI.
 
 ### Step 6: Execute Choice
 
@@ -291,6 +311,18 @@ git worktree remove <worktree-path>
 - **Problem:** Accidentally delete work
 - **Fix:** Require typed "discard" confirmation
 
+**Skipping pre-push validation**
+- **Problem:** "Tests passed during /build so this should be fine" — but refactors between Phase 3 and finish, plus drift in companion files, can silently break the build. Pushing broken code wastes CI minutes and creates a red PR for reviewers.
+- **Fix:** Always run Step 5.5's full validation matrix before Option 1 merge or Option 2 push. Every applicable check must exit 0.
+
+**Silencing validation failures**
+- **Problem:** `2>/dev/null || true` patterns hide tool failures and make "no output" indistinguishable from "tool missing" — a failing tsc looks identical to a repo without TypeScript.
+- **Fix:** Detect the toolchain from manifest files first, then run only the checks that apply with strict exit-code discipline. Explicitly narrate skipped checks rather than silencing errors.
+
+**Pushing and moving on**
+- **Problem:** `git push` returns, `gh pr create` returns a URL, task feels done. CI runs later, fails, and nobody notices until the next review session.
+- **Fix:** Block on `gh pr checks <pr-number> --watch` (or equivalent poll loop). Treat a red PR as a hard stop — never report success to the user on a failing PR.
+
 ## Red Flags
 
 **Never:**
@@ -300,12 +332,19 @@ git worktree remove <worktree-path>
 - Merge without verifying tests on result
 - Delete work without confirmation
 - Force-push without explicit request
+- Push code that has not passed the full local validation matrix in Step 5.5
+- Use `|| true` or `2>/dev/null` to silence a validation check — skipped checks must be narrated, not hidden
+- Report success to the user after `gh pr create` without confirming all CI checks pass
+- Abandon a watched PR to work on something else — a red PR is an actionable blocker
 
 **Always:**
 - Verify tests before code review
 - Run full code review before presenting options
 - Run red-team after code review passes, before presenting options
 - Fix Critical/Important review findings before proceeding
+- Detect the project toolchain from manifest files before Step 5.5 dispatch
+- Run every applicable validation check with strict exit-code discipline
+- Watch CI to completion after push (`gh pr checks --watch`) before declaring Option 2 done
 - Present exactly 4 options
 - Get typed confirmation for Option 4
 - Clean up worktree (if applicable) for Options 1, 2 & 4 only

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -147,44 +147,30 @@ Which option?
 
 **BLOCK semantics:** you CANNOT proceed to Option 1 (merge) or Option 2 (push + PR) until local validation passes. A failing check is a hard stop. Do not push "then fix in CI"; do not merge "then fix on main."
 
-**Detect the project's toolchain once** (read `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, etc. before running anything). Run only the checks that actually apply. Silently-missing tools are NOT a pass — they are an "unknown" that must be resolved by either running the real tool or explicitly documenting its absence. Never use `2>/dev/null || true` patterns that hide failures.
+**Detect the project's toolchain first** by reading manifest files at repo root: `package.json`, `Cargo.toml`, `pyproject.toml` / `requirements.txt`, `go.mod`, `*.csproj` / `*.sln`, `Gemfile`, `build.gradle` / `pom.xml`. Run only the checks that actually apply.
 
-**Validation matrix (run every applicable check; each must exit 0):**
+- **Monorepo / polyglot root:** if multiple manifests coexist at root (e.g., a Rust product with a Node.js tooling script), scope validation to whichever ecosystem owns the files changed in the diff (`git diff --name-only <base>...HEAD`). If ambiguous, ask the user before running the full matrix.
+- **Nested manifests:** if the diff touches files under a subdirectory with its own manifest, scope to that subdirectory.
 
-| Ecosystem | Type-check | Lint | Tests |
-|---|---|---|---|
-| TypeScript/Node | `npx tsc --noEmit` (if `tsconfig.json` present) | `npm run lint` or `pnpm lint` or `biome check` (whichever the repo configures) | `npm test` / `pnpm test` / `vitest run` / `jest` |
-| Rust | (compiler via test) | `cargo clippy --all-targets -- -D warnings` | `cargo test --all` |
-| Python | `mypy` or `pyright` (if configured) | `ruff check` or `flake8` (whichever is configured) | `pytest` |
-| Go | (compiler via test) | `go vet ./...` | `go test ./...` |
+Silently-missing tools are NOT a pass — they are an "unknown." Either run the real tool, or narrate the skip ("no type-check configured — skipping"), or ask the user. Never mask a failure with `|| true` or `2>/dev/null`.
 
-**If a check is not configured for this repo, say so explicitly in the narration** ("no type-check configured — skipping") rather than silencing the command. If uncertain whether a check is configured, ask the user; do not assume.
+**Validation matrix (run every applicable check; each must exit 0 unless its documented exit-code contract says otherwise):**
 
-**On ANY non-zero exit code: STOP.** Report the failure, dispatch a fix, and re-run the full matrix from scratch. Do not partially re-run — a fix in one layer can regress another.
+| Ecosystem | Type-check | Lint | Format | Tests |
+|---|---|---|---|---|
+| TypeScript/Node | `npx tsc --noEmit` (if `tsconfig.json`) | `npm run lint` / `pnpm lint` / `biome check` (whichever the repo configures) | `prettier --check .` / `biome format --check` (whichever configured) | `npm test` / `pnpm test` / `vitest run` / `jest` |
+| Rust | `cargo check --all-targets --all-features` | `cargo clippy --all-targets --all-features -- -D warnings` | `cargo fmt -- --check` | `cargo test --workspace --all-features` |
+| Python | `mypy` or `pyright` (if configured) | `ruff check` / `flake8` (whichever configured) | `ruff format --check` / `black --check` (whichever configured) | `pytest` |
+| Go | (compiler via `go build ./...`) | `go vet ./...` (add `golangci-lint run` if configured) | `gofmt -l .` (output must be empty) | `go test ./...` |
+| .NET | `dotnet build -warnaserror` (covers type + warnings-as-errors) | Roslyn analyzers via `-warnaserror` + any configured analyzer package | `dotnet format --verify-no-changes` | `dotnet test` |
+| Ruby | (runtime only) | `bundle exec rubocop` | `bundle exec rubocop --only Layout` or `bundle exec standardrb` (whichever configured) | `bundle exec rspec` / `bundle exec rake test` |
+| Java/Kotlin | (compiler via `./gradlew build`) | `./gradlew check` (runs linters + tests) or `./mvnw verify` | `./gradlew spotlessCheck` (if configured) | covered by `check` / `verify` |
 
-### Step 5.6: Post-Push CI Monitoring (Option 2 only)
+For ecosystems not in this matrix, extend it: manifest → type-check → lint → format-check → test. Do not skip an ecosystem because it isn't listed.
 
-**BLOCK semantics:** after `gh pr create` returns the PR URL, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done."
+**Exit-code interpretation:** treat each tool's documented exit-code contract authoritatively, not just 0 vs non-0. Example: `gh pr checks` exits 8 for "checks pending" — a legitimate non-terminal state, not a failure. The rule is "never mask an exit code without interpreting it," not "non-zero is always failure." If a tool's contract is unclear, treat non-zero as failure and ask the user.
 
-```bash
-# Watch checks to completion — blocks until all checks resolve
-gh pr checks <pr-number> --watch
-```
-
-`--watch` streams check status and exits with the final aggregate code (0 = all pass, non-zero = at least one failure/cancellation). If `--watch` is unavailable in the installed `gh` version, poll:
-
-```bash
-while true; do
-  STATUS=$(gh pr checks <pr-number> --json state --jq '[.[] | .state] | unique')
-  echo "$STATUS"
-  echo "$STATUS" | grep -qE '"PENDING"|"QUEUED"|"IN_PROGRESS"' || break
-  sleep 20
-done
-```
-
-**If any check fails:** diagnose the failure from CI logs (`gh run view <run-id> --log-failed` or `gh pr checks <pr-number>`), dispatch a fix, push, and re-watch. Do NOT report success on a red PR, and do NOT leave the watch running while moving on to another task — CI failure is an actionable blocker that takes precedence.
-
-**If checks are entirely absent** (repo has no CI configured): record that in the final report so the user knows local validation was the only gate, and recommend they add CI.
+**On ANY unhandled non-zero exit (after exit-code interpretation): STOP.** Report the failure, dispatch a fix, and re-run the full matrix from scratch. Do not partially re-run — a fix in one layer can regress another.
 
 ### Step 6: Execute Choice
 
@@ -232,6 +218,31 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 EOF
 )"
 ```
+
+**Post-Push CI Monitoring (Non-Negotiable):** after `gh pr create` returns the PR URL, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done." BLOCK on the watch command below.
+
+```bash
+# Primary: --watch streams status and returns aggregate exit code
+# (0 = all pass, non-zero = at least one failure/cancellation).
+gh pr checks <pr-number> --watch
+```
+
+**Fallback (if `--watch` cannot run):** poll until all checks reach a terminal state, then assert the bucket set is a subset of `{pass, skipping}`. The `bucket` field is the GitHub-normalized coalescence of raw states — use it instead of raw `state` values to avoid missing edge states like `NEUTRAL`, `ACTION_REQUIRED`, or lowercase legacy commit-status values.
+
+```bash
+while true; do
+  BUCKETS=$(gh pr checks <pr-number> --json bucket --jq '[.[].bucket] | unique')
+  echo "$BUCKETS"
+  echo "$BUCKETS" | grep -q '"pending"' || break
+  sleep 20
+done
+# Assert the final bucket set is only {pass, skipping}
+echo "$BUCKETS" | grep -qE '"fail"|"cancel"' && { echo "CI failed"; exit 1; }
+```
+
+If the exit is non-zero (either via `--watch` or the explicit assertion): diagnose from CI logs (`gh run view <run-id> --log-failed` or `gh pr checks <pr-number>`), dispatch a fix, push, and re-watch. Do NOT report success on a red PR. Do NOT leave the watch running while moving on to another task — CI failure is an actionable blocker that takes precedence.
+
+If checks are entirely absent (repo has no CI configured): record that in the final report so the user knows local validation was the only gate, and recommend they add CI.
 
 Then: If using a worktree, clean it up (Step 7)
 
@@ -333,7 +344,7 @@ git worktree remove <worktree-path>
 - Delete work without confirmation
 - Force-push without explicit request
 - Push code that has not passed the full local validation matrix in Step 5.5
-- Use `|| true` or `2>/dev/null` to silence a validation check — skipped checks must be narrated, not hidden
+- Mask a non-zero exit code without interpreting it against the tool's documented contract (e.g., `|| true`, `2>/dev/null`). Known non-failure non-zero codes must be matched to their meaning — `gh pr checks` exit 8 is "checks pending," not failure. When a tool's contract is unclear, treat non-zero as failure.
 - Report success to the user after `gh pr create` without confirming all CI checks pass
 - Abandon a watched PR to work on something else — a red PR is an actionable blocker
 
@@ -373,5 +384,6 @@ Before completing this skill, confirm every mandatory checkpoint was executed:
 - [ ] Red-team review
 - [ ] Pre-push validation passed
 - [ ] Repository safety checked (if public repo, Option 2)
+- [ ] Post-push CI monitoring completed green (Option 2 only)
 
 **If any checkbox is unchecked, STOP. Go back and execute the missed gate.**

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -221,6 +221,14 @@ PR_URL=$(gh pr create --title "<title>" --body "$(cat <<'EOF'
 EOF
 )")
 PR_NUMBER="${PR_URL##*/}"
+
+# Guard: if gh pr create failed (e.g., a PR already exists for this branch),
+# PR_URL is empty — surface the real diagnostic instead of falling through
+# into CI monitoring and emitting a misleading "CI failed" message.
+if [ -z "$PR_URL" ] || [ -z "$PR_NUMBER" ]; then
+  echo "gh pr create did not return a PR URL — possible duplicate PR. Inspect: gh pr list --head <feature-branch>"
+  exit 1
+fi
 ```
 
 **Post-Push CI Monitoring (Non-Negotiable):** after `gh pr create` returns, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done." BLOCK on the watch + empty-check assertion below. Fail closed on any non-zero result that isn't the "no CI configured" case:

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -219,23 +219,40 @@ EOF
 )"
 ```
 
-**Post-Push CI Monitoring (Non-Negotiable):** after `gh pr create` returns the PR URL, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done." BLOCK on the watch command below.
+**Post-Push CI Monitoring (Non-Negotiable):** after `gh pr create` returns, you CANNOT report success to the user until CI has finished AND passed. "Pushed" is not "done." BLOCK on the watch + empty-check assertion below.
+
+First, capture the PR number deterministically — `gh pr create` emits a URL, not an integer, and relying on branch-to-PR mapping is fragile on repos with multiple open PRs per branch:
 
 ```bash
-# Primary: --watch streams status and returns aggregate exit code
-# (0 = all pass, non-zero = at least one failure/cancellation).
-gh pr checks <pr-number> --watch
+PR_NUMBER=$(gh pr view --json number -q .number)
 ```
 
-**Fallback (if `--watch` cannot run):** poll until all checks reach a terminal state, then assert the bucket set is a subset of `{pass, skipping}` (allow-list, not deny-list — an unknown future bucket value must fail closed). Use gh's normalized `bucket` field, not raw `state` values, to avoid missing edge states like `NEUTRAL`, `ACTION_REQUIRED`, or lowercase legacy commit-status values. Capture `gh`'s own exit code and interpret it per its documented contract (0 = all terminal, 8 = at least one pending, other non-zero = gh itself errored).
+Then watch the checks:
+
+```bash
+# Primary: --watch streams status and returns aggregate exit code.
+# Exit 0 = all terminal passes OR no checks configured (must disambiguate below).
+# Non-zero = at least one failure/cancellation.
+gh pr checks "$PR_NUMBER" --watch
+
+# --watch on a PR with zero checks exits 0 silently — guard against
+# vacuously satisfying the "CI passed" requirement.
+if [ "$(gh pr checks "$PR_NUMBER" --json bucket --jq 'length')" = "0" ]; then
+  echo "No CI checks configured — record in final report and recommend adding CI"
+fi
+```
+
+**Fallback (if `--watch` cannot run):** poll until all checks reach a terminal state, then assert the bucket set is a subset of `{pass, skipping}` (allow-list, not deny-list — an unknown future bucket value must fail closed). Use gh's normalized `bucket` field, not raw `state` values, to avoid missing edge states like `NEUTRAL`, `ACTION_REQUIRED`, or lowercase legacy commit-status values.
+
+**gh exit-code contract:** per gh's own documentation, `gh pr checks` exits 0 when all checks terminal-passed, 1 when at least one check terminal-failed, 8 when at least one is still pending, and other values for tool errors (auth, network, rate-limit). Both 0 and 1 are terminal — the fallback's assertion block disambiguates pass from fail via the bucket set. 8 means continue polling. Anything else means gh itself couldn't determine state.
 
 ```bash
 while true; do
-  BUCKETS=$(gh pr checks <pr-number> --json bucket --jq '[.[].bucket] | unique')
+  BUCKETS=$(gh pr checks "$PR_NUMBER" --json bucket --jq '[.[].bucket] | unique')
   RC=$?
   echo "CI buckets: $BUCKETS"
   case "$RC" in
-    0|1) break ;;                                 # 0 = all pass, 1 = at least one failed; both terminal — let assertion classify
+    0|1) break ;;                                 # 0 = all pass, 1 = at least one failed; both terminal — assertion classifies
     8) sleep 20 ;;                                # at least one pending — keep polling
     *) echo "gh pr checks errored (rc=$RC) — cannot determine CI state"; exit 1 ;;
   esac
@@ -251,7 +268,7 @@ else
 fi
 ```
 
-If the exit is non-zero (either via `--watch` or the explicit assertion): diagnose from CI logs (`gh run view <run-id> --log-failed` or `gh pr checks <pr-number>`), dispatch a fix, **re-run Step 5.5's full validation matrix** (the fix can regress local checks), push, and re-watch. Do NOT report success on a red PR. Do NOT leave the watch running while moving on to another task — CI failure is an actionable blocker that takes precedence.
+If the exit is non-zero (either via `--watch` or the explicit assertion): diagnose from CI logs (`gh run view <run-id> --log-failed` or `gh pr checks "$PR_NUMBER"`), dispatch a fix, **re-run Step 5.5's full validation matrix** (the fix can regress local checks), push, and re-watch. Do NOT report success on a red PR. Do NOT leave the watch running while moving on to another task — CI failure is an actionable blocker that takes precedence.
 
 If the block exits with the "No CI checks configured" message, record that in the final report so the user knows local validation was the only gate, and recommend they add CI.
 

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -161,7 +161,7 @@ Silently-missing tools are NOT a pass — they are an "unknown." Either run the 
 | TypeScript/Node | `npx tsc --noEmit` (if `tsconfig.json`) | `npm run lint` / `pnpm lint` / `biome check` (whichever the repo configures) | `prettier --check .` / `biome format --check` (whichever configured) | `npm test` / `pnpm test` / `vitest run` / `jest` |
 | Rust | `cargo check --all-targets --all-features` | `cargo clippy --all-targets --all-features -- -D warnings` | `cargo fmt -- --check` | `cargo test --workspace --all-features` |
 | Python | `mypy` or `pyright` (if configured) | `ruff check` / `flake8` (whichever configured) | `ruff format --check` / `black --check` (whichever configured) | `pytest` |
-| Go | (compiler via `go build ./...`) | `go vet ./...` (add `golangci-lint run` if configured) | `test -z "$(gofmt -l .)"` (fails non-zero on drift) | `go test ./...` |
+| Go | (compiler via `go build ./...`) | `go vet ./...` (add `golangci-lint run` if configured) | `out=$(gofmt -l .) && [ -z "$out" ]` (preserves gofmt exit code AND fails non-zero on drift) | `go test ./...` |
 | .NET | `dotnet build -p:TreatWarningsAsErrors=true` (portable across Linux/macOS/Windows; covers type + warnings-as-errors) | Roslyn analyzers via the same `-p:TreatWarningsAsErrors=true` + any configured analyzer package | `dotnet format --verify-no-changes` | `dotnet test` |
 | Ruby | (runtime only) | `bundle exec rubocop` (covers Layout + Style + Lint) | covered by Lint (or `bundle exec standardrb` if configured instead of rubocop) | `bundle exec rspec` / `bundle exec rake test` |
 | Java/Kotlin | (compiler via `./gradlew build`) | `./gradlew checkstyleMain spotbugsMain` or `./mvnw spotbugs:check` (if configured) | `./gradlew spotlessCheck` (if configured) | `./gradlew test` or `./mvnw test` |
@@ -235,7 +235,7 @@ while true; do
   RC=$?
   echo "CI buckets: $BUCKETS"
   case "$RC" in
-    0) break ;;                                   # all terminal — exit loop
+    0|1) break ;;                                 # 0 = all pass, 1 = at least one failed; both terminal — let assertion classify
     8) sleep 20 ;;                                # at least one pending — keep polling
     *) echo "gh pr checks errored (rc=$RC) — cannot determine CI state"; exit 1 ;;
   esac


### PR DESCRIPTION
## Summary

Closes the /finish-shaped portion of #165. The other 3 ACs (pipeline discipline in /build, scope anchoring in /quality-gate, drift detection) were already shipped in prior work; only the /finish gates remained.

## What landed

**Step 5.5 — Pre-Push Validation (BLOCK semantics):**
- Toolchain auto-detection from manifest files, with explicit monorepo/nested-manifest handling
- Validation matrix covering TypeScript/Node, Rust, Python, Go, .NET, Ruby, Java/Kotlin (type-check, lint, format, tests per ecosystem)
- Strict exit-code discipline: no silent `|| true` / `2>/dev/null` masks; explicit exit-code interpretation per tool contract (including `gh pr checks` exit 8 = pending)
- Every applicable check must exit 0 (with documented exceptions per tool); any unhandled non-zero triggers STOP + fix + full-matrix re-run

**Step 6 Option 2 — Post-Push CI Monitoring (BLOCK semantics):**
- `PR_URL` captured directly from `gh pr create` output (deterministic — avoids the branch-to-PR mapping issue)
- Duplicate-PR guard: fails loudly if `gh pr create` returns empty URL
- Primary path: `gh pr checks --watch` with explicit WATCH_RC capture and 3-branch classifier (no-checks / failure / green)
- Fallback path (when `--watch` unavailable): poll loop keyed on gh's documented exit codes (0/1/8), bucket-based allow-list assertion via `jq -e all(...)` — unknown future bucket values fail closed
- "No CI configured" case disambiguated from "all pass" on both paths

**Common Mistakes + Red Flags:**
- 3 new Common Mistake entries (skipping pre-push, silencing failures, pushing-and-moving-on)
- 4 new Red Flag "Never" entries + 3 "Always" entries covering both new gates
- Exit-code-masking rule reframed as "don't mask without interpreting against the tool's documented contract" (avoids the `gh exit 8 = pending` footgun)

**Gate Execution Ledger:**
- Added "Post-push CI monitoring completed green (Option 2 only)" entry

## QG convergence

Ran 7 red-team rounds on this branch. Score progression:

| Round | Significant | Notes |
|---|---|---|
| R1 | 6 | Surface bugs (soft degradation, monitor placement, ledger gap, matrix gaps) |
| R2 | 3 | Bash rigor (allow-list vs deny-list, empty-array pass, gh RC ignored) |
| R3 | 2 | RC handling (use case instead of grep, portable .NET flag) |
| R4 | 1 | Case statement misclassified RC=1 as gh error |
| R5 | 3 | Narrative vs case contradiction, PR_NUMBER capture, --watch no-CI silent pass |
| R6 | 2 | --watch RC not captured, `gh pr view` doesn't actually solve the mapping problem |
| R7 | **0** | PASS — 1 Minor (duplicate-PR diagnostic) addressed in quick-fix |

Each round's findings were real; no stagnation. Final state is tight.

## Test plan

- [x] All 6 R1 Significants addressed
- [x] All 3 R2 Significants addressed
- [x] All 2 R3 Significants addressed
- [x] R4 Significant addressed
- [x] All 3 R5 Significants addressed
- [x] All 2 R6 Significants addressed
- [x] R7 PASS with 1 Minor also addressed
- [x] Institutional memory blocks (existing Common Mistakes, Red Flags rows) preserved additively
- [ ] Dry-run `/finish` on a trivial PR to verify the new bash executes; pre-push matrix completes; `--watch` blocks; duplicate-PR guard fires when expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)