### PR TITLE
feat(recon): Verification Ledger — brief records causal claims; falsifications flow via handoff docs (#213)

### DIFF
--- a/eval/verification-ledger/fixtures/brief-0-claims-expected.md
+++ b/eval/verification-ledger/fixtures/brief-0-claims-expected.md
@@ -1,0 +1,2 @@
+## Verification Ledger
+<!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->

--- a/eval/verification-ledger/fixtures/brief-0-claims-input.md
+++ b/eval/verification-ledger/fixtures/brief-0-claims-input.md
@@ -1,0 +1,12 @@
+# Fixture: empty-state brief (0 causal keyword matches)
+
+## STRUCTURE SCOUT REPORT
+
+### Project Structure
+- The repo uses Bun for package management.
+- Entry point is `src/index.ts`.
+
+## PATTERN SCOUT REPORT
+
+### Existing Patterns
+- Tests use Vitest with `describe`/`it` syntax.

--- a/eval/verification-ledger/fixtures/brief-3-claims-expected.md
+++ b/eval/verification-ledger/fixtures/brief-3-claims-expected.md
@@ -1,0 +1,6 @@
+## Verification Ledger
+<!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->
+
+- **L-01** — The missing Unity asset in `Resources/config.yaml` causes the silent default-branch fallback at `src/loader.cs:L42`. — method: `dual-scout`, evidence: `structure-scout, pattern-scout`, disposition: `confirmed`
+- **L-02** — The build script fails because of the missing `scripts/pre-build.sh` — method: `read`, evidence: `scripts/pre-build.sh`, disposition: `demoted`
+- **L-03** — Auth fails because the token expires — root cause is the 1h TTL in `config/auth.yaml`. — method: `repro-test`, evidence: `tests/auth_spec.py:test_token_expires`, disposition: `confirmed`

--- a/eval/verification-ledger/fixtures/brief-3-claims-input.md
+++ b/eval/verification-ledger/fixtures/brief-3-claims-input.md
@@ -1,0 +1,20 @@
+# Fixture: brief with 3 deduplicated causal claims
+
+## STRUCTURE SCOUT REPORT
+
+### Project Structure
+- The missing Unity asset in `Resources/config.yaml` causes the silent default-branch fallback at `src/loader.cs:L42`. [evidence: grep:src/loader.cs:L42] [confidence: high]
+- The build script fails because of the missing `scripts/pre-build.sh` [evidence: read:scripts/pre-build.sh] [demoted] [confidence: medium]
+
+### Suggested Scope
+#### In Scope
+- `src/loader.cs`
+
+## PATTERN SCOUT REPORT
+
+### Existing Patterns
+- The missing Unity asset at `Resources/config.yaml` is what causes the default-branch fallback behavior at `src/loader.cs`. [evidence: read:src/loader.cs:L40-L50] [confidence: high]
+- Auth fails because the token expires — root cause is the 1h TTL in `config/auth.yaml`. [evidence: repro-test:tests/auth_spec.py:test_token_expires] [confidence: high]
+
+### Prior Art
+- Similar fallback pattern observed in `src/legacy_loader.cs`

--- a/eval/verification-ledger/fixtures/fixture-idempotent/input.md
+++ b/eval/verification-ledger/fixtures/fixture-idempotent/input.md
@@ -1,0 +1,11 @@
+# Fixture: re-run idempotence — same input twice produces byte-identical output
+
+## STRUCTURE SCOUT REPORT
+
+### Project Structure
+- The missing config file causes the silent fallback at `src/loader.ts:L10`. [evidence: grep:src/loader.ts:L10] [confidence: high]
+
+## PATTERN SCOUT REPORT
+
+### Existing Patterns
+- Auth fails because the token expires — root cause is the 1h TTL in `config/auth.yaml`. [evidence: repro-test:tests/auth_spec.py:test_token_expires] [confidence: high]

--- a/eval/verification-ledger/fixtures/fixture-inv7-dedup/input.md
+++ b/eval/verification-ledger/fixtures/fixture-inv7-dedup/input.md
@@ -1,0 +1,11 @@
+# Fixture: isolated dedup — 2 identical causal claims from both scouts merge to 1 entry
+
+## STRUCTURE SCOUT REPORT
+
+### Project Structure
+- The missing config file causes the silent fallback at `src/loader.ts:L10`. [evidence: grep:src/loader.ts:L10] [confidence: high]
+
+## PATTERN SCOUT REPORT
+
+### Existing Patterns
+- The missing config file causes the silent fallback at `src/loader.ts:L10`. [evidence: read:src/loader.ts:L10] [confidence: high]

--- a/eval/verification-ledger/fixtures/fixture-structural-only-merge/expected.md
+++ b/eval/verification-ledger/fixtures/fixture-structural-only-merge/expected.md
@@ -1,0 +1,4 @@
+## Verification Ledger
+<!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->
+
+- **L-01** — The missing `Config/feature-flags.yaml` causes the fallback path to activate in `src/router.ts`. — method: `structural-only`, evidence: `Config/feature-flags.yaml`, disposition: `awaiting`

--- a/eval/verification-ledger/fixtures/fixture-structural-only-merge/input.md
+++ b/eval/verification-ledger/fixtures/fixture-structural-only-merge/input.md
@@ -1,0 +1,11 @@
+# Fixture: structural-only tie-break suppresses dual-scout override
+
+## STRUCTURE SCOUT REPORT
+
+### Project Structure
+- The missing `Config/feature-flags.yaml` causes the fallback path to activate in `src/router.ts`. [evidence: structural-only:Config/feature-flags.yaml] [confidence: medium]
+
+## PATTERN SCOUT REPORT
+
+### Existing Patterns
+- The missing feature-flags config causes the fallback path to activate in `src/router.ts`. [evidence: grep:src/router.ts:L88] [confidence: medium]

--- a/eval/verification-ledger/fixtures/phase5-grep-fenced/handoff.md
+++ b/eval/verification-ledger/fixtures/phase5-grep-fenced/handoff.md
@@ -1,0 +1,13 @@
+# Handoff Doc (Phase 5 fenced-block fixture)
+
+## Falsification findings
+
+- Recon claim falsified: The cache layer was never invalidated under concurrent writes.
+
+## Verification Ledger Convention
+
+The following is a documentation example — do NOT flag as a landmine:
+
+```
+- Recon claim falsified: example sentence shown here for documentation purposes only.
+```

--- a/eval/verification-ledger/fixtures/phase5-grep-match/handoff.md
+++ b/eval/verification-ledger/fixtures/phase5-grep-match/handoff.md
@@ -1,0 +1,7 @@
+# 2026-04-22 Handoff — auth investigation
+
+## Findings
+
+- Recon claim falsified: L-02 from brief 2026-04-20T12-00-00 — `Auth fails because the token expires — root cause is the 1h TTL in config/auth.yaml.` — evidence: repro test showed token TTL is 24h, actual failure was clock-skew in the validator.
+
+Other prose here.

--- a/eval/verification-ledger/fixtures/scout-omits-tag-input.md
+++ b/eval/verification-ledger/fixtures/scout-omits-tag-input.md
@@ -1,0 +1,11 @@
+# Fixture: scout omits [evidence:] tag
+
+## STRUCTURE SCOUT REPORT
+
+### Project Structure
+- The flaky test is caused by a race in `src/cache.ts`. [confidence: low]
+
+## PATTERN SCOUT REPORT
+
+### Existing Patterns
+- No causal claims here.

--- a/eval/verification-ledger/fixtures/structural-only-input.md
+++ b/eval/verification-ledger/fixtures/structural-only-input.md
@@ -1,0 +1,11 @@
+# Fixture: structural-only tag produces awaiting disposition
+
+## STRUCTURE SCOUT REPORT
+
+### Project Structure
+- Adjacent PR #1055 fixes this by adding the missing asset. [evidence: structural-only:Resources/config.yaml] [confidence: medium]
+
+## PATTERN SCOUT REPORT
+
+### Existing Patterns
+- No causal claims here.

--- a/eval/verification-ledger/ledger_scorer.py
+++ b/eval/verification-ledger/ledger_scorer.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Reference implementation of the Verification Ledger assembler (issue #213).
+
+This is an eval artifact — the canonical assembler lives as prose in
+skills/recon/SKILL.md Phase 3 "Ledger Assembly". This Python version lets the
+test suite confirm the assembly rules, dedup (Jaccard + union-find), and
+Phase 5 grep behave as specified.
+
+Per DEC-2 / AMB-1: the ledger is a reader-friendly markdown convention, NOT
+a regex-enforced contract. The regexes in this scorer are INTERNAL to the
+reference implementation; they are NOT a grammar/contract on the ledger
+output format. The authoritative contract is the diff against the expected
+fixture files plus the inline assertions in run-eval.sh.
+
+Usage:
+  python3 ledger_scorer.py assemble <scout-report-bundle.md>
+  python3 ledger_scorer.py phase5-grep <directory>
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Canonical Causal Keyword Set — mirrors skills/recon/SKILL.md "### Causal Keyword Set".
+CAUSAL_KEYWORDS = [
+    "fixes", "causes", "is the bug", "is the fix", "will resolve",
+    "root cause is", "caused by", "resolved by", "because", "due to",
+    "leads to", "responsible for", "the culprit", "breaks because",
+    "stems from", "triggers", "originates", "accounts for",
+    "cascades from", "propagates from", "results in", "arises from",
+    "comes from", "introduced by", "source of", "→", "explains why",
+]
+# Phrase patterns with `*` allow up to 5 intervening words between the anchors.
+PHRASE_PATTERNS = [("the reason", "is"), ("is why", "fails")]
+
+# Small stoplist for token normalization used by Jaccard — keeps dedup robust
+# against trivial articles/connectives without needing an NLP stack.
+STOPLIST = {
+    "a", "an", "the", "is", "are", "was", "were", "of", "for",
+    "and", "or", "to", "in", "on", "with", "at", "by", "this", "that",
+    "it", "its", "be", "been",
+}
+
+EVIDENCE_TAG = re.compile(r"\[evidence:\s*([a-z-]+)\s*:\s*([^\]]+?)\]", re.I)
+DEMOTED_TAG = re.compile(r"\[demoted\]", re.I)
+CONFIDENCE_TAG = re.compile(r"\[confidence:\s*[^\]]+\]", re.I)
+
+PLACEHOLDER = (
+    "<!-- Records causal claims made by this brief (populated this run). "
+    "Falsifications flow via handoff-doc entries under docs/handoffs/ per "
+    "the convention in skills/recon/SKILL.md. -->"
+)
+
+
+def normalize_tokens(text: str) -> set[str]:
+    """Lowercase, strip punctuation, strip bracketed tags, split → token set."""
+    # Strip bracketed tags so [evidence: ...] and [confidence: ...] don't
+    # contaminate the Jaccard comparison (they are metadata, not claim).
+    no_brackets = re.sub(r"\[[^\]]*\]", " ", text)
+    tokens = re.findall(r"[a-z0-9]+", no_brackets.lower())
+    return {t for t in tokens if t not in STOPLIST}
+
+
+def jaccard_tokens(tokens_a: set[str], tokens_b: set[str]) -> float:
+    if not tokens_a and not tokens_b:
+        return 0.0
+    union = tokens_a | tokens_b
+    if not union:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(union)
+
+
+def has_causal_keyword(text: str) -> bool:
+    lower = text.lower()
+    for kw in CAUSAL_KEYWORDS:
+        if kw == "→":
+            if "→" in lower:
+                return True
+            continue
+        # word-boundary semantics; \b works for ASCII word chars (keywords here are ASCII).
+        pattern = r"\b" + re.escape(kw) + r"\b"
+        if re.search(pattern, lower):
+            return True
+    for a, b in PHRASE_PATTERNS:
+        pattern = r"\b" + re.escape(a) + r"\b(?:\s+\w+){0,5}\s+\b" + re.escape(b) + r"\b"
+        if re.search(pattern, lower):
+            return True
+    return False
+
+
+def extract_claims(text: str, scout_name: str, start_idx: int = 0) -> list[dict]:
+    """Parse scout report text → list of claim dicts.
+
+    Each claim dict carries an explicit `_idx` (absolute ingestion index =
+    start_idx + local bullet-position). This field is load-bearing for
+    idempotent output ordering (Check 7).
+
+    Why `_idx` exists: two byte-identical claim dicts compare equal under
+    dict `__eq__`, so `list.index(c)` would collapse them to the first
+    occurrence and produce unstable group ordering across runs. Stamping
+    `_idx` at parse time keeps group sort keys deterministic even when a
+    future fixture introduces identical-content claims from both scouts.
+    """
+    claims: list[dict] = []
+    local_idx = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        body = stripped[2:]
+        if not has_causal_keyword(body):
+            continue
+        m = EVIDENCE_TAG.search(body)
+        method, anchor = (None, None)
+        if m:
+            method = m.group(1).lower()
+            anchor = m.group(2).strip()
+        demoted = bool(DEMOTED_TAG.search(body))
+        # Produce display text: strip evidence/confidence/demoted tags.
+        display = body
+        display = EVIDENCE_TAG.sub("", display)
+        display = CONFIDENCE_TAG.sub("", display)
+        display = DEMOTED_TAG.sub("", display)
+        display = re.sub(r"\s+", " ", display).strip()
+        claims.append({
+            "text": display,
+            "scout": scout_name,
+            "evidence_method": method,
+            "evidence_anchor": anchor,
+            "demoted": demoted,
+            "_idx": start_idx + local_idx,
+        })
+        local_idx += 1
+    return claims
+
+
+def union_find_merge(claims: list[dict], threshold: float = 0.70) -> list[list[dict]]:
+    """Union-find over pairwise token-Jaccard ≥ threshold. Return groups."""
+    n = len(claims)
+    parent = list(range(n))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(i: int, j: int) -> None:
+        ri, rj = find(i), find(j)
+        if ri != rj:
+            parent[ri] = rj
+
+    tokens = [normalize_tokens(c["text"]) for c in claims]
+    for i in range(n):
+        for j in range(i + 1, n):
+            if jaccard_tokens(tokens[i], tokens[j]) >= threshold:
+                union(i, j)
+
+    groups: dict[int, list[dict]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(claims[i])
+    return list(groups.values())
+
+
+def resolve_entry(group: list[dict], ordinal: int) -> dict:
+    """Determine method, anchor, disposition for a merged claim group.
+
+    Precedence (per skills/recon/SKILL.md Phase 3 Ledger Assembly step 3):
+    1. any_structural_only → method=structural-only, disposition=awaiting
+       (beats dual-scout override).
+    2. dual_scout (both scouts present, no structural-only) →
+       method=dual-scout, disposition=confirmed. Unconditional — no tag guard.
+    3. single-scout tag available → method/anchor from pattern tag if present
+       (else structure tag); disposition=demoted iff all group members are
+       demoted, else confirmed. (Pattern-scout tag preferred as the
+       richer-conventions anchor.)
+    4. No tags → method=none, evidence=—, disposition per demoted-all rule.
+    """
+    any_structural_only = any(c["evidence_method"] == "structural-only" for c in group)
+    scouts = {c["scout"] for c in group}
+    dual_scout = len(scouts) == 2
+
+    pattern_tag = next(
+        (c for c in group
+         if c["scout"] == "pattern" and c["evidence_method"]
+         and c["evidence_method"] != "structural-only"),
+        None,
+    )
+    structure_tag = next(
+        (c for c in group
+         if c["scout"] == "structure" and c["evidence_method"]
+         and c["evidence_method"] != "structural-only"),
+        None,
+    )
+
+    if any_structural_only:
+        tag = next(c for c in group if c["evidence_method"] == "structural-only")
+        method = "structural-only"
+        anchor = tag["evidence_anchor"]
+        disposition = "awaiting"
+    elif dual_scout:
+        method = "dual-scout"
+        anchor = "structure-scout, pattern-scout"
+        disposition = "confirmed"
+    elif pattern_tag or structure_tag:
+        chosen = pattern_tag or structure_tag
+        method = chosen["evidence_method"]
+        anchor = chosen["evidence_anchor"]
+        disposition = "demoted" if all(c["demoted"] for c in group) else "confirmed"
+    else:
+        method = "none"
+        anchor = "—"
+        disposition = "demoted" if all(c["demoted"] for c in group) else "confirmed"
+
+    # Canonical display text = first claim in group (by ingestion order).
+    group_sorted = sorted(group, key=lambda c: c["_idx"])
+    text = group_sorted[0]["text"]
+    return {
+        "ord": ordinal, "text": text, "method": method,
+        "anchor": anchor, "disposition": disposition,
+    }
+
+
+def format_ordinal(n: int) -> str:
+    # Zero-padded 2 digits for n ≤ 99, natural 3+ digits past 100
+    # (informational overflow per SKILL.md).
+    return f"{n:02d}" if n <= 99 else str(n)
+
+
+def assemble_ledger(structure_text: str, pattern_text: str) -> str:
+    structure_claims = extract_claims(structure_text, "structure", start_idx=0)
+    pattern_claims = extract_claims(
+        pattern_text, "pattern", start_idx=len(structure_claims)
+    )
+    claims = structure_claims + pattern_claims
+    groups = union_find_merge(claims)
+    groups.sort(key=lambda g: min(c["_idx"] for c in g))
+
+    if not groups:
+        return f"## Verification Ledger\n{PLACEHOLDER}\n"
+
+    lines = ["## Verification Ledger", PLACEHOLDER, ""]
+    for i, group in enumerate(groups, start=1):
+        e = resolve_entry(group, i)
+        lines.append(
+            f"- **L-{format_ordinal(e['ord'])}** — {e['text']} — "
+            f"method: `{e['method']}`, evidence: `{e['anchor']}`, "
+            f"disposition: `{e['disposition']}`"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def split_scout_reports(text: str) -> tuple[str, str]:
+    """Split a bundle file into (structure_body, pattern_body).
+
+    Expects headings `## STRUCTURE SCOUT REPORT` and `## PATTERN SCOUT REPORT`.
+    """
+    parts = re.split(
+        r"(?m)^## (?:STRUCTURE|PATTERN) SCOUT REPORT\s*$", text
+    )
+    structure = parts[1] if len(parts) > 1 else ""
+    pattern = parts[2] if len(parts) > 2 else ""
+    return structure, pattern
+
+
+def cmd_assemble(inputs: list[Path]) -> str:
+    if len(inputs) == 1:
+        bundle = inputs[0].read_text(encoding="utf-8")
+        structure, pattern = split_scout_reports(bundle)
+    elif len(inputs) == 2:
+        structure = inputs[0].read_text(encoding="utf-8")
+        pattern = inputs[1].read_text(encoding="utf-8")
+    else:
+        raise SystemExit("assemble takes 1 (bundle) or 2 (structure+pattern) inputs")
+    return assemble_ledger(structure, pattern)
+
+
+def cmd_phase5_grep(directory: Path) -> list[str]:
+    hits: list[str] = []
+    for md in sorted(Path(directory).rglob("*.md")):
+        try:
+            content = md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in content.splitlines():
+            cleaned = re.sub(r"^(\s*[-*+>]\s*)+", "", line).strip()
+            if cleaned.startswith("Recon claim falsified:"):
+                hits.append(f"LANDMINE: {cleaned}")
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="mode", required=True)
+    ap = sub.add_parser("assemble")
+    ap.add_argument("inputs", nargs="+", type=Path)
+    gp = sub.add_parser("phase5-grep")
+    gp.add_argument("directory", type=Path)
+    args = p.parse_args(argv)
+    if args.mode == "assemble":
+        sys.stdout.write(cmd_assemble(args.inputs))
+        return 0
+    if args.mode == "phase5-grep":
+        for line in cmd_phase5_grep(args.directory):
+            print(line)
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/eval/verification-ledger/ledger_scorer.py
+++ b/eval/verification-ledger/ledger_scorer.py
@@ -285,7 +285,13 @@ def cmd_phase5_grep(directory: Path) -> list[str]:
             content = md.read_text(encoding="utf-8")
         except OSError:
             continue
+        in_fence = False
         for line in content.splitlines():
+            if re.match(r"^\s*`{3,}", line):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
             cleaned = re.sub(r"^(\s*[-*+>]\s*)+", "", line).strip()
             if cleaned.startswith("Recon claim falsified:"):
                 hits.append(f"LANDMINE: {cleaned}")

--- a/eval/verification-ledger/run-eval.sh
+++ b/eval/verification-ledger/run-eval.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# End-to-end eval for the Verification Ledger (issue #213).
+#
+# Runs eight checks against the ledger_scorer reference implementation:
+#   1.  Brief with 3 deduplicated causal claims -> 3 ledger entries (INV-7, N-count variant).
+#   1b. Minimal fixture: 2 identical causal claims -> exactly 1 ledger entry (INV-7, isolated-merge variant).
+#   2.  Brief with 0 causal keyword matches -> header + placeholder comment only (INV-8).
+#   3.  Scout omits [evidence:] tag -> entry emitted with method: none, evidence: -- .
+#   4.  [evidence: structural-only:...] tag -> disposition: awaiting (INV-9).
+#   5.  Phase 5 grep match fixture -> one "landmine dispatch" dry-run line (INV-10).
+#   6.  Phase 5 no-match fixture -> zero dispatches, silent skip (INV-10 negative case).
+#   7.  Re-run idempotence: same input assembled twice produces byte-identical output (innovate).
+#   8.  Structural-only tie-break suppresses dual-scout override (INV-9 variant).
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "=== Check 1: 3 dedup'd causal claims produce 3 ledger entries (INV-7 N-count) ==="
+python3 ledger_scorer.py assemble fixtures/brief-3-claims-input.md | diff - fixtures/brief-3-claims-expected.md
+echo "  PASS"
+
+echo "=== Check 1b: isolated dedup — 2 identical claims merge to 1 entry (INV-7 isolated merge) ==="
+count=$(python3 ledger_scorer.py assemble fixtures/fixture-inv7-dedup/input.md | grep -c '^- \*\*L-')
+[ "$count" = "1" ] || { echo "  FAIL expected 1 ledger entry, got $count"; exit 1; }
+echo "  PASS"
+
+echo "=== Check 2: empty-state brief ==="
+python3 ledger_scorer.py assemble fixtures/brief-0-claims-input.md | diff - fixtures/brief-0-claims-expected.md
+echo "  PASS"
+
+echo "=== Check 3: scout omits [evidence:] tag → method: none ==="
+python3 ledger_scorer.py assemble fixtures/scout-omits-tag-input.md | grep -q 'method: `none`, evidence: `—`'
+echo "  PASS"
+
+echo "=== Check 4: structural-only tag → disposition: awaiting (INV-9) ==="
+python3 ledger_scorer.py assemble fixtures/structural-only-input.md | grep -q 'disposition: `awaiting`'
+echo "  PASS"
+
+echo "=== Check 5: Phase 5 grep finds falsification sentence → 1 landmine ==="
+hits=$(python3 ledger_scorer.py phase5-grep fixtures/phase5-grep-match | wc -l)
+[ "$hits" = "1" ] || { echo "  FAIL expected 1 hit, got $hits"; exit 1; }
+echo "  PASS"
+
+echo "=== Check 6: Phase 5 no matches → zero dispatches ==="
+hits=$(python3 ledger_scorer.py phase5-grep fixtures/phase5-no-matches | wc -l)
+[ "$hits" = "0" ] || { echo "  FAIL expected 0 hits, got $hits"; exit 1; }
+echo "  PASS"
+
+echo "=== Check 7: re-run idempotence — same input twice produces byte-identical output ==="
+diff <(python3 ledger_scorer.py assemble fixtures/fixture-idempotent/input.md) \
+     <(python3 ledger_scorer.py assemble fixtures/fixture-idempotent/input.md)
+echo "  PASS"
+
+echo "=== Check 8: structural-only-merge — dual-scout merge attempted but structural-only wins (INV-9 tie-break) ==="
+output=$(python3 ledger_scorer.py assemble fixtures/fixture-structural-only-merge/input.md)
+echo "$output" | grep -q 'method: `structural-only`' || { echo "  FAIL expected method: structural-only"; exit 1; }
+echo "$output" | grep -q 'disposition: `awaiting`' || { echo "  FAIL expected disposition: awaiting"; exit 1; }
+if echo "$output" | grep -q 'method: `dual-scout`'; then echo "  FAIL dual-scout must not appear"; exit 1; fi
+diff <(echo "$output") fixtures/fixture-structural-only-merge/expected.md
+echo "  PASS"
+
+echo "=== ALL CHECKS PASSED ==="

--- a/eval/verification-ledger/run-eval.sh
+++ b/eval/verification-ledger/run-eval.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # End-to-end eval for the Verification Ledger (issue #213).
 #
-# Runs eight checks against the ledger_scorer reference implementation:
+# Runs nine checks against the ledger_scorer reference implementation:
 #   1.  Brief with 3 deduplicated causal claims -> 3 ledger entries (INV-7, N-count variant).
 #   1b. Minimal fixture: 2 identical causal claims -> exactly 1 ledger entry (INV-7, isolated-merge variant).
 #   2.  Brief with 0 causal keyword matches -> header + placeholder comment only (INV-8).
@@ -11,6 +11,7 @@
 #   6.  Phase 5 no-match fixture -> zero dispatches, silent skip (INV-10 negative case).
 #   7.  Re-run idempotence: same input assembled twice produces byte-identical output (innovate).
 #   8.  Structural-only tie-break suppresses dual-scout override (INV-9 variant).
+#   9.  Phase 5 grep ignores fenced code blocks (inquisitor fix).
 
 set -euo pipefail
 cd "$(dirname "$0")"
@@ -59,4 +60,9 @@ if echo "$output" | grep -q 'method: `dual-scout`'; then echo "  FAIL dual-scout
 diff <(echo "$output") fixtures/fixture-structural-only-merge/expected.md
 echo "  PASS"
 
-echo "=== ALL CHECKS PASSED ==="
+echo "=== Check 9: Phase 5 grep ignores fenced code blocks (inquisitor fix) ==="
+hits=$(python3 ledger_scorer.py phase5-grep fixtures/phase5-grep-fenced | wc -l)
+[ "$hits" = "1" ] || { echo "  FAIL expected 1 hit (non-fenced only), got $hits"; exit 1; }
+echo "  PASS"
+
+echo "=== ALL CHECKS PASSED (9/9) ==="

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -307,6 +307,73 @@ The same Claim Equivalence rule is used by the Phase 3 Ledger Assembly
 dedup step (see below). Criterion (c) and Ledger Assembly dedup share this
 one canonical definition.
 
+### Ledger Assembly
+
+After Causal Claim Verification, assemble the `## Verification Ledger`
+section of the Investigation Brief. The ledger covers Phase 3 core-scout
+causal claims only — depth-module (Phase 4) claims are out of scope.
+
+**Algorithm:**
+
+1. **Re-scan** both scout reports for causal-keyword matches using the
+   **Causal Keyword Set** defined above. For each match, check whether
+   the lint demoted the finding to Open Questions; this drives the
+   disposition.
+2. **Deduplicate** using the **Claim Equivalence** rule (token Jaccard
+   ≥ 0.70 + transitive-closure via union-find — same rule used by
+   Causal Claim Verification criterion (c)). Claims in one equivalence
+   class merge into a single ledger entry.
+3. **For each merged claim:**
+   - **(a) Evidence source.** Extract `[evidence: <method>:<anchor>]`
+     from the scout finding. If missing, fall back to lint-internal
+     evidence:
+       - If lint (a) cited a repro test (`file:test_name`) → `method:
+         repro-test`, `evidence: <file:test>`.
+       - If lint (b) cited a math/logic derivation → `method: math`,
+         `evidence: <one-line summary>`.
+       - If neither → `method: none`, `evidence: —` (em-dash U+2014).
+   - **(b) Dual-scout override.** If lint criterion (c) fired for this
+     merged claim, override to `method: dual-scout`, `evidence:
+     structure-scout, pattern-scout`. **Tie-break:** if EITHER scout
+     tagged `structural-only` for this claim, DO NOT override —
+     `structural-only` takes precedence, disposition stays `awaiting`.
+     **Merged-claim tag tie-break:** if dedup merged two claims and BOTH
+     scouts emitted non-structural-only `[evidence:]` tags (lint (c) did
+     not fire), use the Pattern Scout's tag (richer conventions anchor).
+   - **(c) Disposition:**
+       - `method: structural-only` → `awaiting` (overrides lint verdict;
+         `awaiting` has exactly one producer).
+       - Otherwise, lint passed (a/b/c) → `confirmed`.
+       - Otherwise → `demoted`.
+4. **Assign ordinal** `L-NN` (zero-padded 2 digits, monotonic within the
+   brief; continue as 3-digit `L-100+` if the brief exceeds 99 entries —
+   informational, not an error).
+5. **Append to the ledger section.** Per-entry format:
+
+       - **L-NN** — <claim text> — method: `<method>`, evidence: `<anchor>`, disposition: `<disposition>`
+
+   The ledger section is the **last core-brief section** (after
+   `## Open Questions`). Empty state (zero causal-keyword matches from
+   step 1) emits only the section header plus the canonical HTML-comment
+   placeholder:
+
+       ## Verification Ledger
+       <!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->
+
+   The same placeholder is used for both empty and populated states —
+   see `## Verification Ledger Convention`.
+
+6. **Write the assembled brief** (including the ledger) to
+   `<scratch>/investigation-brief.md` at the end of Phase 3. This is the
+   **core brief**. This step also closes an existing latent gap where
+   `investigation-brief.md` was referenced by Persisted Artifacts and
+   Compaction Recovery but no phase wrote it.
+
+   Phase 4's depth-module append is a recon-internal re-write of this
+   file, permitted by I-2 (consumer skills may not mutate it; recon
+   itself may). See Phase 4 Output Handling for the serialized re-write
+   rule.
+
 ### Open Questions Aggregation
 
 After contradiction detection, aggregate open questions from both scout reports:
@@ -373,6 +440,11 @@ Build the Investigation Brief markdown with all core sections:
 ## Open Questions
 <!-- Aggregated from scouts and depth modules — what recon couldn't determine -->
 - **[Question]** — [Why it matters] — Relevant to: [consumer list] — Resolvable by: [specific investigation or human input]
+
+## Verification Ledger
+<!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->
+<!-- Populated entries, if any: -->
+- **L-NN** — [claim text] — method: `<method>`, evidence: `<anchor>`, disposition: `<confirmed | demoted | awaiting>`
 ```
 
 ## Overflow Handling
@@ -530,6 +602,10 @@ The brief follows the exact template from the design, including the metadata blo
 ...
 
 ## Open Questions
+...
+
+## Verification Ledger
+<!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->
 ...
 
 ---

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -244,9 +244,13 @@ When scouts report `cartographer-conflict` findings, apply this adjudication tab
 For auto-update actions: queue the update for Phase 5 (Cartographer Feedback).
 For unresolved actions: surface in the `## Conflicts` section of the brief.
 
-### Causal Claim Verification
+### Causal Keyword Set
 
-After contradiction detection, scan both scout reports for causal language:
+The canonical list of causal-language keywords used by both the Causal Claim
+Verification step and the Phase 3 Ledger Assembly re-scan. Both steps MUST
+reference this set by name; do not re-list keywords inline. **This set is
+referenced by name from (a) Causal Claim Verification and (b) Ledger Assembly
+step (below) — update in both uses when modifying.**
 
     fixes, causes, is the bug, is the fix, will resolve, root cause is,
     caused by, resolved by, because, due to, leads to, responsible for,
@@ -259,11 +263,17 @@ Keyword matching is case-insensitive with word-boundary semantics (the
 keyword must not be embedded inside a larger word). Phrase patterns with `*`
 allow up to 5 intervening words between the anchors.
 
+### Causal Claim Verification
+
+After contradiction detection, scan both scout reports for causal language
+using the **Causal Keyword Set** defined above.
+
 For each match, verify the finding has at least ONE of:
 
   (a) Repro test cited (file + test name)
   (b) Math or logic derivation included in the finding
-  (c) Both scouts reached the same finding independently
+  (c) Both scouts reached the same claim independently, where "same claim"
+      is defined by the **Claim Equivalence** rule below.
 
 If none of (a)/(b)/(c) hold, DEMOTE the finding to an Open Question with this
 format:
@@ -279,6 +289,23 @@ in Open Questions with the verification gap explicit.
 Scout-supplied confidence labels are ADVISORY — this lint checks for evidence,
 not self-labels. A scout-tagged `[confidence: high]` claim without (a)/(b)/(c)
 is still demoted.
+
+#### Claim Equivalence
+
+Two causal claims A and B are "the same claim" if their normalized token sets
+satisfy **token Jaccard ≥ 0.70**:
+
+1. Normalize: lowercase, strip punctuation, split on whitespace → token set.
+2. Compute |A ∩ B| / |A ∪ B|. If ≥ 0.70, A and B are pairwise-equivalent.
+3. **Transitive closure (union-find).** Build a graph over all claims with an
+   edge for each pairwise-equivalent pair. The connected components
+   (computed via union-find) are the equivalence classes. This yields a
+   deterministic result independent of comparison order — if A ↔ B and
+   B ↔ C but A and C do not pairwise match, A, B, C still form one class.
+
+The same Claim Equivalence rule is used by the Phase 3 Ledger Assembly
+dedup step (see below). Criterion (c) and Ledger Assembly dedup share this
+one canonical definition.
 
 ### Open Questions Aggregation
 

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -533,9 +533,31 @@ When multiple modules are requested, dispatch them in parallel. Each depth agent
 
 ### Output Handling
 
-- Write each depth module output to scratch as individual files (e.g., `<scratch>/impact-analysis.md`)
-- Append completed depth module sections to the Investigation Brief after the core sections, separated by `---`
-- Narrate after each: "Depth module [name] complete. Returning Investigation Brief."
+- Write each depth module output to scratch as individual files (e.g.,
+  `<scratch>/impact-analysis.md`) as each module returns. Individual module
+  files are safe under parallel dispatch — each file has exactly one
+  writer.
+- **Serialize the brief re-write.** Do NOT re-write
+  `<scratch>/investigation-brief.md` incrementally after each module
+  returns — Phase 4 Dispatch runs depth modules in parallel, and
+  interleaved re-writes race. Instead:
+    1. Wait until ALL dispatched depth modules have completed (or failed
+       per the Depth Module Failure rules below).
+    2. Append all completed depth-module sections to the in-memory brief
+       after the core sections, separated by `---`, in a deterministic
+       order: the order modules appear in the resolved effective modules
+       list (see Phase 4 opening — the list produced by branches 1/2/3,
+       including any auto-inclusion prepend).
+    3. Perform exactly one re-write of `<scratch>/investigation-brief.md`
+       with the fully-assembled brief (core + all depth sections) AFTER
+       ALL depth modules complete. Per-module writes are forbidden.
+- This serialized-write rule satisfies INV-11 without requiring
+  cross-writer coordination. If Phase 4 is skipped (no depth modules
+  requested), the Phase 3 write from Ledger Assembly step 6 stands as
+  the final on-disk brief — no Phase 4 re-write occurs.
+- Narrate after each module's individual completion: "Depth module [name]
+  complete. Returning Investigation Brief." The brief re-write itself is
+  internal; no separate narration required.
 
 ### Depth Module Failure
 

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -779,6 +779,7 @@ The Investigation Brief is consumed by 6+ skills. Section headers are the contra
 
 **Semi-stable (additive, consumers opt-in):**
 - `## Open Questions` — present when scouts report unknowns. Consumers that need it parse for it; consumers that don't can ignore it. Not yet validated by consumer integration — promoted to stable once 2+ consumers confirm they consume it.
+- `## Verification Ledger` — present in every brief (may contain only an HTML-comment placeholder when no causal claims detected). Consumers that do not parse the ledger can ignore it; the section is additive. The per-entry format is a reader-friendly convention, not a strict grammar.
 
 **Semi-stable (consumers that request specific modules depend on these):**
 - Depth module section headers: `## Impact Analysis`, `## Consumer Registry`, `## Friction Scan`, `## Subsystem Manifest`, `## Diagnostic Context`, `## Execution Readiness`
@@ -787,7 +788,108 @@ The Investigation Brief is consumed by 6+ skills. Section headers are the contra
 **Unstable (internal content, not parsed by header):**
 - Content within sections — formatting, subheadings, bullet structure may evolve
 
-**Process:** Any change to a stable or semi-stable header is a breaking change. The PR must update all consumer skill templates that reference the changed header. Adding new depth modules is non-breaking.
+**Process:** Any change to a stable or semi-stable header is a breaking change. The PR must update all consumer skill templates that reference the changed header. **Exception: adding a new semi-stable header is additive and non-breaking.** Consumers that don't parse the new section are unaffected. Renaming or semantically changing an existing header is still breaking. Adding new depth modules is non-breaking.
+
+## Verification Ledger Convention
+
+The `## Verification Ledger` section of the Investigation Brief is a
+reader-friendly markdown record of causal claims made by recon. Per
+DEC-2 / AMB-1, this is a **convention, not a regex-enforced contract** —
+consumers that eventually need machine parseability will add a regex
+contract then (flagged in the design's Open Questions).
+
+### Scope
+
+- Phase 3 core-scout causal claims only.
+- Depth-module (Phase 4) claims are OUT OF SCOPE in MVP. A follow-up
+  ticket may extend both the causal-lint and the ledger to depth modules.
+- The ledger is the last core-brief section (after `## Open Questions`).
+  Phase 4 depth modules are appended after the core brief, separated by
+  `---` per existing convention.
+
+### Per-entry format (reader-friendly, not a grammar)
+
+    - **L-NN** — <claim text> — method: `<method>`, evidence: `<anchor>`, disposition: `<disposition>`
+
+- **Ordinal `L-NN`** — zero-padded 2 digits, monotonic within the brief.
+  Overflows to 3-digit `L-100+` are informational (brief is unusually
+  large), not errors.
+- **method** — one of `grep | read | math | glob | repro-test |
+  dual-scout | structural-only | none`. A textual convention, not a
+  regex-enforced enum.
+- **evidence** — an anchor:
+    - `file:line` for `grep`, `read`, `structural-only`
+    - one-line derivation for `math`
+    - glob pattern for `glob`
+    - `<file>:<test>` for `repro-test`
+    - `structure-scout, pattern-scout` for `dual-scout` (note the comma
+      is part of the value, NOT a field separator — any future machine
+      parser MUST respect backtick quoting)
+    - em-dash `—` (U+2014) for `none` (plain hyphen also accepted by the
+      reader-friendly convention; canonical form is em-dash)
+- **disposition** — one of `confirmed | demoted | awaiting`.
+    - `confirmed` — Causal-lint (a/b/c) satisfied.
+    - `demoted` — lint failed; finding also moved to `## Open Questions`.
+      The ledger entry is retained so future runs see "recon knew this
+      was unverified."
+    - `awaiting` — produced ONLY by `[evidence: structural-only:<anchor>]`.
+      Claim is structurally verified but causally hypothetical; invites
+      downstream falsification. Lint silent-failures produce `demoted`
+      with a narrated warning, NOT `awaiting`.
+
+### Empty state
+
+If Phase 3's re-scan finds zero causal-keyword matches, the ledger is:
+
+```
+## Verification Ledger
+<!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->
+```
+
+The same placeholder comment is used for both empty and populated states
+(single canonical form). A brief with keyword matches that were all
+demoted by the lint still produces populated ledger entries with
+`disposition: demoted` — it is NOT empty state.
+
+### Handoff-doc falsification sentence (for consumer skills)
+
+Downstream skills that discover a ledger claim was wrong record the
+falsification in any markdown under the #211 doc-mining scopes
+(`docs/handoffs/`, `docs/postmortems/`, `docs/retros/`,
+`docs/retrospectives/`, `docs/decisions/`, `docs/adr/`, `docs/incidents/`,
+or `HANDOFF.md` / `POSTMORTEM.md` / `DECISIONS.md` at repo root).
+
+**Canonical sentence format (single line):**
+
+    Recon claim falsified: L-<NN> from brief <run-id> — `<claim text verbatim>` — evidence: <what proved it wrong>.
+
+Conventions:
+
+- Wrap claim text in backticks (markdown code syntax) — renders cleanly
+  even when claim text contains quotes or special characters. If claim
+  text contains a literal backtick, escape with `` \` `` or abbreviate
+  with `...` and reference the originating brief.
+- **Keep the sentence on a single line** (no hard wrap) — grep returns
+  one line per match. Abbreviate long claim text with `...`.
+- Inline claim text so the falsification survives brief pruning.
+- `<run-id>` is copy-pasted from the brief metadata block.
+- **No identifier hash required.** Sentence format is the contract.
+- Authoring skill may add its own signature (commit SHA, author) inline
+  as prose — not formalized.
+
+**Consumer contract:** briefs are write-once. Consumers never mutate
+recon scratch brief files — they record falsifications in handoff docs
+under their own control, which the next `/recon` run surfaces via Phase 5
+falsification-grep and doc-mining.
+
+### For recon maintainers
+
+- Ledger format and assembly: see Phase 3 `### Ledger Assembly`.
+- Disposition semantics and Claim Equivalence: see Phase 3
+  `### Causal Claim Verification` + `#### Claim Equivalence`.
+- Phase 5 grep-to-landmine flow: see Phase 5 `### Falsification Grep`.
+- Brief write location: `<scratch>/investigation-brief.md` (INV-6 /
+  INV-11).
 
 ## Design Principles
 

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -574,6 +574,52 @@ On failure (timeout, error, or agent did not return useful output):
 
 After the Investigation Brief is assembled (core + any depth modules):
 
+### Falsification Grep (pre-recorder)
+
+Before the cartographer recorder dispatch, grep the following scopes
+(canonicalized from #211 doc-mining — see
+`skills/recon/pattern-scout-prompt.md`) for lines containing
+`Recon claim falsified:`:
+
+- `docs/handoffs/`
+- `docs/postmortems/`
+- `docs/retros/`, `docs/retrospectives/`
+- `docs/decisions/`, `docs/adr/`
+- `docs/incidents/`
+- Repo root: `HANDOFF.md`, `POSTMORTEM.md`, `DECISIONS.md`
+
+For each hit:
+
+1. Strip any leading markdown list prefix (`- `, `* `, `+ `), blockquote
+   marker (`> `), or leading whitespace from the matched line.
+2. Pass the stripped sentence payload to the cartographer recorder
+   (dispatched in the step below) as a new landmine:
+
+       "Recon previously claimed X; later falsified. Do not re-assert
+       without fresh evidence."
+
+   The inline claim text carried in each falsification sentence is the
+   load-bearing evidence — no round-trip verification to originating
+   briefs (AMB-5).
+
+3. If grep finds zero hits, skip silently — emit no landmine dispatch
+   for this step (INV-10 negative case).
+
+4. If a hit is malformed (missing run-id, garbled format), pass the raw
+   stripped line to the cartographer recorder with a best-effort note.
+   Do not abort.
+
+**Handoff-doc falsification sentence convention.** The grep target
+format is documented in `## Verification Ledger Convention` below.
+Consumer skills (e.g., `/build`, `/debugging`, `/design`) adopt the
+convention opportunistically in separate tickets.
+
+After the Falsification Grep step above, the rest of Phase 5 proceeds as
+documented: check for new information (step 1), dispatch cartographer
+recorder if needed (step 2). Falsification-grep landmines and new-info
+updates are both passed to the SAME recorder dispatch if one occurs — do
+not dispatch the recorder twice.
+
 1. **Check for new information:** Compare scout findings against cartographer context provided in Phase 1.
 2. **If scouts discovered new information not in the map:** Dispatch cartographer recorder:
    ```

--- a/skills/recon/pattern-scout-prompt.md
+++ b/skills/recon/pattern-scout-prompt.md
@@ -107,6 +107,30 @@ Agent tool (subagent_type: Explore, model: sonnet):
     independently of your self-label — unverified causal claims get demoted
     regardless of tag.
 
+    ## Evidence Tags
+
+    When you make a causal claim ("X causes Y", "X fixes Y", "because of",
+    "root cause is", etc.), annotate it with an evidence tag:
+
+        [evidence: <method>:<anchor>]
+
+    Methods:
+    - `grep` / `read` / `math` / `glob` — standard verification; anchor is
+      `file:line`, a glob pattern, or a one-line derivation
+    - `structural-only` — the structural fact is verified (file exists,
+      symbol present), but the causal link is hypothesis. Use this when you
+      want to keep the claim in the brief as "awaiting downstream
+      falsification" rather than suppress it.
+    - `none` — inferred without verification; anchor is the em-dash `—`
+
+    Do NOT emit `dual-scout` or `repro-test` yourself — the orchestrator
+    sets `dual-scout` when both scouts reach the same claim independently,
+    and propagates `repro-test` from the lint's (a) criterion.
+
+    The `[evidence:]` tag is independent of `[confidence:]` — emit both
+    where applicable. Ledger assembly reads only `[evidence:]`; other
+    bracketed tags are ignored.
+
     ## Scope Suggestions
 
     After your investigation, emit a `suggested_scope` section:

--- a/skills/recon/structure-scout-prompt.md
+++ b/skills/recon/structure-scout-prompt.md
@@ -96,6 +96,30 @@ Agent tool (subagent_type: Explore, model: sonnet):
     independently of your self-label — unverified causal claims get demoted
     regardless of tag.
 
+    ## Evidence Tags
+
+    When you make a causal claim ("X causes Y", "X fixes Y", "because of",
+    "root cause is", etc.), annotate it with an evidence tag:
+
+        [evidence: <method>:<anchor>]
+
+    Methods:
+    - `grep` / `read` / `math` / `glob` — standard verification; anchor is
+      `file:line`, a glob pattern, or a one-line derivation
+    - `structural-only` — the structural fact is verified (file exists,
+      symbol present), but the causal link is hypothesis. Use this when you
+      want to keep the claim in the brief as "awaiting downstream
+      falsification" rather than suppress it.
+    - `none` — inferred without verification; anchor is the em-dash `—`
+
+    Do NOT emit `dual-scout` or `repro-test` yourself — the orchestrator
+    sets `dual-scout` when both scouts reach the same claim independently,
+    and propagates `repro-test` from the lint's (a) criterion.
+
+    The `[evidence:]` tag is independent of `[confidence:]` — emit both
+    where applicable. Ledger assembly reads only `[evidence:]`; other
+    bracketed tags are ignored.
+
     ## Scope Suggestions
 
     After your investigation, emit a `suggested_scope` section:


### PR DESCRIPTION
## Summary

Adds a human-readable Verification Ledger to the `/recon` Investigation Brief that records every causal claim made by the scouts, paired with verification method, evidence anchor, and disposition. Establishes a handoff-doc falsification sentence convention so downstream skills close the loop to future recon runs via the existing #211 doc-mining hook.

Closes #213.

## Design lineage

- Design doc passed 8 rounds of quality-gate on 2026-04-21, accepted as ESCALATED — user-accepted diminishing-returns exit. Three residual Significants were deliberately deferred to this build for inline fix:
  - **S-1 / INV-11** — Phase 4 parallel-write race → serialized write AFTER ALL depth modules (now explicit in SKILL.md Output Handling; per-module writes forbidden).
  - **S-2** — causal-keyword drift → new canonical `### Causal Keyword Set` block in SKILL.md, referenced by name from both Causal Claim Verification AND the new Ledger Assembly step.
  - **S-3** — lint criterion (c) informality → `### Claim Equivalence Rule` with Jaccard ≥ 0.70 + transitive-closure (union-find), shared between criterion (c) and Ledger Assembly dedup.

- Design is deliberately simple: reader-friendly markdown ledger, **no regex contract, no strict grammar, no round-trip identifier hash**. This was a mid-design pivot from an earlier strict-grammar approach; the handoff-doc inline-claim channel covers the load-bearing learning vector.

## What's in the PR

- `skills/recon/SKILL.md` — canonical Causal Keyword Set + Claim Equivalence Rule; Phase 3 Ledger Assembly step + explicit brief-write (closes **latent INV-6 gap** — Persisted Artifacts + Compaction Recovery reference `investigation-brief.md` but no phase was writing it); Phase 4 serialized re-write; Phase 5 falsification grep → cartographer landmines; new `## Verification Ledger Convention` sibling section; Brief Schema Stability additive-header carve-out + new semi-stable entry.
- `skills/recon/{structure,pattern}-scout-prompt.md` — identical `## Evidence Tags` block teaching scouts the `[evidence: <method>:<anchor>]` convention (independent of the existing `[confidence:]` tag from #210).
- `eval/verification-ledger/` — 9-check harness (`run-eval.sh`), stdlib-only Python scorer (`ledger_scorer.py`), 9 fixtures exercising INV-7/8/9/10 including isolated dedup (INV-7 2nd variant), structural-only-merge tie-break, byte-identical idempotence, and fenced-code-block skip.

## Acceptance gate

\`bash eval/verification-ledger/run-eval.sh\` → **9/9 PASS** on HEAD.

## Notes for reviewer

1. **Contract INV-11 wording supersession.** `docs/plans/2026-04-21-verification-ledger-contract.yaml` INV-11 describes the Phase 4 brief re-write as "after each depth-module append." This PR implements the opposite — **single serialized write after ALL depth modules** — per DEC-8 S-1, which supersedes the per-module wording to eliminate the parallel-write race. INV-11 is still satisfied (a single final write trivially satisfies "SKILL.md Phase 4 Output Handling contains an explicit re-write after depth-module append(s)"), just serialized.

2. **Latent INV-6 gap closed.** Pre-existing SKILL.md references `investigation-brief.md` in Persisted Artifacts table + Compaction Recovery section, but no phase actually wrote it. Phase 3 Ledger Assembly step 6 now writes it unconditionally — closes the gap incidentally.

3. **Brief-assembly template edits.** Implementer added `## Verification Ledger` to both brief-assembly templates in SKILL.md for consistency with the new assembly step. Slightly beyond Task 4's strict scope but necessary to prevent template/assembly drift.

4. **Implicit dead-prose in SKILL.md** — Merged-claim tag tie-break (Pattern-Scout preferred) is described for a case that is unreachable under the Jaccard ≥ 0.70 merge rule (since any merge implies lint (c) fired, triggering the dual-scout override first). The scorer's `dual_scout` branch produces the correct output regardless. Minor, noted for future cleanup.

5. **Phase 5 falsification grep scope.** Production scope is `docs/handoffs/`, `docs/postmortems/`, `docs/retros/{,retrospectives/}`, `docs/decisions/`, `docs/adr/`, `docs/incidents/`, and repo-root `HANDOFF.md` / `POSTMORTEM.md` / `DECISIONS.md` — same canonical list as #211 doc-mining. The inquisitor-fix (commit \`4b856a2\`) adds code-fence detection to prevent phantom landmines when handoff docs quote the canonical sentence inside fenced examples.

6. **Innovate addition.** Eval Check 7 (idempotence: byte-identical re-run) was added via `/innovate` during planning. Catches silent-regression class where a future scorer refactor could reorder \`L-NN\` ordinals across runs — which would invalidate every handoff-doc falsification sentence already on disk (they hard-reference the ordinal).

7. **Scope discipline.** Depth-module (Phase 4) causal claims are **explicitly out of scope** for the ledger in MVP — documented as the primary known gap in the design's Open Questions. Follow-up ticket.

## Noticed follow-ups (not blocking)

- SKILL.md `## Recon Progress` narration has no ledger-specific status line ("N causal claims logged"). UX polish for a future ticket.
- SKILL.md Phase 5 step numbering: Falsification Grep subsection introduces its own 1–4 list between the Phase 5 intro sentence and the existing step list (which restarts at 1). Reads fine; future cleanup could linearize.
- /build receipt-linter Tier-2 gap: during Phase 3, one implementer (Task 1 scaffold) declared PASS with a commit SHA that wasn't in git history; follow-up implementer re-authored the scaffold and the end-state is correct, but the phantom commit wasn't caught by Tier-2 verification. Follow-up ticket on /build hardening.

## Test plan

- [x] `bash eval/verification-ledger/run-eval.sh` — 9/9 PASS locally
- [x] Scout prompt edits render correctly (4-space indented block inside the heredoc-style code fence); grep verification passed in both files
- [x] SKILL.md grep checks: `### Causal Keyword Set`, `### Ledger Assembly` (after Causal Claim Verification, before Open Questions), Phase 3 brief-write, Phase 4 "AFTER ALL depth modules" language, Phase 5 \`Recon claim falsified:\` grep instruction, `## Verification Ledger Convention`, additive-header carve-out — all verified
- [ ] Reviewer confirms brief-assembly template edits don't accidentally alter unrelated brief sections
- [ ] Reviewer confirms INV-11 contract wording supersession per note 1 above is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)