### PR TITLE
feat(recon): scout hardening — runtime-config, confidence labels, doc mining, debugging auto-module

### DIFF
--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -326,8 +326,14 @@ Build the Investigation Brief markdown with all core sections:
 - **[Description]** — [file paths] — [relevance to current task]
 
 <!-- If Pattern Scout emitted `### Prior Knowledge Documents`, merge those
-     entries in here, tagged `(handoff doc)` / `(postmortem)` / `(decision record)`
-     so consumers can distinguish code prior art from written prior knowledge.
+     entries in here with a source-derived tag so consumers can distinguish
+     code prior art from written prior knowledge. Tag by source directory:
+       docs/handoffs/ → (handoff doc)
+       docs/postmortems/ → (postmortem)
+       docs/retros/, docs/retrospectives/ → (retro)
+       docs/decisions/, docs/adr/ → (ADR)
+       docs/incidents/ → (incident)
+       repo-root HANDOFF.md / POSTMORTEM.md / DECISIONS.md → (handoff doc) / (postmortem) / (decision record)
      Preserve the quoted passage sub-bullet from the scout report. -->
 <!-- Only present if Pattern Scout returned Prior Knowledge Documents: -->
 - **(handoff doc) [Doc title]** — `path/to/doc.md` (mtime YYYY-MM-DD) — [relevance]

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -249,7 +249,15 @@ For unresolved actions: surface in the `## Conflicts` section of the brief.
 After contradiction detection, scan both scout reports for causal language:
 
     fixes, causes, is the bug, is the fix, will resolve, root cause is,
-    caused by, resolved by
+    caused by, resolved by, because, due to, leads to, responsible for,
+    the culprit, breaks because, stems from, triggers, originates,
+    accounts for, cascades from, propagates from, results in, arises from,
+    comes from, introduced by, source of, →, explains why, the reason *
+    is, is why * fails
+
+Keyword matching is case-insensitive with word-boundary semantics (the
+keyword must not be embedded inside a larger word). Phrase patterns with `*`
+allow up to 5 intervening words between the anchors.
 
 For each match, verify the finding has at least ONE of:
 
@@ -317,10 +325,13 @@ Build the Investigation Brief markdown with all core sections:
 [From Pattern Scout report]
 - **[Description]** — [file paths] — [relevance to current task]
 
-<!-- Merge Pattern Scout's `### Prior Knowledge Documents` sub-section in here,
-     tagged `(handoff doc)` / `(postmortem)` / `(decision record)` so consumers
-     can distinguish code prior art from written prior knowledge: -->
+<!-- If Pattern Scout emitted `### Prior Knowledge Documents`, merge those
+     entries in here, tagged `(handoff doc)` / `(postmortem)` / `(decision record)`
+     so consumers can distinguish code prior art from written prior knowledge.
+     Preserve the quoted passage sub-bullet from the scout report. -->
+<!-- Only present if Pattern Scout returned Prior Knowledge Documents: -->
 - **(handoff doc) [Doc title]** — `path/to/doc.md` (mtime YYYY-MM-DD) — [relevance]
+  - [Quoted passage with line reference]
 
 ## Conflicts
 <!-- Only present if contradictions detected between scouts -->
@@ -354,7 +365,15 @@ Same policy applies to depth module outputs (3,000 token budget, 2,000 for readi
 
 ## Phase 4: Depth Module Dispatch
 
-Evaluate the caller's original `modules:` list for the empty-list opt-out FIRST (see Auto-Inclusion below — opt-out takes precedence over auto-inclusion). Then dispatch only if the resulting list is non-empty. Dispatch **after** core synthesis completes — depth agents receive core findings as input context.
+Resolve the effective modules list by evaluating these branches in order:
+
+1. **Explicit empty list (`modules: []`)** — opt-out. Skip auto-inclusion
+   and dispatch nothing.
+2. **Otherwise, run Auto-Inclusion below** — this may prepend
+   `diagnostic-context` to the caller's list (or produce a singleton list
+   from an omitted `modules:`).
+3. **Dispatch** the resulting list if non-empty. Dispatch **after** core
+   synthesis completes — depth agents receive core findings as input context.
 
 ### Auto-Inclusion for Debugging Tasks
 
