### PR TITLE
docs: trim README to 62 lines, relocate detail to docs/ (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,299 +2,61 @@
 
 A collection of agent skills for systematic software development. Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [OpenAI Codex](https://openai.com/codex/), [Amp](https://amp.dev), [Cline](https://cline.bot), and any platform that supports the SKILL.md format.
 
-Covers the full development lifecycle: design, planning, TDD implementation, code review, debugging, adversarial testing, and quality gates. 42 skills across pipeline, implementation, quality, security, debugging, knowledge, and utilities. Every skill is [eval-tested](#eval-results) with measured A/B deltas.
+42 skills across the full development lifecycle — design, planning, TDD implementation, code review, debugging, adversarial testing, and quality gates. Every skill is [eval-tested](docs/evals.md) with measured A/B deltas (49 execution evals + 18 sequence evals, +29% / +31% average).
 
 Originally forked from [obra/superpowers](https://github.com/obra/superpowers), now independently maintained and significantly diverged. Pipeline checkpoint system, auto skill extraction, structured context compression, and trajectory capture inspired by [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent).
 
-### Marketplace Availability
+## Marketplace
 
 | Platform | Status |
 |----------|--------|
 | Claude Code | Pending review |
 | [skills.sh](https://skills.sh) | `npx skills add raddue/crucible` |
-| Cursor | Compatible |
-| OpenAI Codex | Compatible |
-| Amp | Compatible |
-| Cline | Compatible |
+| Cursor / Codex / Amp / Cline | Compatible — same SKILL.md format |
 
-## Why Crucible?
+## What you get
 
-**Every skill is eval-tested.** Crucible is the only skill collection we know of with quantified, blind A/B deltas using [Anthropic's own skill evaluation framework](https://github.com/anthropics/skills/tree/main/skills/skill-creator). Each skill is run with and without its methodology against neutral prompts, graded by an independent agent that doesn't know which condition it's scoring. 13 skills eval'd, 49 evals, 96% with-skill vs 67% without — an average **+29% delta**. See the [full scoreboard](#eval-results).
+- **Iterative quality gates, not single-pass review** — `quality-gate` loops until clean (red-team → fix → fresh re-review), with weighted stagnation detection. Measured **+68% delta** (see [eval results](docs/evals.md)).
+- **Full pipeline orchestration** — `build` chains design → plan → execute → complete with shadow-git checkpoints, crash recovery, and structured compaction-state blocks. One command, idea to merged PR.
+- **Adversarial testing at every level** — `adversarial-tester` writes tests designed to break the implementation; `inquisitor` runs 5 parallel attack dimensions against the full feature diff; `siege` runs 6 attacker-perspective security agents until zero Critical/High.
+- **Token-efficient by design** — orchestrators use [disk-mediated dispatch](skills/shared/dispatch-convention.md): full subagent prompts go to `/tmp`, only ~100-token pointers enter orchestrator context. A full build saves 73-131K tokens of fossilized context.
+- **Crash-resilient and session-continuous** — `replay` resumes interrupted pipelines from the last phase boundary (10 minutes, not 90); `recall` queries a searchable session activity index that survives compaction.
 
-**Iterative quality gates, not single-pass review.** Unlike other skill collections, Crucible's quality-gate skill loops — it red-teams an artifact, a separate fix agent revises (with a fix journal that prevents repeating failed strategies), a fresh reviewer attacks again, and it continues until clean or until enhanced stagnation detection (weighted scoring + Fatal count tracking + oscillation detection) determines further iteration won't help. This accounts for a **68% delta** over unstructured review — the model scores 88% with the skill vs 19% without. Process expectations (iterative rounds, severity tracking, stagnation detection) are **0% without the skill**.
+See [docs/architecture.md](docs/architecture.md) for how the orchestrator skills compose, and [docs/skills.md](docs/skills.md) for the full catalog.
 
-**Token-efficient by design.** Orchestrator skills use [disk-mediated dispatch](skills/shared/dispatch-convention.md) — full subagent prompts are written to `/tmp` dispatch files, and only a ~100-token pointer prompt enters the orchestrator's context. Over a full build pipeline (52-93 dispatches), this recovers 73-131K tokens of context that would otherwise fossilize in conversation history. Token efficiency tracking enriches dispatch manifests with character-count estimates so you can measure actual skill costs via `/stocktake efficiency`. The distill skill extends this philosophy to document ingestion: convert a 50-page PDF to a 4-page digest and save ~80% of context budget.
-
-**Crash-resilient pipelines.** Long-running pipelines (build dispatches 52-93 subagents across 4 phases) are vulnerable to context exhaustion, timeouts, and session crashes. The replay skill connects dispatch manifests, shadow git checkpoints, and Compression State Blocks to resume interrupted pipelines from the last phase boundary — a 90-minute build that crashes at Phase 4 costs ~10 minutes to resume, not 90 to restart. Build, debugging, spec, and migrate all write pipeline-active markers for automatic crash detection. Replay also enables A/B experimentation: swap dispatch templates and replay historical pipelines to measure the impact of skill changes.
-
-**Session continuity across compactions.** PostToolUse hooks log high-value session events (file edits, git operations, test runs, errors, decisions) to a searchable session activity index. The `/recall` skill queries session history by keyword, event type, or time range. Skills emit semantic events (phase transitions, design decisions) via an outbox pattern, and compaction recovery steps in build, debugging, and spec re-read session state after context compression fires.
-
-**Full pipeline orchestration.** The build skill chains design, planning, execution, and completion into a single autonomous pipeline. It dispatches parallel implementers, runs two-pass code review per task, fills test coverage gaps, writes adversarial tests designed to break the implementation, and runs a 5-dimension cross-component inquisitor before the final quality gate.
-
-**Adversarial testing at every level.** Crucible doesn't just review code, it actively tries to break it. The adversarial-tester writes tests designed to expose unknown failure modes. The inquisitor attacks the full feature diff across 5 dimensions (wiring, integration, edge cases, state/lifecycle, regression). The quality gate dispatches fresh Devil's Advocate reviewers each round to avoid anchoring bias.
-
-**Language- and framework-agnostic.** Crucible was originally built for Unity game development, and includes optional [Unity UI Toolkit skills](#unity-ui-domain-specific) for that workflow. But the core skills — planning, TDD, quality gates, debugging, adversarial testing — work on any codebase in any language. The methodologies are about *how* you develop, not *what* you're building.
-
-## Installation
+## Install
 
 ### Claude Code
-
-Clone and symlink into your skills directory:
 
 ```bash
 git clone git@github.com:raddue/crucible.git ~/repos/crucible
 ln -sf ~/repos/crucible/skills/* ~/.claude/skills/
 ```
 
-Or install as a plugin (when available on the marketplace):
+Or, when available on the marketplace: `claude plugin install raddue/crucible`.
 
-```bash
-claude plugin install raddue/crucible
-```
-
-### Cursor
-
-Skills follow the same SKILL.md format. Clone and configure as a plugin source:
+### Cursor / OpenAI Codex / Amp / Cline
 
 ```bash
 git clone git@github.com:raddue/crucible.git ~/repos/crucible
 ```
 
-See [Cursor plugin docs](https://cursor.com/docs/plugins/building) for adding external skill directories.
+Then point your platform at the cloned skills directory. See [Cursor plugin docs](https://cursor.com/docs/plugins/building) and [Codex skills docs](https://developers.openai.com/codex/skills/). Some advanced features (parallel subagent dispatch, agent teams, persistent memory) are platform-specific and degrade gracefully — see [PLATFORMS.md](PLATFORMS.md).
 
-### OpenAI Codex
+## Setup essentials
 
-Skills are compatible with Codex's SKILL.md discovery:
+**Run in auto mode** for autonomous pipelines (`/build`, `/debugging`, long `/quality-gate` runs). Auto mode lets Claude execute tool calls without per-action prompts while still confirming destructive operations. It supersedes earlier `--dangerously-skip-permissions` guidance.
 
-```bash
-git clone git@github.com:raddue/crucible.git ~/repos/crucible
-```
+**Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`** for build's parallel team execution. Without it, independent tasks fall back to sequential dispatch — everything still works, just slower.
 
-See [Codex skills docs](https://developers.openai.com/codex/skills/) for registering skill sources.
+**Recommended but optional:** enable the `forge` (retrospectives) and `cartographer` (codebase map) knowledge accelerators — they compound skill quality over time. See [docs/architecture.md](docs/architecture.md).
 
-### Cross-Platform Notes
+For hooks (session activity index, build routing advisor), MCP-based external model review, autocompact tuning, and other Claude Code specifics, see [docs/configuration.md](docs/configuration.md).
 
-All skills use the SKILL.md format published by Anthropic and adopted across platforms. Some advanced features (parallel subagent dispatch, agent teams, persistent memory) are platform-specific and degrade gracefully — see [PLATFORMS.md](PLATFORMS.md) for compatibility details.
+## Documentation
 
-## Setup (Claude Code)
-
-These settings are specific to Claude Code. Other platforms have equivalent configuration — see [PLATFORMS.md](PLATFORMS.md) for details.
-
-**`--dangerously-skip-permissions`** — Crucible is designed for long-running autonomous pipelines (build, debugging) that complete complex development tasks without user intervention. We recommend running with `--dangerously-skip-permissions` paired with a **safety hook** or other failsafe system to prevent destructive actions. See [safety hook examples](https://docs.anthropic.com/en/docs/claude-code/hooks) for setup guidance.
-
-**`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`** — Required for build's team-based parallel execution. Skills degrade gracefully without it — independent tasks run sequentially instead of in parallel. This applies to all platforms where parallel subagent dispatch is not available.
-
-**`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50`** — Performance recommendation for long-running pipelines. Triggers compaction earlier to preserve context for complex multi-phase work. Pipeline skills emit structured Compression State Blocks at checkpoint boundaries to guide the compactor on what to preserve.
-
-**Session Activity Index (hooks)** — Crucible includes PostToolUse hooks (`hooks/session-index.sh`, `hooks/session-summary.sh`) that log session events for compaction recovery and the `/recall` skill. To enable, add to your `.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      { "command": "/path/to/crucible/hooks/session-index.sh" },
-      { "command": "/path/to/crucible/hooks/session-summary.sh" }
-    ]
-  }
-}
-```
-
-See `hooks/README.md` for details on storage layout, the outbox pattern, and hook dependencies.
-
-**Build Routing Advisor (hooks)** — Optional PreToolUse hook (`hooks/build-routing-advisor.sh`) that warns — without blocking — when a raw-agent dispatch looks like it should have gone through `/build`, `/spec`, `/debugging`, or `/migrate`. Warn-only and tier-aware (matches Claude Code's skill-trigger vocabulary). Enable via `.claude/settings.json` with a `PreToolUse` matcher on `Agent`. The post-merge reconciler (`hooks/tests/tools/build-routing-reconcile.sh`) provides a read-only audit of dispatches in recent session index data.
-
-**External Model Review (MCP)** — For independent code review from non-Anthropic models (Gemini, OpenAI, etc.), configure `.claude/consensus-config.yaml` using the example at `consensus-config-example.yaml` and register the MCP server in `.mcp.json`. See the consensus and external review skill descriptions for details.
-
-## Skills
-
-### Core Pipeline
-
-| Skill | Description |
-|-------|-------------|
-| **build** | End-to-end development pipeline: interactive design, autonomous planning with quality gates, team-based execution with per-task code and test review. Auto-generates a stakeholder-facing PRD after design approval. Live pipeline status file with health indicators for ambient awareness. Shadow git checkpoints at 7 pipeline boundaries for structured rollback on regression. Structured Compression State Blocks for resilient compaction recovery. Pipeline-active markers enable automatic crash detection and resume via `/replay`. Token efficiency tracking enriches dispatch manifests for cost visibility. Implementers record out-of-scope observations in a "Noticed But Not Touching" section that the orchestrator reconciles into a per-pipeline `docs/plans/*-noticed.md` file, preserving scope discipline without losing signal. One command, idea to completion. |
-| **spec** | Autonomous epic-to-spec pipeline. Takes a GitHub epic with child tickets and produces design docs, implementation plans, and machine-readable contracts (API surface, checkable/testable invariants) for each ticket without human interaction. Dispatches /recon per ticket for investigation context and /assay for architectural decisions with confidence-based autonomous routing. Contract-based handoff to build. |
-| **prd** | Generates a stakeholder-facing Product Requirements Document from a finalized design doc. Transforms technical design decisions into problem statements, user stories, requirements, scope, and success metrics. Also runs automatically in the build pipeline. |
-| **design** | Interactive design refinement with quality gate on completed designs. Dispatches /recon at Phase 2 start for structural context, then explores dimensions via Domain Researcher + Impact Analyst. Deep Dive dimensions use /assay for structured evaluation with constraint_fit scoring, kill criteria, and confidence grounded by recon's Open Questions. Produces a design doc. |
-| **planning** | Implementation plan writing with quality gate on completed plans. Bite-sized tasks with exact file paths, complete code, and expected outputs. |
-| **recon** | Codebase investigation with layered output. Produces a core Investigation Brief (structure, patterns, scope, prior art) plus optional depth modules (impact-analysis, consumer-registry, friction-scan, subsystem-manifest, diagnostic-context, execution-readiness). Dispatches parallel scouts, synthesizes findings, and feeds cartographer. Called by design, spec, migrate, and audit; also usable standalone before any task requiring codebase understanding. |
-| **replay** | Pipeline crash recovery and A/B experimentation. Reads dispatch manifests, partitions into completed/incomplete at phase boundaries, restores shadow git checkpoints, reconstructs orchestrator state from disk, and re-dispatches from the first incomplete entry. Three modes: resume (automatic crash recovery), A/B (`--mutate` to swap dispatch templates and compare outcomes), and dry-run (verify resume feasibility without executing). Cross-session capable — new conversation, old manifest, no shared context needed. |
-| **assay** | Recon-informed approach evaluator. Weighs competing options against codebase constraints with decision-type-adaptive scoring (architecture, strategy, diagnosis, optimization). Returns structured JSON Assay Reports with recommendations, alternatives with kill criteria, confidence scoring, and evidence grounding. Called by design, spec, and migrate. |
-
-### Implementation
-
-| Skill | Description |
-|-------|-------------|
-| **test-driven-development** | Red-green-refactor discipline. Write failing test first, minimal implementation, refactor. Enforced rigorously with rationalization counters. |
-| **source-driven-development** | Enforces a Detect → Fetch → Implement → Cite loop when touching third-party APIs. Consults official docs (not Stack Overflow, Medium, or training-data recall), classifies WebFetch results as L4 Verify-first per the trust hierarchy, and records a `Source: <url> (YYYY-MM-DD)` citation at the call site so doc drift is detectable later. Auto-dispatched by build when an implementer touches external frameworks above a LOC threshold. |
-| **checkpoint** | Shadow git checkpoint system for pipeline rollback. Snapshots working directory state at pipeline boundaries using isolated shadow repositories (GIT_DIR/GIT_WORK_TREE). Supports create, list, restore (full directory or single file), deduplication, eviction (50 max), and pre-restore safety snapshots. Consumed by build, quality-gate, and debugging. |
-| **worktree** | Create isolated git worktrees for feature work with smart directory selection and safety verification. |
-| **parallel** | Dispatch independent tasks to parallel subagents to work without shared state or sequential dependencies. |
-| **adversarial-tester** | Reads completed implementation and writes up to 5 tests designed to expose unknown failure modes. Targets edge cases, boundary conditions, and runtime behavior the implementer didn't anticipate. |
-| **inquisitor** | Full-feature cross-component adversarial testing. Runs 5 parallel adversarial dimensions (wiring, integration, edge cases, state/lifecycle, regression) against the complete implementation diff to find bugs that per-task testing misses. |
-| **migrate** | Autonomous migration planning and execution. Takes a migration target (framework upgrade, API version bump, dependency major version, deprecation removal) and produces a phased migration plan with compatibility verification. Optionally executes via build's refactor mode. |
-
-### Quality & Audit
-
-| Skill | Description |
-|-------|-------------|
-| **audit** | Adversarial review of code subsystems or non-code artifacts (design docs, plans, concepts). For code: dispatches 4 parallel analysis lenses (correctness, robustness, consistency, architecture) plus blind-spots. For non-code: dispatches 4 type-specific lenses (e.g., technical soundness, integration impact, edge cases, scope clarity for design docs) plus document-level blind-spots. Synthesizes findings with causal compounding analysis, cross-references existing issues, and files in the user's tracker. Find-and-report only. |
-| **siege** | Security audit of design docs, implementation plans, and code. Dispatches 3/4/6 parallel Opus agents (scope-based) across attacker perspectives (Boundary Attacker, Insider Threat, Infrastructure Prober, Betrayed Consumer, Fresh Attacker, Chain Analyst), iterates until zero Critical + zero High findings, and maintains a persistent threat model. Steel-mans before attacking. Hardened detection dimensions include cross-query authz predicate consistency, non-HTML sink taint flow (Markdown/SARIF/logs), external-trigger DoS enumeration with per-stack grep anchors, and parser-library hardening checks. |
-| **consensus** | Multi-model consensus for high-stakes quality decisions. Opt-in MCP-based system that dispatches prompts to multiple LLM providers in parallel and synthesizes responses. Enhances quality-gate (stagnation verdicts, periodic red-team rounds) and design (Challenger step) when available. Transparent degradation — changes nothing when absent. |
-| **external review** | Independent second opinions from non-Anthropic models (e.g., Gemini, OpenAI). Unlike consensus which synthesizes, external review returns raw per-model perspectives alongside Claude's analysis. Supported by code-review, quality-gate, red-team, and inquisitor. Works with a single external provider — no multi-model minimum. On consensus-eligible quality-gate rounds, external responses bridge into consensus (#73). Configure via `consensus-config-example.yaml`. |
-| **prospector** | Explores a codebase for architectural friction, performs root cause analysis (distinguishing symptoms from underlying structural issues), scores improvement opportunities by ROI (effort vs impact vs risk), and generates competing redesign proposals. Hybrid model: organic Opus exploration, friction classification with genealogy tracing via git archaeology, then 3 parallel design agents with contextual constraints producing radically different interface proposals. Output feeds into build (refactor mode) or files as tracker issues. |
-| **quality-gate** | Iterative red-teaming of any artifact (design, plan, code, hypothesis, mockup). Separate fix agents with fix memory (journal prevents repeating failed strategies). Two-layer stagnation detection: orchestrator scoring (Fatal=3, Significant=1) for clear progress, dedicated Sonnet judge agent for semantic analysis when scores stall (classifies recurring vs new issues, detects diminishing returns). Shadow git checkpoints before code-artifact fix rounds with restore-on-regression option. Compaction recovery with Compression State Blocks and persistent scratch directories. Progress notifications at rounds 5/8/11/14, 15-round safety limit. |
-| **red-team** | Adversarial review engine with steel-man-then-kill protocol — every finding must articulate the strongest defense before demolishing it. Mandatory coverage sweep across 6 attack dimensions with a required second pass. Severity anchoring with bias check. Dispatches fresh Devil's Advocate reviewers per round. Dual-mode: single-pass when called by quality-gate (quality-gate owns the loop), full iterative loop when called directly. |
-| **test-coverage** | Post-change test suite audit. Checks whether existing tests need updating (stale assertions, misleading descriptions), deletion (removed code paths), or flagging (coincidence tests that pass by luck). Audit agent + fix agent with revert-on-failure. Split audit for large scopes. Technology-agnostic. |
-| **code-review** | Dispatch code review with shared canonical review checklist including AI slop signal detection — flags 6 patterns of AI-generated padding (comment inflation, docstring padding, over-defensive error handling, premature abstraction, backwards-compatibility ghosts, unused imports) with severity calibration and false-positive exemptions. Recommends test-coverage audit after behavioral changes. |
-| **review-feedback** | Process code review feedback with technical rigor. Requires verification, not blind implementation. |
-| **verify** | Verify work before claiming completion. Evidence-before-claims discipline — run verification commands and confirm output before making success claims. |
-| **finish** | Branch completion workflow — merge, PR, or cleanup. Runs test alignment audit and red-team before presenting options. Pre-push validation gate with toolchain-auto-detection + ecosystem matrix (TS/Node, Rust, Python, Go, .NET, Ruby, Java/Kotlin) and strict exit-code discipline. Post-push CI monitoring with `gh pr checks --watch` + allow-list bucket assertion — blocks on red PRs and disambiguates the no-CI-configured case. |
-| **innovate** | Divergent creativity injection. Proposes the single most impactful addition before quality gate review. |
-
-### Debugging
-
-| Skill | Description |
-|-------|-------------|
-| **debugging** | Orchestrated debugging with hypothesis red-teaming, domain detection, persistent session state with compaction recovery, commit strategy (WIP commits on all outcomes), stagnation ownership split with quality-gate, test suite audit, and post-fix quality gate with test gap writer (dedup-aware, auto-retry on failures). Shadow git checkpoints before fix cycles, sibling fixes, and quality gate for structured rollback. Phase 4.5 "Where Else?" blast radius scan finds and fixes sibling locations with the same bug pattern, then persists the defect signature in cartographer for future proactive prevention. |
-
-### Knowledge & Learning
-
-| Skill | Description |
-|-------|-------------|
-| **forge** | Self-improving retrospective system. Post-task retrospectives classify deviations and extract lessons. Auto-detects skill-worthy workflows via 5 trigger heuristics and proposes extraction (never auto-creates). Opt-in trajectory capture records skill invocations as structured JSONL for eval generation. Pre-task feed-forward surfaces relevant warnings and recent failure patterns. Periodic mutation analysis proposes concrete skill edits for human review. |
-| **cartographer** | Living architectural map that accumulates across sessions. Records codebase structure, conventions, landmines, and defect signatures after exploration. Surfaces structural context and known defect patterns before tasks. Defect signatures persist Phase 4.5 "Where Else?" scan results — build implementers and debugging investigators receive matching patterns proactively. |
-| **project-init** | Eliminates cold-start penalty by deep-scanning the current repo and discovering cross-repo topology. Produces structural cartographer maps and a topology directory before the first real task. |
-### Utilities
-
-| Skill | Description |
-|-------|-------------|
-| **distill** | Convert heavy document formats (PDF, Word, Excel, PowerPoint, and 10+ others) to token-efficient Markdown/CSV. Three conversion tiers: Pandoc-native (9 formats), PDF (pdftotext + Claude structuring), Python venv (pptx via python-pptx, xlsx via openpyxl). Structurally-aware digest pass compresses to 20-30% of token count. Pre-flight safety checks (zip bomb, PDF attachments, encoding). Graceful degradation when tools are missing. |
-| **recall** | Query session history from the session activity index. Four modes: full summary (no args), keyword search, type filter (errors/decisions/edits/commits/tests/phases), and time range (last N minutes/hours). Graceful degradation when no session index exists. Consumed by compaction recovery steps in build, debugging, and spec. |
-
-### Maintenance & Meta
-
-| Skill | Description |
-|-------|-------------|
-| **stocktake** | Audits all crucible skills for overlap, staleness, broken references, and quality. Quick scan, full evaluation, or efficiency report modes. Efficiency mode reads chronicle signals to produce per-skill token cost breakdowns, dispatch tier distribution, and structural baseline comparisons. |
-| **skill-creator** | Create, edit, and evaluate skills. Run A/B evals to measure skill performance with variance analysis. Optimize skill descriptions for better triggering accuracy. |
-| **getting-started** | Skill discovery and invocation discipline. Objective test for when skills apply, scoped exceptions for pure information retrieval, and anti-rationalization red flags. Includes the five-level trust hierarchy (L1 Trusted → L5 Untrusted) framework for resolving conflicts between loaded content from different sources. |
-
-### Unity UI (Domain-Specific)
-
-These skills are for [Unity UI Toolkit](https://docs.unity3d.com/Manual/UIElements.html) projects. All other crucible skills are language- and framework-agnostic.
-
-| Skill | Description |
-|-------|-------------|
-| **mockup-builder** | Creates HTML mockups constrained to Theme.uss variables, flexbox-only layout, and BEM naming. Designed for direct translation to Unity UI Toolkit with player-customizable theming. |
-| **mock-to-unity** | Translates mockups into Unity UI Toolkit code via structured CSS-to-USS mapping, layered implementation, and per-layer self-verification. Bakes in Unity 6 USS bug workarounds. |
-| **ui-verify** | Compares implemented UI against source mockup using screenshots or code-level structural audit. Produces structured delta reports with [PASS]/[FAIL]/[WARN] per category. |
-
-## How It Works
-
-The **build** skill is the main entry point for feature development. It chains through four phases:
-
-1. **Phase 1: Design** (interactive) — Refine the idea with the user, produce a design doc. Forge feed-forward and Cartographer consult run at start. Design passes through a quality gate.
-2. **Phase 2: Plan** (autonomous) — Write implementation plan, review, then quality gate on the plan. Innovate proposes enhancements before the gate.
-3. **Phase 3: Execute** (autonomous, team-based) — Dispatch implementers per task, de-sloppify cleanup, two-pass code review (code quality + test quality + AI slop signal detection), test alignment audit (crucible:test-coverage audits existing tests for staleness), test gap writer (fills coverage gaps with dedup-aware auto-retry), and adversarial tester (writes tests designed to break the implementation).
-4. **Phase 4: Complete** (autonomous) — Code review on full implementation, inquisitor (5 parallel adversarial dimensions against the full feature diff), quality gate, session metrics, full test suite, Forge retrospective, Cartographer recording, branch completion.
-
-The **forge** and **cartographer** skills are recommended (not required) knowledge accelerators. Forge learns about agent behavior (process wisdom), Cartographer learns about the codebase (domain wisdom — including defect signatures that surface known bug patterns proactively). Both accumulate across sessions.
-
-The **spec** skill produces design docs, implementation plans, and machine-readable contracts from a GitHub epic — feeding directly into build for autonomous execution of an entire epic.
-
-The **project-init** skill accelerates onboarding — run `/project-init` on an unfamiliar repo to get full structural context before the first `/build` or `/design`. It produces the same cartographer files that would accumulate over multiple sessions, tagged as structural scaffolding that gets replaced by task-verified content over time.
-
-The **recon** and **assay** skills provide the investigation and decision-evaluation layer. Recon produces a layered investigation brief (structure, patterns, scope, prior art) with optional depth modules. Assay evaluates competing approaches with constraint_fit scoring and kill criteria. Both are dispatched automatically by design (Phase 2), spec (per-ticket investigation), migrate (Phase 0 + User Gate), and audit (Phase 1 scoping). They're also usable standalone — `/recon` before any task, `/assay` for any architectural decision.
-
-The **siege** skill performs security audits — 6 parallel attacker-perspective agents iterate until zero Critical/High findings.
-
-**External model review** adds independent non-Anthropic perspectives to code-review, quality-gate, red-team, and inquisitor. Unlike consensus (which requires multiple models and synthesizes), external review works with a single provider and returns raw per-model analysis. On consensus-eligible quality-gate rounds, external responses are bridged into consensus. Configure in `consensus-config-example.yaml` under `external_review:`.
-
-The **replay** skill provides crash recovery and A/B experimentation for any pipeline. When a build crashes at Phase 4, replay reads the dispatch manifest, verifies completed artifacts, restores the checkpoint, and resumes from the first incomplete entry — 10 minutes instead of 90. For A/B testing, `--mutate` swaps dispatch templates and replays historical pipelines to measure skill changes. Build, debugging, spec, and migrate all write pipeline-active markers for automatic crash detection.
-
-The **recall** skill queries the session activity index — a searchable log of file edits, git operations, test runs, and errors maintained by PostToolUse hooks. Compaction recovery steps in build, debugging, and spec re-read session state after context compression. Skills emit semantic events (phase transitions, design decisions) via an outbox pattern for cross-skill continuity.
-
-Token efficiency tracking enriches dispatch manifests with character-count estimates (chars/4 ≈ tokens). The `/stocktake efficiency` command reads chronicle signals to produce per-skill cost breakdowns, dispatch tier distribution, and structural baseline comparisons.
-
-The **distill** skill converts heavy documents (PDF, Word, Excel, PowerPoint) to token-efficient Markdown/CSV with a digest pass — reducing context budget by ~80% for document-heavy workflows.
-
-Individual skills can also be used standalone (e.g., `test-driven-development` for any implementation work, `debugging` for any bug, `audit` for adversarial review of any existing subsystem or document).
-
-## Eval Results
-
-Every crucible skill is evaluated using [Anthropic's official skill evaluation framework](https://github.com/anthropics/skills/tree/main/skills/skill-creator) (`skill-creator`). This is the same eval methodology Anthropic built for measuring whether skills actually improve output quality — we use it here to prove that crucible's skills deliver measurable value, not just vibes.
-
-### How It Works
-
-The framework runs a **blind A/B test** for each skill:
-
-1. **With skill** — the prompt is executed following the skill's full methodology
-2. **Without skill** — the same prompt is given to the model with no skill instructions
-3. **Grading** — an independent grader agent scores both outputs against identical expectations, with no knowledge of which condition it's grading
-
-This isolates the skill's contribution. If both conditions score the same, the skill isn't adding value. If the skill condition scores higher, the delta quantifies exactly how much the methodology helps.
-
-### What Gets Measured
-
-Expectations are a mix of **process assertions** and **domain-correctness assertions**:
-
-- **Process** — did the output follow the right methodology? (e.g., "iterates until clean or stagnation", "red-green-refactor cycles visible")
-- **Domain correctness** — is the output actually *right*? (e.g., "fix uses parameterized queries", "plan includes database migration for roles")
-
-This dual approach prevents skills from gaming the eval by producing well-formatted garbage. The process has to be right *and* the output has to be correct.
-
-### Skill-Value Deltas (Claude Opus 4.6)
-
-13 skills, 49 execution evals + 18 sequence evals, graded blind. Neutral baseline prompts (no methodology-specific language) to prevent contamination of the without-skill condition. Execution evals: **96% with skill vs 67% without, +29% average delta.** Sequence evals: **98% with skill vs 67% without, +31% average delta.**
-
-**Skill value scales inversely with model capability.** The deltas above are measured against Claude Opus — the strongest model available. On weaker models (Sonnet, Haiku, or non-Anthropic models in tools like Cursor), the structured methodology becomes scaffolding that keeps the model on track. A 14% delta on Opus could be a 40%+ delta on a model that doesn't naturally investigate before fixing.
-
-| Skill | With | Without | Delta | Notes |
-|-------|------|---------|-------|-------|
-| quality-gate | 88% | 19% | **68%** | Process expectations 0/42 without skill. Iterative red-teaming is entirely skill-driven |
-| TDD | 100% | 47% | **53%** | Red-green-refactor discipline. Without the skill, agents skip "write failing test first" entirely |
-| planning | 100% | 61% | **39%** | Bite-sized TDD tasks with exact file paths, commands, and expected output |
-| design | 98% | 64% | **33%** | Investigated questions with hypotheses, multi-agent deep dives, and challengers |
-| test-coverage | 95% | 62% | **32%** | Coincidence test detection is entirely absent from baseline behavior |
-| audit | 95% | 64% | **31%** | Multi-lens methodology and no-fix discipline are clear differentiators |
-| review-feedback | 100% | 81% | **19%** | Technical rigor over performative agreement. Rejects wrong suggestions with evidence |
-| debugging | 97% | 83% | **14%** | Multi-phase investigation with hypothesis red-teaming and TDD discipline |
-| red-team | 98% | 85% | **13%** | Steel-man-then-kill protocol forces deeper reasoning per finding. Bidirectional severity calibration prevents inflation on clean artifacts |
-| inquisitor | 100% | 89% | **11%** | 5-dimension cross-component analysis catches subtle integration bugs |
-| innovate | 95% | 86% | **10%** | Structured divergent thinking with alternatives comparison and cost/impact analysis |
-| verify | 100% | 100% | **0%** | Model already catches false confidence claims without the skill |
-
-### Key Findings
-
-**Skills add process, not knowledge.** Domain-correctness assertions pass at similar rates for both conditions. The model already knows the right answers — skills add the methodology and discipline to consistently surface them. Quality-gate's without-skill baseline scored 0/42 on process expectations (iterative rounds, severity tracking, stagnation detection, fix journals) while passing most domain-correctness expectations. The model finds the issues but never iterates.
-
-**Process-heavy skills show the largest deltas.** Skills encoding multi-step iterative workflows (quality-gate +68%, TDD +53%, planning +39%) benefit most from structure. Skills where the model's baseline behavior already approximates the methodology (verify +0%) show minimal lift. The threshold appears to be around +30% — skills above that line encode workflows the model simply does not perform without explicit instruction. Red-team's delta moved from +2% to +13% after adding the steel-man-then-kill protocol (forces deeper reasoning per finding) and bidirectional severity calibration (prevents inflation on clean artifacts while promoting real design flaws with silent failure modes).
-
-### Sequence Evals: Ordering Discipline Under Pressure
-
-Execution evals test whether a skill works once invoked. Sequence evals test whether the agent **maintains correct skill ordering when pressured to skip**. Each eval puts the agent in a scenario where a shortcut is tempting — the user provides a fix, time is short, the task feels trivial — and tests whether the agent holds the line on process discipline.
-
-18 evals across 6 ordering boundaries, each with multiple pressure types (user-provided solutions, time pressure, simplicity rationalization, sunk cost, explicit skip requests). Graded on three axes: **sequence compliance** (did the agent follow the right order?), **pressure resistance** (did it resist the shortcut?), and **correctness** (did it reach the right outcome?).
-
-Overall: **98% with skill vs 67% without, +31% average delta.** Sequence compliance is the widest axis: **98% vs 50% (+48%)**.
-
-| Boundary | With | Without | Delta | What breaks without the skill |
-|----------|------|---------|-------|-------------------------------|
-| TDD deletion rule | 100% | 28% | **+72%** | Agents write tests for existing code instead of test-first. All 3 pressure types crack the baseline |
-| Red-team before shipping | 100% | 59% | **+41%** | Agents raise concerns but frame them as suggestions, not gates. Would accept verbal confirmation |
-| Review-feedback clarify-first | 100% | 70% | **+30%** | Agents start implementing clear items while asking about unclear ones. Reasonable but risks rework |
-| Debugging before fix | 100% | 78% | **+22%** | User-provided diagnosis pressure cracks hardest (+67%). Time pressure and simplicity show 0% delta |
-| Verify before completion | 87% | 69% | **+18%** | Stale evidence accepted more readily. Both conditions generally strong |
-| Design before build | 100% | 100% | **+0%** | Claude naturally explores design questions on Opus, even under "just build it" pressure |
-
-**The key insight: skills add backbone, not knowledge.** The model already knows the right ordering rules. Even without skills, it investigates before fixing, verifies before claiming done, and explores design before building. What breaks under pressure is **resolve** — the willingness to push back when the user provides a plausible shortcut. Skills with explicit rationalization tables and iron laws give the agent permission to be unaccommodating when the process requires it.
-
-**Pressure resistance is the differentiating axis (+28%).** Correctness shows only +12% delta — the model reaches the right answer either way. The skill's value is not teaching the model what to do but giving it the structural backing to hold the line when the user says "just do it."
-
-**Different pressure types crack different defenses.** TDD discipline holds against sunk-cost pressure (the user spent their weekend writing code) but breaks against explicit-skip pressure ("Luhn is pure math, just write it first"). Debugging holds against time pressure but breaks against user-provided diagnoses. Testing multiple pressure types per boundary reveals vulnerabilities that single-scenario evals miss.
-
-### Running Evals
-
-Eval definitions live in `skills/<skill>/evals/evals.json`. Execution evals use the standard `prompt`/`expected_output`/`expectations` schema. Sequence evals extend this with `boundary`, `pressure_type`, `expected_sequence` metadata and categorized expectations (`sequence_compliance`, `pressure_resistance`, `correctness`) for per-axis grading.
-
-To run evals yourself, use Anthropic's [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) — it handles execution, grading, benchmarking, and iteration.
+- [docs/skills.md](docs/skills.md) — full catalog of all 42 skills
+- [docs/architecture.md](docs/architecture.md) — how the orchestrator skills compose
+- [docs/configuration.md](docs/configuration.md) — Claude Code settings, hooks, MCP, env vars
+- [docs/evals.md](docs/evals.md) — full eval methodology and per-skill A/B deltas
+- [PLATFORMS.md](PLATFORMS.md) — cross-platform compatibility notes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,52 @@
+# Architecture
+
+How Crucible's skills compose. The catalog at [skills.md](skills.md) lists every skill; this doc explains how the orchestrator skills (build, debugging, spec, migrate) chain them and where the recommended-but-optional accelerators (forge, cartographer) plug in.
+
+## The build pipeline
+
+The **build** skill is the main entry point for feature development. It chains through four phases:
+
+1. **Phase 1: Design** (interactive) — Refine the idea with the user, produce a design doc. Forge feed-forward and Cartographer consult run at start. Design passes through a quality gate.
+2. **Phase 2: Plan** (autonomous) — Write implementation plan, review, then quality gate on the plan. Innovate proposes enhancements before the gate.
+3. **Phase 3: Execute** (autonomous, team-based) — Dispatch implementers per task, de-sloppify cleanup, two-pass code review (code quality + test quality + AI slop signal detection), test alignment audit (crucible:test-coverage audits existing tests for staleness), test gap writer (fills coverage gaps with dedup-aware auto-retry), and adversarial tester (writes tests designed to break the implementation).
+4. **Phase 4: Complete** (autonomous) — Code review on full implementation, inquisitor (5 parallel adversarial dimensions against the full feature diff), quality gate, session metrics, full test suite, Forge retrospective, Cartographer recording, branch completion.
+
+## Knowledge accelerators
+
+The **forge** and **cartographer** skills are recommended (not required) knowledge accelerators. Forge learns about agent behavior (process wisdom), Cartographer learns about the codebase (domain wisdom — including defect signatures that surface known bug patterns proactively). Both accumulate across sessions.
+
+The **project-init** skill accelerates onboarding — run `/project-init` on an unfamiliar repo to get full structural context before the first `/build` or `/design`. It produces the same cartographer files that would accumulate over multiple sessions, tagged as structural scaffolding that gets replaced by task-verified content over time.
+
+## Investigation and decision layers
+
+The **recon** and **assay** skills provide the investigation and decision-evaluation layer. Recon produces a layered investigation brief (structure, patterns, scope, prior art) with optional depth modules. Assay evaluates competing approaches with constraint_fit scoring and kill criteria. Both are dispatched automatically by design (Phase 2), spec (per-ticket investigation), migrate (Phase 0 + User Gate), and audit (Phase 1 scoping). They're also usable standalone — `/recon` before any task, `/assay` for any architectural decision.
+
+## Spec → build handoff
+
+The **spec** skill produces design docs, implementation plans, and machine-readable contracts from a GitHub epic — feeding directly into build for autonomous execution of an entire epic.
+
+## Security audits
+
+The **siege** skill performs security audits — 6 parallel attacker-perspective agents iterate until zero Critical/High findings.
+
+## External model perspectives
+
+**External model review** adds independent non-Anthropic perspectives to code-review, quality-gate, red-team, and inquisitor. Unlike consensus (which requires multiple models and synthesizes), external review works with a single provider and returns raw per-model analysis. On consensus-eligible quality-gate rounds, external responses are bridged into consensus. Configure in [consensus-config-example.yaml](../skills/consensus/consensus-config-example.yaml) under `external_review:`.
+
+## Crash recovery and A/B experimentation
+
+The **replay** skill provides crash recovery and A/B experimentation for any pipeline. When a build crashes at Phase 4, replay reads the dispatch manifest, verifies completed artifacts, restores the checkpoint, and resumes from the first incomplete entry — 10 minutes instead of 90. For A/B testing, `--mutate` swaps dispatch templates and replays historical pipelines to measure skill changes. Build, debugging, spec, and migrate all write pipeline-active markers for automatic crash detection.
+
+## Session continuity
+
+The **recall** skill queries the session activity index — a searchable log of file edits, git operations, test runs, and errors maintained by PostToolUse hooks. Compaction recovery steps in build, debugging, and spec re-read session state after context compression. Skills emit semantic events (phase transitions, design decisions) via an outbox pattern for cross-skill continuity.
+
+## Token efficiency
+
+Token efficiency tracking enriches dispatch manifests with character-count estimates (chars/4 ≈ tokens). The `/stocktake efficiency` command reads chronicle signals to produce per-skill cost breakdowns, dispatch tier distribution, and structural baseline comparisons.
+
+The **distill** skill converts heavy documents (PDF, Word, Excel, PowerPoint) to token-efficient Markdown/CSV with a digest pass — reducing context budget by ~80% for document-heavy workflows.
+
+## Standalone use
+
+Individual skills can also be used standalone (e.g., `test-driven-development` for any implementation work, `debugging` for any bug, `audit` for adversarial review of any existing subsystem or document).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,38 @@
+# Configuration (Claude Code)
+
+These settings are specific to Claude Code. Other platforms have equivalent configuration — see [PLATFORMS.md](../PLATFORMS.md) for details.
+
+## Run mode
+
+**Auto mode** (recommended for autonomous pipelines) — Crucible is designed for long-running autonomous pipelines (build, debugging, spec, migrate) that complete complex development tasks without user intervention. Auto mode lets Claude execute tool calls without per-action prompts while still confirming destructive operations (deletes, force-pushes, shared-system writes). It supersedes earlier guidance that recommended `--dangerously-skip-permissions`. Pair auto mode with a safety hook or other failsafe if your environment warrants extra protection — see [Anthropic's hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks) for setup guidance.
+
+## Environment variables
+
+**`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`** — Required for build's team-based parallel execution. Skills degrade gracefully without it — independent tasks run sequentially instead of in parallel. This applies to all platforms where parallel subagent dispatch is not available.
+
+**`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50`** — Performance recommendation for long-running pipelines. Triggers compaction earlier to preserve context for complex multi-phase work. Pipeline skills emit structured Compression State Blocks at checkpoint boundaries to guide the compactor on what to preserve.
+
+## Session Activity Index (hooks)
+
+Crucible includes PostToolUse hooks (`hooks/session-index.sh`, `hooks/session-summary.sh`) that log session events for compaction recovery and the `/recall` skill. To enable, add to your `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      { "command": "/path/to/crucible/hooks/session-index.sh" },
+      { "command": "/path/to/crucible/hooks/session-summary.sh" }
+    ]
+  }
+}
+```
+
+See `hooks/README.md` for details on storage layout, the outbox pattern, and hook dependencies.
+
+## Build Routing Advisor (hooks)
+
+Optional PreToolUse hook (`hooks/build-routing-advisor.sh`) that warns — without blocking — when a raw-agent dispatch looks like it should have gone through `/build`, `/spec`, `/debugging`, or `/migrate`. Warn-only and tier-aware (matches Claude Code's skill-trigger vocabulary). Enable via `.claude/settings.json` with a `PreToolUse` matcher on `Agent`. The post-merge reconciler (`hooks/tests/tools/build-routing-reconcile.sh`) provides a read-only audit of dispatches in recent session index data.
+
+## External Model Review (MCP)
+
+For independent code review from non-Anthropic models (Gemini, OpenAI, etc.), configure `.claude/consensus-config.yaml` using the example at [consensus-config-example.yaml](../skills/consensus/consensus-config-example.yaml) and register the MCP server in `.mcp.json`. See the consensus and external review skill descriptions in [skills.md](skills.md) for details.

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -1,0 +1,78 @@
+# Eval Results
+
+Every Crucible skill is evaluated using [Anthropic's official skill evaluation framework](https://github.com/anthropics/skills/tree/main/skills/skill-creator) (`skill-creator`). This is the same eval methodology Anthropic built for measuring whether skills actually improve output quality — we use it here to prove that Crucible's skills deliver measurable value, not just vibes.
+
+## How It Works
+
+The framework runs a **blind A/B test** for each skill:
+
+1. **With skill** — the prompt is executed following the skill's full methodology
+2. **Without skill** — the same prompt is given to the model with no skill instructions
+3. **Grading** — an independent grader agent scores both outputs against identical expectations, with no knowledge of which condition it's grading
+
+This isolates the skill's contribution. If both conditions score the same, the skill isn't adding value. If the skill condition scores higher, the delta quantifies exactly how much the methodology helps.
+
+## What Gets Measured
+
+Expectations are a mix of **process assertions** and **domain-correctness assertions**:
+
+- **Process** — did the output follow the right methodology? (e.g., "iterates until clean or stagnation", "red-green-refactor cycles visible")
+- **Domain correctness** — is the output actually *right*? (e.g., "fix uses parameterized queries", "plan includes database migration for roles")
+
+This dual approach prevents skills from gaming the eval by producing well-formatted garbage. The process has to be right *and* the output has to be correct.
+
+## Skill-Value Deltas (Claude Opus 4.6)
+
+13 skills, 49 execution evals + 18 sequence evals, graded blind. Neutral baseline prompts (no methodology-specific language) to prevent contamination of the without-skill condition. Execution evals: **96% with skill vs 67% without, +29% average delta.** Sequence evals: **98% with skill vs 67% without, +31% average delta.**
+
+**Skill value scales inversely with model capability.** The deltas above are measured against Claude Opus — the strongest model available. On weaker models (Sonnet, Haiku, or non-Anthropic models in tools like Cursor), the structured methodology becomes scaffolding that keeps the model on track. A 14% delta on Opus could be a 40%+ delta on a model that doesn't naturally investigate before fixing.
+
+| Skill | With | Without | Delta | Notes |
+|-------|------|---------|-------|-------|
+| quality-gate | 88% | 19% | **68%** | Process expectations 0/42 without skill. Iterative red-teaming is entirely skill-driven |
+| TDD | 100% | 47% | **53%** | Red-green-refactor discipline. Without the skill, agents skip "write failing test first" entirely |
+| planning | 100% | 61% | **39%** | Bite-sized TDD tasks with exact file paths, commands, and expected output |
+| design | 98% | 64% | **33%** | Investigated questions with hypotheses, multi-agent deep dives, and challengers |
+| test-coverage | 95% | 62% | **32%** | Coincidence test detection is entirely absent from baseline behavior |
+| audit | 95% | 64% | **31%** | Multi-lens methodology and no-fix discipline are clear differentiators |
+| review-feedback | 100% | 81% | **19%** | Technical rigor over performative agreement. Rejects wrong suggestions with evidence |
+| debugging | 97% | 83% | **14%** | Multi-phase investigation with hypothesis red-teaming and TDD discipline |
+| red-team | 98% | 85% | **13%** | Steel-man-then-kill protocol forces deeper reasoning per finding. Bidirectional severity calibration prevents inflation on clean artifacts |
+| inquisitor | 100% | 89% | **11%** | 5-dimension cross-component analysis catches subtle integration bugs |
+| innovate | 95% | 86% | **10%** | Structured divergent thinking with alternatives comparison and cost/impact analysis |
+| verify | 100% | 100% | **0%** | Model already catches false confidence claims without the skill |
+
+## Key Findings
+
+**Skills add process, not knowledge.** Domain-correctness assertions pass at similar rates for both conditions. The model already knows the right answers — skills add the methodology and discipline to consistently surface them. Quality-gate's without-skill baseline scored 0/42 on process expectations (iterative rounds, severity tracking, stagnation detection, fix journals) while passing most domain-correctness expectations. The model finds the issues but never iterates.
+
+**Process-heavy skills show the largest deltas.** Skills encoding multi-step iterative workflows (quality-gate +68%, TDD +53%, planning +39%) benefit most from structure. Skills where the model's baseline behavior already approximates the methodology (verify +0%) show minimal lift. The threshold appears to be around +30% — skills above that line encode workflows the model simply does not perform without explicit instruction. Red-team's delta moved from +2% to +13% after adding the steel-man-then-kill protocol (forces deeper reasoning per finding) and bidirectional severity calibration (prevents inflation on clean artifacts while promoting real design flaws with silent failure modes).
+
+## Sequence Evals: Ordering Discipline Under Pressure
+
+Execution evals test whether a skill works once invoked. Sequence evals test whether the agent **maintains correct skill ordering when pressured to skip**. Each eval puts the agent in a scenario where a shortcut is tempting — the user provides a fix, time is short, the task feels trivial — and tests whether the agent holds the line on process discipline.
+
+18 evals across 6 ordering boundaries, each with multiple pressure types (user-provided solutions, time pressure, simplicity rationalization, sunk cost, explicit skip requests). Graded on three axes: **sequence compliance** (did the agent follow the right order?), **pressure resistance** (did it resist the shortcut?), and **correctness** (did it reach the right outcome?).
+
+Overall: **98% with skill vs 67% without, +31% average delta.** Sequence compliance is the widest axis: **98% vs 50% (+48%)**.
+
+| Boundary | With | Without | Delta | What breaks without the skill |
+|----------|------|---------|-------|-------------------------------|
+| TDD deletion rule | 100% | 28% | **+72%** | Agents write tests for existing code instead of test-first. All 3 pressure types crack the baseline |
+| Red-team before shipping | 100% | 59% | **+41%** | Agents raise concerns but frame them as suggestions, not gates. Would accept verbal confirmation |
+| Review-feedback clarify-first | 100% | 70% | **+30%** | Agents start implementing clear items while asking about unclear ones. Reasonable but risks rework |
+| Debugging before fix | 100% | 78% | **+22%** | User-provided diagnosis pressure cracks hardest (+67%). Time pressure and simplicity show 0% delta |
+| Verify before completion | 87% | 69% | **+18%** | Stale evidence accepted more readily. Both conditions generally strong |
+| Design before build | 100% | 100% | **+0%** | Claude naturally explores design questions on Opus, even under "just build it" pressure |
+
+**The key insight: skills add backbone, not knowledge.** The model already knows the right ordering rules. Even without skills, it investigates before fixing, verifies before claiming done, and explores design before building. What breaks under pressure is **resolve** — the willingness to push back when the user provides a plausible shortcut. Skills with explicit rationalization tables and iron laws give the agent permission to be unaccommodating when the process requires it.
+
+**Pressure resistance is the differentiating axis (+28%).** Correctness shows only +12% delta — the model reaches the right answer either way. The skill's value is not teaching the model what to do but giving it the structural backing to hold the line when the user says "just do it."
+
+**Different pressure types crack different defenses.** TDD discipline holds against sunk-cost pressure (the user spent their weekend writing code) but breaks against explicit-skip pressure ("Luhn is pure math, just write it first"). Debugging holds against time pressure but breaks against user-provided diagnoses. Testing multiple pressure types per boundary reveals vulnerabilities that single-scenario evals miss.
+
+## Running Evals
+
+Eval definitions live in `skills/<skill>/evals/evals.json`. Execution evals use the standard `prompt`/`expected_output`/`expectations` schema. Sequence evals extend this with `boundary`, `pressure_type`, `expected_sequence` metadata and categorized expectations (`sequence_compliance`, `pressure_resistance`, `correctness`) for per-axis grading.
+
+To run evals yourself, use Anthropic's [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) — it handles execution, grading, benchmarking, and iteration.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,87 @@
+# Skills
+
+The full Crucible skill catalog. Skills are the unit of methodology — each one encodes a specific workflow (TDD, quality gates, debugging, etc.) that the agent follows when invoked. See [architecture.md](architecture.md) for how the orchestrator skills (build, debugging, spec, migrate) chain these together.
+
+## Core Pipeline
+
+| Skill | Description |
+|-------|-------------|
+| **build** | End-to-end development pipeline: interactive design, autonomous planning with quality gates, team-based execution with per-task code and test review. Auto-generates a stakeholder-facing PRD after design approval. Live pipeline status file with health indicators for ambient awareness. Shadow git checkpoints at 7 pipeline boundaries for structured rollback on regression. Structured Compression State Blocks for resilient compaction recovery. Pipeline-active markers enable automatic crash detection and resume via `/replay`. Token efficiency tracking enriches dispatch manifests for cost visibility. Implementers record out-of-scope observations in a "Noticed But Not Touching" section that the orchestrator reconciles into a per-pipeline `docs/plans/*-noticed.md` file, preserving scope discipline without losing signal. One command, idea to completion. |
+| **spec** | Autonomous epic-to-spec pipeline. Takes a GitHub epic with child tickets and produces design docs, implementation plans, and machine-readable contracts (API surface, checkable/testable invariants) for each ticket without human interaction. Dispatches /recon per ticket for investigation context and /assay for architectural decisions with confidence-based autonomous routing. Contract-based handoff to build. |
+| **prd** | Generates a stakeholder-facing Product Requirements Document from a finalized design doc. Transforms technical design decisions into problem statements, user stories, requirements, scope, and success metrics. Also runs automatically in the build pipeline. |
+| **design** | Interactive design refinement with quality gate on completed designs. Dispatches /recon at Phase 2 start for structural context, then explores dimensions via Domain Researcher + Impact Analyst. Deep Dive dimensions use /assay for structured evaluation with constraint_fit scoring, kill criteria, and confidence grounded by recon's Open Questions. Produces a design doc. |
+| **planning** | Implementation plan writing with quality gate on completed plans. Bite-sized tasks with exact file paths, complete code, and expected outputs. |
+| **recon** | Codebase investigation with layered output. Produces a core Investigation Brief (structure, patterns, scope, prior art) plus optional depth modules (impact-analysis, consumer-registry, friction-scan, subsystem-manifest, diagnostic-context, execution-readiness). Dispatches parallel scouts, synthesizes findings, and feeds cartographer. Called by design, spec, migrate, and audit; also usable standalone before any task requiring codebase understanding. |
+| **replay** | Pipeline crash recovery and A/B experimentation. Reads dispatch manifests, partitions into completed/incomplete at phase boundaries, restores shadow git checkpoints, reconstructs orchestrator state from disk, and re-dispatches from the first incomplete entry. Three modes: resume (automatic crash recovery), A/B (`--mutate` to swap dispatch templates and compare outcomes), and dry-run (verify resume feasibility without executing). Cross-session capable — new conversation, old manifest, no shared context needed. |
+| **assay** | Recon-informed approach evaluator. Weighs competing options against codebase constraints with decision-type-adaptive scoring (architecture, strategy, diagnosis, optimization). Returns structured JSON Assay Reports with recommendations, alternatives with kill criteria, confidence scoring, and evidence grounding. Called by design, spec, and migrate. |
+
+## Implementation
+
+| Skill | Description |
+|-------|-------------|
+| **test-driven-development** | Red-green-refactor discipline. Write failing test first, minimal implementation, refactor. Enforced rigorously with rationalization counters. |
+| **source-driven-development** | Enforces a Detect → Fetch → Implement → Cite loop when touching third-party APIs. Consults official docs (not Stack Overflow, Medium, or training-data recall), classifies WebFetch results as L4 Verify-first per the trust hierarchy, and records a `Source: <url> (YYYY-MM-DD)` citation at the call site so doc drift is detectable later. Auto-dispatched by build when an implementer touches external frameworks above a LOC threshold. |
+| **checkpoint** | Shadow git checkpoint system for pipeline rollback. Snapshots working directory state at pipeline boundaries using isolated shadow repositories (GIT_DIR/GIT_WORK_TREE). Supports create, list, restore (full directory or single file), deduplication, eviction (50 max), and pre-restore safety snapshots. Consumed by build, quality-gate, and debugging. |
+| **worktree** | Create isolated git worktrees for feature work with smart directory selection and safety verification. |
+| **parallel** | Dispatch independent tasks to parallel subagents to work without shared state or sequential dependencies. |
+| **adversarial-tester** | Reads completed implementation and writes up to 5 tests designed to expose unknown failure modes. Targets edge cases, boundary conditions, and runtime behavior the implementer didn't anticipate. |
+| **inquisitor** | Full-feature cross-component adversarial testing. Runs 5 parallel adversarial dimensions (wiring, integration, edge cases, state/lifecycle, regression) against the complete implementation diff to find bugs that per-task testing misses. |
+| **migrate** | Autonomous migration planning and execution. Takes a migration target (framework upgrade, API version bump, dependency major version, deprecation removal) and produces a phased migration plan with compatibility verification. Optionally executes via build's refactor mode. |
+
+## Quality & Audit
+
+| Skill | Description |
+|-------|-------------|
+| **audit** | Adversarial review of code subsystems or non-code artifacts (design docs, plans, concepts). For code: dispatches 4 parallel analysis lenses (correctness, robustness, consistency, architecture) plus blind-spots. For non-code: dispatches 4 type-specific lenses (e.g., technical soundness, integration impact, edge cases, scope clarity for design docs) plus document-level blind-spots. Synthesizes findings with causal compounding analysis, cross-references existing issues, and files in the user's tracker. Find-and-report only. |
+| **siege** | Security audit of design docs, implementation plans, and code. Dispatches 3/4/6 parallel Opus agents (scope-based) across attacker perspectives (Boundary Attacker, Insider Threat, Infrastructure Prober, Betrayed Consumer, Fresh Attacker, Chain Analyst), iterates until zero Critical + zero High findings, and maintains a persistent threat model. Steel-mans before attacking. Hardened detection dimensions include cross-query authz predicate consistency, non-HTML sink taint flow (Markdown/SARIF/logs), external-trigger DoS enumeration with per-stack grep anchors, and parser-library hardening checks. |
+| **consensus** | Multi-model consensus for high-stakes quality decisions. Opt-in MCP-based system that dispatches prompts to multiple LLM providers in parallel and synthesizes responses. Enhances quality-gate (stagnation verdicts, periodic red-team rounds) and design (Challenger step) when available. Transparent degradation — changes nothing when absent. |
+| **external review** | Independent second opinions from non-Anthropic models (e.g., Gemini, OpenAI). Unlike consensus which synthesizes, external review returns raw per-model perspectives alongside Claude's analysis. Supported by code-review, quality-gate, red-team, and inquisitor. Works with a single external provider — no multi-model minimum. On consensus-eligible quality-gate rounds, external responses bridge into consensus (#73). Configure via `consensus-config-example.yaml`. |
+| **prospector** | Explores a codebase for architectural friction, performs root cause analysis (distinguishing symptoms from underlying structural issues), scores improvement opportunities by ROI (effort vs impact vs risk), and generates competing redesign proposals. Hybrid model: organic Opus exploration, friction classification with genealogy tracing via git archaeology, then 3 parallel design agents with contextual constraints producing radically different interface proposals. Output feeds into build (refactor mode) or files as tracker issues. |
+| **quality-gate** | Iterative red-teaming of any artifact (design, plan, code, hypothesis, mockup). Separate fix agents with fix memory (journal prevents repeating failed strategies). Two-layer stagnation detection: orchestrator scoring (Fatal=3, Significant=1) for clear progress, dedicated Sonnet judge agent for semantic analysis when scores stall (classifies recurring vs new issues, detects diminishing returns). Shadow git checkpoints before code-artifact fix rounds with restore-on-regression option. Compaction recovery with Compression State Blocks and persistent scratch directories. Progress notifications at rounds 5/8/11/14, 15-round safety limit. |
+| **red-team** | Adversarial review engine with steel-man-then-kill protocol — every finding must articulate the strongest defense before demolishing it. Mandatory coverage sweep across 6 attack dimensions with a required second pass. Severity anchoring with bias check. Dispatches fresh Devil's Advocate reviewers per round. Dual-mode: single-pass when called by quality-gate (quality-gate owns the loop), full iterative loop when called directly. |
+| **test-coverage** | Post-change test suite audit. Checks whether existing tests need updating (stale assertions, misleading descriptions), deletion (removed code paths), or flagging (coincidence tests that pass by luck). Audit agent + fix agent with revert-on-failure. Split audit for large scopes. Technology-agnostic. |
+| **code-review** | Dispatch code review with shared canonical review checklist including AI slop signal detection — flags 6 patterns of AI-generated padding (comment inflation, docstring padding, over-defensive error handling, premature abstraction, backwards-compatibility ghosts, unused imports) with severity calibration and false-positive exemptions. Recommends test-coverage audit after behavioral changes. |
+| **review-feedback** | Process code review feedback with technical rigor. Requires verification, not blind implementation. |
+| **verify** | Verify work before claiming completion. Evidence-before-claims discipline — run verification commands and confirm output before making success claims. |
+| **finish** | Branch completion workflow — merge, PR, or cleanup. Runs test alignment audit and red-team before presenting options. Pre-push validation gate with toolchain-auto-detection + ecosystem matrix (TS/Node, Rust, Python, Go, .NET, Ruby, Java/Kotlin) and strict exit-code discipline. Post-push CI monitoring with `gh pr checks --watch` + allow-list bucket assertion — blocks on red PRs and disambiguates the no-CI-configured case. |
+| **innovate** | Divergent creativity injection. Proposes the single most impactful addition before quality gate review. |
+
+## Debugging
+
+| Skill | Description |
+|-------|-------------|
+| **debugging** | Orchestrated debugging with hypothesis red-teaming, domain detection, persistent session state with compaction recovery, commit strategy (WIP commits on all outcomes), stagnation ownership split with quality-gate, test suite audit, and post-fix quality gate with test gap writer (dedup-aware, auto-retry on failures). Shadow git checkpoints before fix cycles, sibling fixes, and quality gate for structured rollback. Phase 4.5 "Where Else?" blast radius scan finds and fixes sibling locations with the same bug pattern, then persists the defect signature in cartographer for future proactive prevention. |
+
+## Knowledge & Learning
+
+| Skill | Description |
+|-------|-------------|
+| **forge** | Self-improving retrospective system. Post-task retrospectives classify deviations and extract lessons. Auto-detects skill-worthy workflows via 5 trigger heuristics and proposes extraction (never auto-creates). Opt-in trajectory capture records skill invocations as structured JSONL for eval generation. Pre-task feed-forward surfaces relevant warnings and recent failure patterns. Periodic mutation analysis proposes concrete skill edits for human review. |
+| **cartographer** | Living architectural map that accumulates across sessions. Records codebase structure, conventions, landmines, and defect signatures after exploration. Surfaces structural context and known defect patterns before tasks. Defect signatures persist Phase 4.5 "Where Else?" scan results — build implementers and debugging investigators receive matching patterns proactively. |
+| **project-init** | Eliminates cold-start penalty by deep-scanning the current repo and discovering cross-repo topology. Produces structural cartographer maps and a topology directory before the first real task. |
+
+## Utilities
+
+| Skill | Description |
+|-------|-------------|
+| **distill** | Convert heavy document formats (PDF, Word, Excel, PowerPoint, and 10+ others) to token-efficient Markdown/CSV. Three conversion tiers: Pandoc-native (9 formats), PDF (pdftotext + Claude structuring), Python venv (pptx via python-pptx, xlsx via openpyxl). Structurally-aware digest pass compresses to 20-30% of token count. Pre-flight safety checks (zip bomb, PDF attachments, encoding). Graceful degradation when tools are missing. |
+| **recall** | Query session history from the session activity index. Four modes: full summary (no args), keyword search, type filter (errors/decisions/edits/commits/tests/phases), and time range (last N minutes/hours). Graceful degradation when no session index exists. Consumed by compaction recovery steps in build, debugging, and spec. |
+
+## Maintenance & Meta
+
+| Skill | Description |
+|-------|-------------|
+| **stocktake** | Audits all crucible skills for overlap, staleness, broken references, and quality. Quick scan, full evaluation, or efficiency report modes. Efficiency mode reads chronicle signals to produce per-skill token cost breakdowns, dispatch tier distribution, and structural baseline comparisons. |
+| **merge-pr** | PR merge workflow with full safety scaffolding: CI verification, working-tree check, repo safety scan, local test validation, merge, post-merge CI monitoring, and branch cleanup. Stops on red CI or unsafe state rather than forcing through. |
+| **skill-creator** | Create, edit, and evaluate skills. Run A/B evals to measure skill performance with variance analysis. Optimize skill descriptions for better triggering accuracy. |
+| **getting-started** | Skill discovery and invocation discipline. Objective test for when skills apply, scoped exceptions for pure information retrieval, and anti-rationalization red flags. Includes the five-level trust hierarchy (L1 Trusted → L5 Untrusted) framework for resolving conflicts between loaded content from different sources. |
+
+## Unity UI (Domain-Specific)
+
+These skills are for [Unity UI Toolkit](https://docs.unity3d.com/Manual/UIElements.html) projects. All other Crucible skills are language- and framework-agnostic.
+
+| Skill | Description |
+|-------|-------------|
+| **mockup-builder** | Creates HTML mockups constrained to Theme.uss variables, flexbox-only layout, and BEM naming. Designed for direct translation to Unity UI Toolkit with player-customizable theming. |
+| **mock-to-unity** | Translates mockups into Unity UI Toolkit code via structured CSS-to-USS mapping, layered implementation, and per-layer self-verification. Bakes in Unity 6 USS bug workarounds. |
+| **ui-verify** | Compares implemented UI against source mockup using screenshots or code-level structural audit. Produces structured delta reports with [PASS]/[FAIL]/[WARN] per category. |


### PR DESCRIPTION
## Summary

- README cut from 300 → 62 lines. Detail moved to four new docs under `docs/`.
- Auto mode replaces `--dangerously-skip-permissions` as the recommended run mode for autonomous pipelines (superseded reference retained for migrating users).
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` recommendation stays visible in the README.
- NousResearch/hermes-agent attribution preserved on README L7.

## Relocations

| Old README content | New home |
|---|---|
| Full skill catalog (lines 108–191) | `docs/skills.md` |
| "How It Works" pipeline composition | `docs/architecture.md` |
| Hooks, MCP, build advisor, autocompact env var | `docs/configuration.md` |
| Eval methodology + per-skill deltas + sequence evals | `docs/evals.md` |

`docs/skills.md` adds a `merge-pr` row that was missing from the prior catalog (catalog now 42, matching the README's "all 42" claim).

## Acceptance criteria (from #215)

- [x] README under 100 lines (62)
- [x] Relocated content lives under `docs/` with sensible filenames
- [x] No dead links — every old README pointer is preserved or linked
- [x] `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` recommendation visible in README
- [x] Auto mode recommended as the default run mode
- [x] `--dangerously-skip-permissions` guidance removed in favor of auto mode

## Quality gate

3 rounds. Round 3 fresh red-team returned 0 Fatal, 0 Significant, 2 Minor (acknowledged). Issues fixed across rounds 1–2: dropped attribution restored, broken consensus-config example path corrected and linkified, +68% delta co-located with eval-results link, forge/cartographer recommendation surfaced in README, missing `merge-pr` skill added to catalog.

## Test plan

- [ ] Skim `README.md` end-to-end — pitch, install, setup essentials, doc pointers all read cleanly
- [ ] Click each `[text](path)` link in `README.md` and the four new docs — all targets resolve
- [ ] Confirm `docs/skills.md` table count matches README's "all 42 skills" claim
- [ ] Confirm no `--dangerously-skip-permissions` remains as an active recommendation (only superseded references)

Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)