### PR TITLE
fix(temper): reconcile placeholder names (audit F1)

### DIFF
--- a/skills/temper/SKILL.md
+++ b/skills/temper/SKILL.md
@@ -62,11 +62,12 @@ Determine what to review based on the argument:
 
 Use the Task tool with `subagent_type="general-purpose"`. Fill in the template at `temper-reviewer.md` in this directory and pass it as the subagent prompt.
 
-**Placeholders:**
-- `{WHAT_WAS_IMPLEMENTED}` — derived from PR title if available, else `Changes in <base>..<head>`
-- `{PLAN_OR_REQUIREMENTS}` — PR body if available, else `(none provided — review against general production-readiness criteria)`
-- `{BASE_SHA}` / `{HEAD_SHA}` — resolved SHA range from Step 1
-- `{DESCRIPTION}` — one-line summary (PR title or "changes on branch X")
+**Placeholders** (four slots, all must be filled before dispatch — these match the section slots in `temper-reviewer.md` exactly):
+- `{DESCRIPTION}` — one-line summary of what was implemented. PR title if available, else `Changes in <base>..<head>` / `changes on branch X`.
+- `{PLAN_REFERENCE}` — PR body / plan / requirements if available, else `(none provided — review against general production-readiness criteria)`.
+- `{BASE_SHA}` / `{HEAD_SHA}` — resolved SHA range from Step 1.
+
+Earlier drafts listed `{WHAT_WAS_IMPLEMENTED}` and `{PLAN_OR_REQUIREMENTS}` as separate placeholders. Those names were redundant aliases for `{DESCRIPTION}` and `{PLAN_REFERENCE}` respectively — the template now uses the canonical names in both its prose and its section slots, so there is exactly one slot per concept.
 
 ### Step 3: Act on feedback and iterate
 

--- a/skills/temper/temper-reviewer.md
+++ b/skills/temper/temper-reviewer.md
@@ -7,8 +7,8 @@
 You are reviewing code changes for production readiness.
 
 **Your task:**
-1. Review {WHAT_WAS_IMPLEMENTED}
-2. Compare against {PLAN_OR_REQUIREMENTS}
+1. Review {DESCRIPTION}
+2. Compare against {PLAN_REFERENCE}
 3. Check code quality, architecture, testing
 4. Categorize issues by severity
 5. Assess production readiness


### PR DESCRIPTION
## Summary
Closes the Fatal from #263. `SKILL.md` Step 2 listed `{WHAT_WAS_IMPLEMENTED}` and `{PLAN_OR_REQUIREMENTS}` as placeholders, but `temper-reviewer.md`'s section slots use `{DESCRIPTION}` and `{PLAN_REFERENCE}`. Literal substitution would dispatch reviewer prompts with unfilled `{PLAN_REFERENCE}` tokens.

## Resolution
Each concept had two redundant names. Standardized on the section-slot names:
- `{WHAT_WAS_IMPLEMENTED}` -> `{DESCRIPTION}` (was already a section slot at template line 18; the prose reference at line 10 now uses the same name)
- `{PLAN_OR_REQUIREMENTS}` -> `{PLAN_REFERENCE}` (was already a section slot at template line 22; the prose reference at line 11 now uses the same name)

SKILL.md's placeholder list is now four canonical slots (`{DESCRIPTION}`, `{PLAN_REFERENCE}`, `{BASE_SHA}`, `{HEAD_SHA}`) — one slot per concept.

## Verification
- `grep` confirms no stale `{WHAT_WAS_IMPLEMENTED}` / `{PLAN_OR_REQUIREMENTS}` placeholders remain in `skills/temper/` (two prose-mentions remain in SKILL.md only — they are the explanatory note about the rename).
- Diff is 8 insertions / 7 deletions across two files; no other content changed.

## Test plan
- [x] grep verification
- [ ] Next `/temper` run should produce a clean dispatched prompt with all slots filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)