@@ -363,7 +382,17 @@ substrings, auto-include `diagnostic-context` as the FIRST entry in modules:
 
     bug, bugs, crash, crashes, crashing, broken, breaks, wrong, incorrect,
     regression, regressed, fail, failing, failure, error, investigate,
-    diagnose, why does, why is, glitch, inverted
+    diagnose, why does, why is, glitch, inverted behavior, appears inverted
+
+**Matching semantics:** Case-insensitive. Single-word keywords match with
+word-boundary semantics — `error` matches "fix this error" but NOT
+"error-handling"; `fail` matches "request fails" but NOT "failover". This
+reduces false positives on feature work that references error-adjacent
+domains.
+
+Multi-word keywords (`why does`, `why is`, etc.) match as contiguous token
+sequences, also case-insensitive, with word-boundaries anchored at each end
+of the phrase.
 
 **Opt-out:** If caller passed `modules: []` (explicitly empty), suppress
 auto-inclusion — the empty list signals "core only, no auto-detection."

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -71,6 +71,8 @@ List of depth modules to produce after core synthesis. Valid values:
 
 Most invocations request 0-1 depth modules. Omit for core-only output (cheapest).
 
+**Auto-inclusion:** Debugging-keyword tasks automatically add `diagnostic-context` (see Phase 4 Auto-Inclusion). Pass `modules: []` (explicit empty list) to suppress auto-inclusion — omitting `modules:` does not suppress it.
+
 **`scope`** (optional)
 Directory constraint. When provided, overrides scout scope suggestions entirely — scouts constrain exploration to the given path(s). Cheaper, faster.
 
@@ -242,6 +244,34 @@ When scouts report `cartographer-conflict` findings, apply this adjudication tab
 For auto-update actions: queue the update for Phase 5 (Cartographer Feedback).
 For unresolved actions: surface in the `## Conflicts` section of the brief.
 
+### Causal Claim Verification
+
+After contradiction detection, scan both scout reports for causal language:
+
+    fixes, causes, is the bug, is the fix, will resolve, root cause is,
+    caused by, resolved by
+
+For each match, verify the finding has at least ONE of:
+
+  (a) Repro test cited (file + test name)
+  (b) Math or logic derivation included in the finding
+  (c) Both scouts reached the same finding independently
+
+If none of (a)/(b)/(c) hold, DEMOTE the finding to an Open Question with this
+format:
+
+    **Question:** [scout-name proposed: "X causes Y"]. Not verified.
+    **Why it matters:** If true, resolves Y; if false, misdirects investigation.
+    **Resolvable by:** [repro test / math derivation / second-scout corroboration]
+
+Causal claims that pass verification appear in their normal brief section
+(e.g., Project Structure, Existing Patterns) unchanged. Demoted claims appear
+in Open Questions with the verification gap explicit.
+
+Scout-supplied confidence labels are ADVISORY — this lint checks for evidence,
+not self-labels. A scout-tagged `[confidence: high]` claim without (a)/(b)/(c)
+is still demoted.
+
 ### Open Questions Aggregation
 
 After contradiction detection, aggregate open questions from both scout reports:
@@ -287,6 +317,11 @@ Build the Investigation Brief markdown with all core sections:
 [From Pattern Scout report]
 - **[Description]** — [file paths] — [relevance to current task]
 
+<!-- Merge Pattern Scout's `### Prior Knowledge Documents` sub-section in here,
+     tagged `(handoff doc)` / `(postmortem)` / `(decision record)` so consumers
+     can distinguish code prior art from written prior knowledge: -->
+- **(handoff doc) [Doc title]** — `path/to/doc.md` (mtime YYYY-MM-DD) — [relevance]
+
 ## Conflicts
 <!-- Only present if contradictions detected between scouts -->
 - **[Tension]** — Structure Scout: [claim + evidence]. Pattern Scout: [claim + evidence]. Confidence: [assessment].
