### PR TITLE
feat(audit): non-code path context improvements (closes #254 #255)

### DIFF
--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -281,7 +281,7 @@ Read `scratch/<run-id>/artifact-type.md`. If present and not `code`, follow non-
 ### Non-Code Recovery (artifact_type: design | plan | concept)
 
 1. Read `artifact-type.md` to recover the artifact type
-2. **Phase 1 recovery:** If `artifact-type.md` exists but `gate-approved.md` does not, re-present the scope summary to the user for confirmation
+2. **Phase 1 recovery:** If `artifact-type.md` exists but `gate-approved.md` does not, re-present the scope summary to the user for confirmation. If `dispatch-context.md` is absent and the artifact type is `plan` or `concept`, re-run step 4.5 (operating-environment gathering) before proceeding to Phase 2.
 3. **Phase 2 recovery:** Look for `<lens-name-kebab>-findings.md` files matching the type's lens names (e.g., `technical-soundness-findings.md` for design). Dispatch any lenses that don't have findings files.
 4. **Phase 2.5 recovery:** If all 4 lens findings exist but `noncode-blindspots-findings.md` does not, build the lens summary and dispatch the non-code blind-spots agent. If `noncode-blindspots-findings.md` exists, Phase 2.5 is complete.
 5. **Phase 3/4 recovery:** Same as code path — re-read findings, re-run synthesis if needed, continue with reporting.
@@ -325,7 +325,18 @@ No scoping agent needed — the artifact IS the scope. The orchestrator:
    - Issue references (`#NNN`)
    - Explicit "see also" references
    For each referenced file that exists locally: read and include as supporting context. For issue references: fetch title and body via `gh issue view`. **Soft cap: 2000 lines total.** If exceeded: prioritize files referenced in decision-critical sections (Key Decisions, Risk Areas) over background references. Truncate with note: "[truncated — 2000-line context cap reached]". If no references found: proceed with artifact-only context.
-5. **Present user gate:** "Auditing [artifact name] as a [type]. Supporting context: [list of referenced docs, if any]. Proceed?"
+4.5. **Gather operating-environment context (plan and concept artifacts only).** For `plan` and `concept` artifact types, the Feasibility and Risk & Dependencies lenses cannot meaningfully assess an artifact in the abstract — they need to know what the executor actually has. For `design` artifacts, this step is OPTIONAL and may be skipped if the design is environment-independent.
+
+   Inspect:
+   - The project's `CLAUDE.md` for toolchain / build / framework constraints
+   - Any cartographer module map (`memory/cartographer/conventions.md` or similar) for architectural constraints. If the module map is flagged stale (mtime > 30 days or explicit stale marker), include the staleness note rather than the stale claims.
+   - The skill(s) the artifact names as its execution vehicle (e.g., `/audit`, `/build`, `/debug`) — pull their hard caps, budgets, and red flags from the named skill's SKILL.md
+   - The tracker conventions from `preferences.md` if present
+
+   Bundle these into a `## Operating Environment` block. **Soft cap: 500 lines.** Write to `scratch/<run-id>/dispatch-context.md` so lens dispatches reference the same file rather than each prompt copy-pasting 500 lines × 5 dispatches. If the bundle is empty (no relevant constraints found), record `## Operating Environment\n(none detected)` and proceed — the lens prompts treat an empty block as a no-op.
+
+   Anti-rationalization: skipping this step for plan/concept artifacts because "the constraints are obvious" produces generic feasibility findings ("sampling is generally hard") instead of concrete ones grounded in the executor's actual caps. Always run.
+5. **Present user gate:** "Auditing [artifact name] as a [type]. Supporting context: [list of referenced docs, if any]. Operating environment: [one-line summary of bundled constraints, if any]. Proceed?"
 6. **Write gate marker:** Write `scratch/<run-id>/gate-approved.md` (same as code path).
 
 ## Phase 2: Analysis
@@ -335,7 +346,7 @@ No scoping agent needed — the artifact IS the scope. The orchestrator:
 Dispatch: `Task tool (general-purpose, model: opus)` per lens, in parallel, using `audit-noncode-lens-prompt.md` with lens-specific instruction injection.
 
 For each of the 4 lenses matching the artifact type (see Artifact Types table):
-1. Fill the template placeholders: `{{LENS_NAME}}`, `{{LENS_QUESTION}}`, `{{LENS_FOCUS_AREAS}}`, `{{LENS_EXCLUSIONS}}`, `{{ARTIFACT_TYPE}}`, `{{ARTIFACT_CONTENT}}`, `{{SUPPORTING_CONTEXT}}`
+1. Fill the template placeholders: `{{LENS_NAME}}`, `{{LENS_QUESTION}}`, `{{LENS_FOCUS_AREAS}}`, `{{LENS_EXCLUSIONS}}`, `{{ARTIFACT_TYPE}}`, `{{ARTIFACT_CONTENT}}`, `{{SUPPORTING_CONTEXT}}`, `{{OPERATING_ENVIRONMENT}}`. The `{{OPERATING_ENVIRONMENT}}` slot is filled from `scratch/<run-id>/dispatch-context.md` (see Phase 1 step 4.5). For `design` artifacts where Phase 1 skipped step 4.5, pass an empty string — the prompt template handles the no-op case.
 2. Dispatch via disk-mediated dispatch
 3. Write findings to `scratch/<run-id>/<lens-name-kebab>-findings.md` (e.g., `technical-soundness-findings.md`)
 
@@ -568,7 +579,7 @@ Blind-spots template (`Task tool, general-purpose, model: opus`):
 
 ### Non-Code Audit Templates
 
-- `audit-noncode-lens-prompt.md` -- Parameterized lens dispatch for all non-code artifact types. Orchestrator fills `{{LENS_NAME}}`, `{{LENS_QUESTION}}`, `{{LENS_FOCUS_AREAS}}`, `{{LENS_EXCLUSIONS}}`, `{{ARTIFACT_TYPE}}`, `{{ARTIFACT_CONTENT}}`, `{{SUPPORTING_CONTEXT}}`.
+- `audit-noncode-lens-prompt.md` -- Parameterized lens dispatch for all non-code artifact types. Orchestrator fills `{{LENS_NAME}}`, `{{LENS_QUESTION}}`, `{{LENS_FOCUS_AREAS}}`, `{{LENS_EXCLUSIONS}}`, `{{ARTIFACT_TYPE}}`, `{{ARTIFACT_CONTENT}}`, `{{SUPPORTING_CONTEXT}}`, `{{OPERATING_ENVIRONMENT}}`.
 - `audit-noncode-blindspots-prompt.md` -- Non-code blind-spots dispatch (receives lens summary, not coverage map)
 
 Each analysis template includes:

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -324,7 +324,18 @@ No scoping agent needed — the artifact IS the scope. The orchestrator:
    - File paths (`path/to/file.ext`)
    - Issue references (`#NNN`)
    - Explicit "see also" references
+   - **Project-memory references** — bare filenames or relative paths that match Crucible-style memory conventions (see Project-Memory Reference Resolution below)
+   - **Skill name references** — names of skills the artifact mentions (e.g., "the `riftlock-standards` skill", "`feedback_use_component_library`")
+
    For each referenced file that exists locally: read and include as supporting context. For issue references: fetch title and body via `gh issue view`. **Soft cap: 2000 lines total.** If exceeded: prioritize files referenced in decision-critical sections (Key Decisions, Risk Areas) over background references. Truncate with note: "[truncated — 2000-line context cap reached]". If no references found: proceed with artifact-only context.
+
+   **Project-Memory Reference Resolution.** A reference that does not resolve repo-relative is tried against the project-memory directory at `~/.claude/projects/<project-hash>/memory/`:
+   - If the reference is a path (e.g., `memory/cartographer/conventions.md`), try `<project-memory-root>/cartographer/conventions.md`.
+   - If the reference is a bare filename matching `<prefix>_<rest>.md` where prefix is one of `user`, `feedback`, `project`, `reference` (Crucible memory convention) OR matches a date-prefixed retrospective pattern `YYYY-MM-DD-*.md`, search for it under `<project-memory-root>/` (root), `<project-memory-root>/forge/retrospectives/`, and `<project-memory-root>/cartographer/`.
+   - If the reference is a skill name (matches an entry in the available-skills list), include the skill's one-line description as supporting context. Skill body is opt-in via explicit user instruction; do NOT auto-include skill SKILL.md (token cost).
+   - **Path-collision resolution:** prefer repo-relative match over project-memory match if both exist.
+   - **No project hash known:** when the orchestrator cannot determine the project hash (e.g., running outside Claude Code, or `~/.claude/projects/<hash>/` is not discoverable from cwd), skip the project-memory fallback silently. No regression vs prior behavior.
+   - **Stale-memory annotation:** when a resolved memory file has a "stale" marker in frontmatter (some Crucible setups inject one for memories older than 30 days, or based on mtime), the orchestrator includes the file content with a leading note: "**Note: this memory was marked stale (mtime: <date>); verify current relevance before relying on its claims.**" Do not silently include stale memories without annotation.
 4.5. **Gather operating-environment context (plan and concept artifacts only).** For `plan` and `concept` artifact types, the Feasibility and Risk & Dependencies lenses cannot meaningfully assess an artifact in the abstract — they need to know what the executor actually has. For `design` artifacts, this step is OPTIONAL and may be skipped if the design is environment-independent.
 
    Inspect:

--- a/skills/audit/audit-noncode-lens-prompt.md
+++ b/skills/audit/audit-noncode-lens-prompt.md
@@ -37,6 +37,22 @@ Task tool (general-purpose, model: opus):
     If no supporting context is provided, evaluate the artifact on its
     own merits.
 
+    ## Operating Environment
+
+    {{OPERATING_ENVIRONMENT}}
+
+    The Operating Environment block describes the executor's actual
+    constraints — toolchain capacities, framework versions, hard caps of
+    skills the artifact names as its execution vehicle, tracker conventions,
+    and any stale-data caveats. For Feasibility and Risk & Dependencies
+    lenses on plan and concept artifacts, this is load-bearing: ground
+    your findings in these specific constraints rather than abstract
+    "this is generally hard" reasoning.
+
+    If the block is empty or absent (common for design artifacts), evaluate
+    the artifact without environment-specific grounding. Do not invent
+    constraints not listed here.
+
     ## Your Job
 
     1. **Read the artifact carefully.** Understand its structure, claims,


### PR DESCRIPTION
## Summary

Two related improvements to the `/audit` non-code path, both surfaced from real-world audits where lens findings degraded because Phase 1 missed load-bearing context.

### Commit 1 — #254: Operating-environment injection slot

Adds Phase 1 step 4.5 for `plan` and `concept` artifacts. The orchestrator gathers a bundle of executor constraints — `CLAUDE.md` toolchain, cartographer module map (with staleness annotation), hard caps of skills the artifact names as its execution vehicle, tracker conventions — and writes them to `scratch/<run-id>/dispatch-context.md`. The non-code lens prompt grows a new `{{OPERATING_ENVIRONMENT}}` slot that pulls from this file.

For `design` artifacts the step is optional (orchestrator may pass empty string).

**Symptom this fixes:** Auditing a test-suite audit plan that named `/audit` as its execution vehicle, the Feasibility lens couldn't detect a 50× violation of `/audit`'s own 1500-line × 20-agent caps. The orchestrator hand-authored a `## Project context` block into each of 4 lens dispatch prompts.

### Commit 2 — #255: Project-memory fallback in reference resolver

Phase 1 step 4 previously parsed markdown links, repo-relative paths, issue refs, and see-also refs — and dropped everything else. Added fallback for Crucible-style memory references:

- Path doesn't resolve repo-relative → try project-memory root
- Bare filename matches Crucible memory convention (user_/feedback_/project_/reference_ prefix OR date-prefixed retro) → search memory root + retrospectives + cartographer
- Reference is a skill name → include one-line description from available-skills (skill body opt-in)
- Repo-relative wins over project-memory if both exist
- No project hash → skip silently (no regression)
- Stale memories (frontmatter marker or mtime > 30 days) include with explicit staleness annotation

**Symptom this fixes:** Auditing an issue whose References cited a forge retro, two memory files, a cartographer conventions file, and a skill name — all five dropped silently by the resolver. The forge retro was the single most-cited evidence across all five lenses (3 of 4 Fatal findings derived from it).

## Test plan

Spec-only PR (markdown edits to `skills/audit/SKILL.md` and `skills/audit/audit-noncode-lens-prompt.md`).

- [ ] Cross-reference check: Phase 1 step 4 vs step 4.5 vs lens prompt template vs compaction recovery
- [ ] `dispatch-context.md` is referenced consistently across step 4.5, Phase 2 dispatch, and recovery
- [ ] Stale-annotation rule applies to both project-memory and repo-relative resolved files

Closes #254, #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)