@@ -319,7 +354,28 @@ Same policy applies to depth module outputs (3,000 token budget, 2,000 for readi
 
 ## Phase 4: Depth Module Dispatch
 
-Only if `modules:` parameter is non-empty. Dispatch **after** core synthesis completes — depth agents receive core findings as input context.
+Evaluate the caller's original `modules:` list for the empty-list opt-out FIRST (see Auto-Inclusion below — opt-out takes precedence over auto-inclusion). Then dispatch only if the resulting list is non-empty. Dispatch **after** core synthesis completes — depth agents receive core findings as input context.
+
+### Auto-Inclusion for Debugging Tasks
+
+If the caller-provided `task:` parameter contains any of these case-insensitive
+substrings, auto-include `diagnostic-context` as the FIRST entry in modules:
+
+    bug, bugs, crash, crashes, crashing, broken, breaks, wrong, incorrect,
+    regression, regressed, fail, failing, failure, error, investigate,
+    diagnose, why does, why is, glitch, inverted
+
+**Opt-out:** If caller passed `modules: []` (explicitly empty), suppress
+auto-inclusion — the empty list signals "core only, no auto-detection."
+
+**Idempotency:** Skip auto-inclusion if caller's modules list already contains
+`diagnostic-context`.
+
+**Narration:** When auto-including, narrate: "Debugging task detected (keyword:
+'[match]'). Auto-including diagnostic-context. Pass modules: [] to opt out."
+
+**Pipeline status:** Append under a new `## Auto-Included Modules` section in
+`pipeline-status.md`: `diagnostic-context | reason=keyword: '[match]'`.
 
 ### Dispatch
 
@@ -545,6 +601,8 @@ The Investigation Brief is consumed by 6+ skills. Section headers are the contra
 - Never exceed context budgets without overflow handling
 - Never auto-update cartographer without both-scout agreement + verifiable evidence
 - Never return depth module output without the core brief
+- Never let an unverified causal claim reach the brief's main sections — demote to Open Questions per the Causal Claim Verification step
+- Never skip auto-inclusion of diagnostic-context on a debugging task unless caller explicitly passed `modules: []`
 
 ## Integration
 

--- a/skills/recon/pattern-scout-prompt.md
+++ b/skills/recon/pattern-scout-prompt.md
@@ -38,6 +38,24 @@ Agent tool (subagent_type: Explore, model: sonnet):
 
     Search the codebase for:
 
+    - **Prior-knowledge documents (check FIRST, before grepping source)** —
+      scan for written prior knowledge in these locations:
+        * `docs/handoffs/*.md`
+        * `docs/postmortems/*.md`
+        * `docs/retros/*.md`, `docs/retrospectives/*.md`
+        * `docs/decisions/*.md`, `docs/adr/*.md`
+        * `docs/incidents/*.md`
+        * `HANDOFF.md`, `POSTMORTEM.md`, `DECISIONS.md` at repo root
+      Glob each location. Sort matches by mtime (newest first). Read titles
+      and first paragraphs. If ≥2 content words (nouns, verbs, or identifiers
+      — excluding articles, prepositions, and auxiliary verbs like *the, a,
+      is, of, and*) from the task description appear in a doc's title or
+      first paragraph, read the doc fully. Read at most 5
+      matching docs fully; list any additional matches as open questions.
+      Prior-knowledge docs are often more current than cartographer and
+      frequently contain Open Questions or known-issue notes that resolve
+      the investigation cheaply. ALWAYS check them before grepping source
+      from scratch.
     - **Naming conventions** — files, functions, variables, classes
     - **Code organization patterns** — how similar features are structured
     - **Test patterns** — test file location, naming, framework usage, fixture patterns
@@ -52,6 +70,29 @@ Agent tool (subagent_type: Explore, model: sonnet):
 
     **Epistemic honesty:** If you look for something and can't determine it, report
     it as an open question. What you couldn't find is as valuable as what you did.
+
+    ## Confidence Labels
+
+    Tag every finding with `[confidence: high|medium|low]` based on HOW you
+    verified it (not subjective certainty):
+
+    - **high** — one of:
+        * File existence / absence directly verified via Glob or Read
+        * Pattern grepped with 2+ concrete examples cited (each as `path:line` — summaries like "many occurrences" count as medium, not high)
+        * Math or logic derivation included in the finding
+        * Two scouts independently reach the same finding (orchestrator will tag)
+    - **medium** — single source confirmed, not cross-verified:
+        * File exists but not read in detail
+        * Pattern observed in 1 location, generalization assumed
+        * Convention inferred from naming plus 1 example
+    - **low** — inferred or circumstantial:
+        * "Related fix exists, plausible cause"
+        * "Similar pattern in another module"
+        * Reasoning depends on assumed semantics not directly checked
+
+    Do not inflate labels. The orchestrator lint checks for evidence
+    independently of your self-label — unverified causal claims get demoted
+    regardless of tag.
 
     ## Scope Suggestions
 
@@ -104,9 +145,15 @@ Agent tool (subagent_type: Explore, model: sonnet):
     ### Existing Patterns
     [Conventions, naming, test patterns, abstractions]
     [Specific examples with file references]
+    [Tag each bullet with `[confidence: high|medium|low]` — see Confidence Labels above]
 
     ### Prior Art
-    - **[Description]** — [file paths] — [relevance to current task]
+    - **[Description]** — [file paths] — [relevance to current task] [confidence: high|medium|low]
+
+    ### Prior Knowledge Documents
+    <!-- Only present if matching docs found -->
+    - **[Doc title]** (`path/to/doc.md`, mtime YYYY-MM-DD) — [relevance to task] [confidence: high|medium|low]
+      - [Quote most relevant passage with line reference]
 
     ### Suggested Scope
     #### In Scope

--- a/skills/recon/pattern-scout-prompt.md
+++ b/skills/recon/pattern-scout-prompt.md
@@ -46,8 +46,11 @@ Agent tool (subagent_type: Explore, model: sonnet):
         * `docs/decisions/*.md`, `docs/adr/*.md`
         * `docs/incidents/*.md`
         * `HANDOFF.md`, `POSTMORTEM.md`, `DECISIONS.md` at repo root
-      Glob each location. Sort matches by mtime (newest first; ties broken
-      alphabetically by path). Read each doc's title (the first `# ` heading,
+      Glob each location. Sort matches by git-authored date (newest first) —
+      use `git log -1 --format=%cs -- <path>` for a stable per-file date that
+      survives fresh clones; fall back to filesystem mtime only when the path
+      is not tracked. Ties broken alphabetically by path. Read each doc's
+      title (the first `# ` heading,
       or the filename without extension if no heading) plus its first
       non-empty paragraph (contiguous non-blank lines after the title).
 

--- a/skills/recon/pattern-scout-prompt.md
+++ b/skills/recon/pattern-scout-prompt.md
@@ -46,12 +46,22 @@ Agent tool (subagent_type: Explore, model: sonnet):
         * `docs/decisions/*.md`, `docs/adr/*.md`
         * `docs/incidents/*.md`
         * `HANDOFF.md`, `POSTMORTEM.md`, `DECISIONS.md` at repo root
-      Glob each location. Sort matches by mtime (newest first). Read titles
-      and first paragraphs. If ≥2 content words (nouns, verbs, or identifiers
-      — excluding articles, prepositions, and auxiliary verbs like *the, a,
-      is, of, and*) from the task description appear in a doc's title or
-      first paragraph, read the doc fully. Read at most 5
-      matching docs fully; list any additional matches as open questions.
+      Glob each location. Sort matches by mtime (newest first; ties broken
+      alphabetically by path). Read each doc's title (the first `# ` heading,
+      or the filename without extension if no heading) plus its first
+      non-empty paragraph (contiguous non-blank lines after the title).
+
+      Tokenize the task description and the combined title+paragraph text
+      the same way: lowercase, split on `\W+` (non-alphanumeric), discard
+      empty tokens. A doc MATCHES if ≥2 task tokens are present in the doc's
+      token set, where each matching token is ≥4 chars and is NOT in this
+      stoplist: {the, a, an, is, are, was, were, of, for, and, or, to, in,
+      on, with, this, that, add, fix, update, make, use, used, have, has,
+      had, should, will, would, can, could}. Exact-token match only —
+      no stemming, prefix, or plural normalization.
+
+      Read matching docs fully, capped at 5. List any additional matches
+      as open questions.
       Prior-knowledge docs are often more current than cartographer and
       frequently contain Open Questions or known-issue notes that resolve
       the investigation cheaply. ALWAYS check them before grepping source

--- a/skills/recon/structure-scout-prompt.md
+++ b/skills/recon/structure-scout-prompt.md
@@ -151,7 +151,7 @@ Agent tool (subagent_type: Explore, model: sonnet):
 
     ### Runtime Config Verification
     <!-- Only present if runtime-config load sites found -->
-    - [file:line load call] → [artifact path] — [found | absent | may-be-local-only] [confidence: high|medium|low]
+    - [file:line load call] → [artifact path] — [found | absent | may-be-local-only | dynamic — cannot verify statically] [confidence: high|medium|low]
 
     ### Suggested Scope
     #### In Scope

--- a/skills/recon/structure-scout-prompt.md
+++ b/skills/recon/structure-scout-prompt.md
@@ -43,11 +43,58 @@ Agent tool (subagent_type: Explore, model: sonnet):
     - **Build system** — package manager, build tool, CI configuration
     - **Key directories** — their responsibilities and what they contain
     - **Module boundaries** — where one subsystem ends and another begins
+    - **Runtime configuration verification** — when you find code that loads
+      configuration at runtime, verify the corresponding artifact exists on
+      disk. Detect these patterns (non-exhaustive):
+        * Unity/.NET: `Resources.Load<T>(path)`, `AssetDatabase.LoadAssetAtPath`,
+          `AssetBundle.LoadAsset`
+        * Config files: `File.ReadAllText(...)`, `yaml.load(open(...))`,
+          `json.load(...)`
+        * Env vars: `os.environ.get(VAR)`, `process.env.VAR`,
+          `System.getenv(...)`, `std::env::var(...)`
+        * Feature flags: `featureFlag.enabled(name)`,
+          `launchDarkly.variation(...)`, `growthbook.isOn(...)`
+        * DI containers: `container.Resolve<T>()`, `Get<T>()` fetched from
+          external scope
+      For each load site with a statically resolvable path (string literal
+      or resolvable constant), run a Glob or Read to check whether the
+      expected artifact exists. If the lookup path is dynamic (env var,
+      feature-flag name, runtime-resolved type, computed string), skip the
+      existence check and report status `dynamic — cannot verify statically`.
+      Report findings under `### Runtime Config Verification` with:
+        - Lookup site (file:line of the load call)
+        - Expected artifact path (or `<dynamic>` when not resolvable)
+        - Status: `found` | `absent` | `not in repo but may be local-only` | `dynamic — cannot verify statically`
+      Absent configuration silently routes execution to the default branch —
+      this is a common class of silent bug in config-gated systems.
 
     Cite specific paths for every finding. Do not make claims without path evidence.
 
     **Epistemic honesty:** If you look for something and can't determine it, report
     it as an open question. What you couldn't find is as valuable as what you did.
+
+    ## Confidence Labels
+
+    Tag every finding with `[confidence: high|medium|low]` based on HOW you
+    verified it (not subjective certainty):
+
+    - **high** — one of:
+        * File existence / absence directly verified via Glob or Read
+        * Pattern grepped with 2+ concrete examples cited (each as `path:line` — summaries like "many occurrences" count as medium, not high)
+        * Math or logic derivation included in the finding
+        * Two scouts independently reach the same finding (orchestrator will tag)
+    - **medium** — single source confirmed, not cross-verified:
+        * File exists but not read in detail
+        * Pattern observed in 1 location, generalization assumed
+        * Convention inferred from naming plus 1 example
+    - **low** — inferred or circumstantial:
+        * "Related fix exists, plausible cause"
+        * "Similar pattern in another module"
+        * Reasoning depends on assumed semantics not directly checked
+
+    Do not inflate labels. The orchestrator lint checks for evidence
+    independently of your self-label — unverified causal claims get demoted
+    regardless of tag.
 
     ## Scope Suggestions
 
@@ -100,6 +147,11 @@ Agent tool (subagent_type: Explore, model: sonnet):
     ### Project Structure
     [Module layout, entry points, build system, key directories]
     [Cite specific paths]
+    [Tag each bullet with `[confidence: high|medium|low]` — see Confidence Labels below]
+
+    ### Runtime Config Verification
+    <!-- Only present if runtime-config load sites found -->
+    - [file:line load call] → [artifact path] — [found | absent | may-be-local-only] [confidence: high|medium|low]
 
     ### Suggested Scope
     #### In Scope


### PR DESCRIPTION
## Summary

Bundled implementation of four recon-skill enhancements surfaced by a real-world `/recon` investigation on Riftlock #1055 (Mode3D camera inversion bug).

- **#208** Structure Scout verifies runtime-config artifacts exist on disk (Unity `Resources.Load`, config reads, env vars, feature flags, DI). Dynamic paths reported as `dynamic — cannot verify statically` rather than silently skipped.
- **#209** `/recon` auto-includes the `diagnostic-context` depth module when the `task:` parameter contains debugging keywords (bug, crash, broken, wrong, inverted, etc.). Opt-out via `modules: []`.
- **#210** Both scouts tag findings with `[confidence: high|medium|low]` based on evidence type. Phase 3 synthesis adds a Causal Claim Verification lint that demotes unverified causal claims ("X causes Y") to Open Questions, regardless of self-label.
- **#211** Pattern Scout mines `docs/handoffs/`, `docs/postmortems/`, `docs/adr/`, etc. **before** grepping source, so prior-knowledge docs surface findings rather than cold-starting from scratch.

All four shipped together — they touch overlapping files (`recon/SKILL.md`, both scout prompt templates), so separating would create merge churn and internal inconsistency.

## Design / Plan

- Design: `docs/plans/2026-04-20-recon-scout-hardening-design.md` (local; docs/plans is gitignored per repo convention)
- Plan: `docs/plans/2026-04-20-recon-scout-hardening-implementation-plan.md` (local)

## Red-team pass

An adversarial review on the diff surfaced 7 actionable findings (1 Critical, 5 Important, 3 Minor). All actionable findings were fixed in the same commit:

1. Opt-out ordering in Phase 4 dispatch (`modules: []` now explicitly evaluated before auto-inclusion).
2. Auto-inclusion documented in the Invocation API (callers who only read the parameter docs will now know about it).
3. `modules:` omitted vs `modules: []` distinction surfaced in the API docs.
4. "Substantive nouns" replaced with concrete "content words" definition + stopword examples.
5. Dynamic-path case in runtime-config verification now explicit (avoids Sonnet scouts hallucinating paths or reporting everything absent).
6. "2+ concrete examples cited" clarified to require `path:line` citations (summaries like "many occurrences" count as medium, not high).
7. Prior Knowledge Documents merge template added to `## Prior Art` in the brief assembly instructions (schema consistency).

Two findings intentionally skipped: cartographer-payload scan extension (scope overreach — those have their own verification path) and negative-context clause for auto-inclusion keywords (design doc explicitly accepted the false-positive cost).

## Dry-run trace (acceptance check for prompt changes)

Tracing a debugging task `/recon task: "investigate Mode3D camera inversion bug"`:

- [x] `bug` / `investigate` / `inverted` all match the auto-inclusion keyword list → `diagnostic-context` added as first module.
- [x] Structure Scout would detect `Resources.Load<RenderingModeConfig>("World/RenderingModeConfig")` at `GameBootstrap.cs:582`, run a `Glob` on `Assets/Resources/World/RenderingModeConfig.asset`, and report `absent`.
- [x] Pattern Scout would glob `docs/handoffs/`, find `2026-04-20-epic-246-p2d-shipped-reopen-1049.md`, detect content-word overlap (`Mode3D`, `camera`, `inversion`), read it fully, and surface Open Question 2 under `### Prior Knowledge Documents`.
- [x] Any claim like "Pattern Scout: PR #1049 fixes the inversion" lacks a repro citation, math derivation, or cross-scout corroboration → Causal Claim Verification demotes it to `## Open Questions` with the verification gap explicit.
- [x] Findings carry `[confidence: high|medium|low]` tags; self-labeling "high" does not bypass the lint because the lint checks for evidence, not self-labels.

No automated tests — prompt template changes are consumed by LLM scouts, so human-readable trace verification is the appropriate acceptance check (noted in the implementation plan).

## Test plan

- [ ] Run `/recon task: "investigate a sample bug"` against any repo with `docs/handoffs/` — verify diagnostic-context auto-includes and Pattern Scout lists handoff docs.
- [ ] Run `/recon task: "investigate the bug-report flow design"` with `modules: []` — verify auto-inclusion is suppressed.
- [ ] Run `/recon` on a Unity project with a `Resources.Load<T>` call pointing at a missing asset — verify Structure Scout reports `absent`.
- [ ] Inject a test scout report containing a causal claim without evidence — verify synthesis demotes it to Open Questions.

Closes #208, #209, #210, #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)