### PR TITLE
feat(temper): add Surgical/DRY/SRP+OCP lenses + eval harness (#287)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docs/prds/
 skills/*-workspace/
 skills/skill-creator/
 skills/stocktake/results.json
+skills/temper/evals/last_run.json
 src/
 tests/
 package.json

--- a/docs/compass.md
+++ b/docs/compass.md
@@ -1,10 +1,11 @@
 # Compass
 
-**Current arc:** #273: Compass implementation + dogfood verification
+**Current arc:** #287: temper Surgical/DRY/SRP+OCP lenses
 **Last meaningful commit:** 8c3c269:feat(#273): compass — persistent arc-level project state
-**Updated:** 2026-05-20 21:01
+**Updated:** 2026-05-20 23:30
 
 ## Open loops
+- [paused] #273: Compass implementation + dogfood verification @ 2026-05-20T23:30:44
 
 ## Next move
 

--- a/scripts/check_canonical_drift.py
+++ b/scripts/check_canonical_drift.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Drift check: canonical Targeted Lenses vs build-reviewer paraphrase.
+
+Invocation (from repo root):
+    python3 scripts/check_canonical_drift.py
+
+Compares the `### Targeted Lenses` block in `skills/shared/reviewer-common.md`
+(canonical) against the paraphrased lens block in
+`skills/build/build-reviewer-prompt.md` (between the
+`<!-- CANONICAL: shared/reviewer-common.md — Targeted Lenses (Pass 1 — paraphrased) -->`
+marker and the next `**Wiring:**` line).
+
+Asserts both blocks contain: the 4 lens subsection headings, the 6 co-fire
+data-row conditions, and the 4 pinned severity-ceiling sentences (with the
+OCP-form ceiling appearing >=3x across DRY/SRP/OCP). Exits 0 if aligned,
+1 with a diff summary otherwise. Stdlib only.
+"""
+from __future__ import annotations
+import pathlib, re, sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CANON = ROOT / "skills/shared/reviewer-common.md"
+BUILD = ROOT / "skills/build/build-reviewer-prompt.md"
+
+LENS_HEADINGS = ["#### Surgical Changes", "#### DRY", "#### SRP", "#### OCP"]
+COFIRE_ROWS = [
+    "Surgical Changes triggers", "Function-SRP fully contains",
+    "Class-SRP fully contains", "Module-SRP overlaps DRY",
+    "SRP and DRY apply, SRP unit does NOT contain", "OCP and any other lens",
+]
+PINNED_SENTENCES = [
+    "Critical/Important when scope-bleed materially obscures",
+    "DRY findings from this lens MUST NOT exceed Minor",
+    "Function- and class-level SRP findings are primary",
+]
+CEILING_PHRASE = "Severity ceiling:** Minor (or Suggestion)."
+
+def extract_canon(text: str) -> str:
+    # Include Targeted Lenses + the sibling ### Lens precedence... section
+    # (where the co-fire table lives), stopping at the next non-precedence ###.
+    m = re.search(
+        r"### Targeted Lenses\n(.*?)(?=\n### (?!Lens precedence))",
+        text, re.DOTALL)
+    return m.group(1) if m else ""
+
+def extract_build(text: str) -> str:
+    m = re.search(
+        r"<!-- CANONICAL: shared/reviewer-common\.md — Targeted Lenses \(Pass 1 — paraphrased\) -->\n(.*?)\*\*Wiring:\*\*",
+        text, re.DOTALL)
+    return m.group(1) if m else ""
+
+def check(name: str, block: str) -> list[str]:
+    if not block:
+        return [f"{name}: block not found / empty"]
+    errs = [f"{name}: missing lens heading '{h}'" for h in LENS_HEADINGS if h not in block]
+    rows = "\n".join(ln for ln in block.splitlines()
+                     if ln.lstrip().lstrip(">").lstrip().startswith("|")
+                     and "---" not in ln and "Co-fire condition" not in ln)
+    errs += [f"{name}: missing co-fire row '{c}'" for c in COFIRE_ROWS if c not in rows]
+    errs += [f"{name}: missing pinned sentence '{s}'" for s in PINNED_SENTENCES if s not in block]
+    n = block.count(CEILING_PHRASE)
+    if n < 3:
+        errs.append(f"{name}: '{CEILING_PHRASE}' appears <3x (got {n})")
+    return errs
+
+def main() -> int:
+    canon_block = extract_canon(CANON.read_text(encoding="utf-8"))
+    build_block = extract_build(BUILD.read_text(encoding="utf-8"))
+    errs = check("canonical", canon_block) + check("build-paraphrase", build_block)
+    if errs:
+        print("DRIFT DETECTED:")
+        for e in errs:
+            print(f"  - {e}")
+        return 1
+    print("OK — canonical and build paraphrase are aligned.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/build/build-reviewer-prompt.md
+++ b/skills/build/build-reviewer-prompt.md
@@ -70,7 +70,7 @@ Task tool (general-purpose, model: opus or sonnet — lead decides per task comp
     - Clean separation of concerns? Single responsibility per component?
     - Clear naming that matches what things DO, not how they work?
     - Proportional error handling? (validate at boundaries, trust internal contracts — see AI Slop Signals for specific diff-level patterns)
-    - DRY principle followed?
+    - DRY violations? (See Targeted Lenses → DRY for the formal trigger threshold and co-fire rules.)
     - No overengineering or YAGNI violations?
 
     <!-- CANONICAL: shared/reviewer-common.md — Review Checklist (AI Slop Signals) -->
@@ -84,6 +84,45 @@ Task tool (general-purpose, model: opus or sonnet — lead decides per task comp
     - Unused imports: imports for modules, types, or symbols not referenced in the file.
     Judge by whether additions serve the task or merely inflate the diff.
     In the build pipeline, check the de-sloppify cleanup log before flagging these patterns independently.
+
+    <!-- CANONICAL: shared/reviewer-common.md — Targeted Lenses (Pass 1 — paraphrased) -->
+    **Targeted Lenses:** Four named lenses focus on disciplines reviewers drift on. Tag findings with `Lens: <name>`. Every lens finding MUST include a `File:` line in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (e.g., `src/foo.py:42`) — function/class names are NOT acceptable line locators (OCP may also cite a registry file with the same numeric format); prose-only suggestions are not findings.
+
+    #### Surgical Changes
+    > Every changed line should trace to what the user asked for. Drive-by edits muddy diffs and inflate review burden.
+    - **Flag:** drive-by reformatting of adjacent code; deletion of pre-existing dead code not orphaned BY this change (mention, don't delete); style "corrections" where existing style is internally consistent; edits to files sharing no symbols with the request.
+    - **Do not flag:** cleanup of code orphaned BY this change; refactors the request called for; mechanically-required adjacent edits (e.g., updating a single caller for a signature change).
+    - **Severity:** Critical/Important when scope-bleed materially obscures the requested change or introduces regression risk. Minor/Suggestion when bleed is cosmetic.
+    - **Precedence:** wins over DRY/SRP/OCP on the same lines; the other lens may surface a separate Minor/Suggestion finding but MUST NOT recommend the fix at higher severity.
+
+    #### DRY
+    - **Flag:** new code duplicating an existing helper; two near-identical blocks in this diff; **syntactic trigger:** 2+ sequences of 5+ contiguous code tokens identical modulo identifier renames, where a maintainer would predictably fix the same bug in both places.
+    - **Do not flag:** 2-3 similar lines / under-5-token repetition; coincidental similarity for semantically distinct ops; framework-API shape repetition (e.g., route registrations).
+    - **Severity ceiling:** Minor (or Suggestion). DRY findings from this lens MUST NOT exceed Minor. If duplication would silently diverge in production, DROP the direct DRY finding entirely (no parallel Minor emit) and re-emit ONE finding under Correctness/Architecture at the appropriate severity, tagged `Lens: DRY (re-attributed)` on its own line. Direct and re-attributed are mutually exclusive.
+
+    #### SRP
+    - **Flag:** new function/class doing two clearly separable jobs (parse+emit, validate+persist, routing+business rules). Module-level mixing surfaces as **architectural observation only** and NEVER displaces DRY on co-fire.
+    - **Do not flag:** existing units (lens applies to NEW or substantially-rewritten units); deliberately-coupled convenience helpers (e.g., `parse_and_validate`).
+    - **Severity ceiling:** Minor (or Suggestion). Function- and class-level SRP findings are primary; module-level is architectural observation only.
+
+    #### OCP
+    - **Flag (ALL must hold):** a NEW `elif`/`case`/`match` arm added to a chain dispatching on a discriminator (string tag, enum, type name) when a registry/strategy table for the same discriminator exists elsewhere AND the OCP finding's `File:` lines explicitly include the registry file path (use a second `File:` line if needed). If the cited registry can't be located, DROP the finding.
+    - **Carve-out:** OCP is the ONLY lens permitted to cite a file outside the diff (the registry).
+    - **Do not flag:** chains with no existing registry; chains dispatching on non-discriminator values (e.g., `if x > threshold`). L/I/D are out of scope.
+    - **Severity ceiling:** Minor (or Suggestion).
+
+    **Co-fire precedence table:**
+
+    | Co-fire condition | Attribute to |
+    |---|---|
+    | Surgical Changes triggers + any other lens (same lines) | Surgical Changes |
+    | Function-SRP fully contains DRY block | SRP |
+    | Class-SRP fully contains DRY block | SRP |
+    | Module-SRP overlaps DRY (any extent) | DRY (module-SRP surfaced separately as architectural observation) |
+    | SRP and DRY apply, SRP unit does NOT contain DRY block | DRY |
+    | OCP and any other lens | Both fire independently (OCP carve-out is structural, not overlapping) |
+
+    Finding format addendum: add `Lens: Surgical | DRY | SRP | OCP` — required when finding originates from a Targeted Lens; omit otherwise. Re-attributed findings use `Lens: <name> (re-attributed)` on its own line immediately after Severity:.
 
     **Wiring:**
     - Is new code actually connected to the rest of the system?
@@ -155,10 +194,11 @@ Task tool (general-purpose, model: opus or sonnet — lead decides per task comp
     ## Report Format
 
     **For each issue found:**
-    - File:line reference (be specific, not vague)
+    - File:line reference, in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (numeric line refs from diff hunks — function/class names are NOT acceptable substitutes)
     - What's wrong
     - Why it matters
     - Severity classification
+    - Lens: Surgical | DRY | SRP | OCP — required when finding originates from a Targeted Lens; omit otherwise. Re-attributed findings use 'Lens: <name> (re-attributed)' on its own line immediately after Severity:.
     - How to fix (if not obvious)
 
     ### Pass 1: Code Review

--- a/skills/shared/reviewer-common.md
+++ b/skills/shared/reviewer-common.md
@@ -23,11 +23,111 @@
 - No scope creep -- implementation matches what was requested?
 
 ### Quality
-- Clean separation of concerns? Single responsibility per component?
+- Clean separation of concerns? Single responsibility per component? (See Targeted Lenses → SRP for the new-function/new-class trigger and OCP carve-out.)
 - Clear naming that matches what things DO, not how they work?
 - Proportional error handling? (validate at boundaries, trust internal contracts — see AI Slop Signals for specific diff-level patterns)
-- DRY principle followed?
+- DRY violations? (See Targeted Lenses → DRY for the formal trigger threshold and co-fire rules.)
 - No overengineering or YAGNI violations?
+
+### Targeted Lenses
+
+> Four named lenses focus the review on disciplines code-review agents reliably drift on. Each lens emits findings tagged with the lens name (`Lens: <name>`) in addition to the standard finding fields. **Every finding emitted from any lens MUST include a `File:` line in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (e.g., `File: src/foo.py:42` or `File: src/foo.py:42-58`). Function names, class names, or parenthetical locators (e.g., `src/foo.py (render_banner)` or `src/foo.py:get_timeout_seconds`) are INVALID — use the actual line number from the diff's `@@` hunks. Findings without a numeric `File:` line are invalid and MUST be dropped before emit.** Prose-only suggestions ("consider being more DRY") are not findings.
+
+#### Surgical Changes (precedence: highest)
+
+> Every changed line should trace to what the user asked for. Drive-by reformatting and adjacent-code "improvements" muddy diffs and increase review burden disproportionately.
+>
+> **Flag:**
+> - Reformatting / rewriting of code adjacent to the task but not part of the request.
+> - Deletion of pre-existing dead code that was not orphaned BY this change (mention it instead — do not delete).
+> - Style "corrections" to match the reviewer's taste when existing style is internally consistent.
+> - Modifications to files that share no edited symbols with the rest of the diff and were not named in the request.
+>
+> **Do not flag:**
+> - Removal of imports, variables, or functions orphaned BY this change (in-scope cleanup).
+> - Renames or refactors that the request explicitly called for.
+> - Adjacent-line changes mechanically required by the new code (e.g., adjusting a function signature also updates its one caller).
+>
+> **Severity:** Critical/Important when scope-bleed materially obscures the requested change or introduces regression risk. Minor/Suggestion when bleed is cosmetic.
+>
+> **Degraded mode (no scope context in this prompt):** When the prompt above does NOT contain a clear statement of what was requested (no PR body, no task spec, no plan reference — only the diff and a placeholder), reserve Important/Critical for surgical findings about structural breakage. Scope-bleed findings drop to Suggestion-severity in degraded mode — without a stated request, "in scope" is unknowable for borderline cases.
+>
+> **Precedence:** When this lens conflicts with DRY/SRP/OCP on the same lines, this lens wins. The other lens may surface the underlying concern as a Minor/Suggestion comment but MUST NOT recommend the fix at higher severity.
+
+#### DRY
+
+> Flag duplication introduced by this diff and new code that bypasses an existing helper.
+>
+> **Flag:**
+> - New code that duplicates an existing helper or utility instead of calling it.
+> - Two near-identical blocks introduced in the same diff (same file or across files).
+> - **Syntactic trigger:** two or more sequences of 5+ contiguous code tokens (excluding whitespace, punctuation, and comments) that are identical or differ only in identifier names. The bar above the trigger: a maintainer would predictably fix the same bug in both places.
+>
+> **Do not flag (over-DRY):**
+> - Two or three similar lines. Inlined repetition under 5 tokens is fine.
+> - Coincidental syntactic similarity where the two blocks express semantically distinct operations and would not co-evolve under a bug fix.
+> - A copy-of-a-pattern that *names* a thing (e.g., two route registrations look similar but the similarity is the framework's API, not the user's code).
+>
+> **Severity ceiling:** Minor (or Suggestion). DRY findings from this lens MUST NOT exceed Minor. If duplication rises to Important (e.g., the two diverging copies will silently behave differently in production), **DROP the Targeted-Lens DRY finding entirely** (do NOT emit it at Minor in parallel — avoids double-counting) and re-emit ONE finding under the appropriate non-lens checklist section (Correctness for behavioral divergence, Architecture and Patterns for structural mixing) at the appropriate severity, tagged on its own line `Lens: DRY (re-attributed)` immediately after the Severity: line. The escape hatch is mutually exclusive with the direct lens finding: emit EITHER a Minor `Lens: DRY` finding OR an Important+ `Lens: DRY (re-attributed)` finding, never both.
+
+#### SRP
+
+> Flag new declarative units (functions, classes, modules) that do two clearly separable jobs.
+>
+> **Flag:**
+> - A new function with two distinct responsibilities (e.g., parses input AND emits output; validates AND persists).
+> - A new class that aggregates two unrelated concerns (e.g., HTTP routing AND business-rule evaluation).
+> - **Module-level SRP** (a new module mixes concerns): surface as an **architectural observation**, not as a refactor recommendation. Module-level SRP NEVER displaces DRY on co-fire.
+>
+> **Do not flag:**
+> - Existing units (this lens applies to NEW or substantially-rewritten declarative units only).
+> - Helpers that compose two operations as a deliberate convenience (e.g., `parse_and_validate(s)` where parsing and validating are tightly coupled by domain).
+>
+> **Severity ceiling:** Minor (or Suggestion). Function- and class-level SRP findings are primary; module-level is architectural observation only.
+
+#### OCP
+
+> Flag a new `elif`, `case`, or `match` arm added to a chain dispatching on a discriminator IFF a registry / strategy table for that discriminator exists elsewhere in the codebase.
+>
+> **Flag conditions (ALL must hold):**
+> - The arm is NEW in this diff (not a modification of an existing arm).
+> - The chain dispatches on a discriminator (string tag, enum, type name).
+> - A registry / strategy dispatch table for the same discriminator exists in the diff's context — and **the finding cites the registry file path in a `File:` line**. The OCP finding's `File:` lines MUST include both the new arm's location AND the registry file path (use two `File:` lines if needed: one for the elif site, one for the registry). Without the registry path explicitly in a `File:` line, the OCP finding is incomplete.
+>
+> **If the cited registry file cannot be located** (the reviewer does not have access to it, or it does not exist), DROP the finding. No false positives.
+>
+> **Out-of-scope-reference carve-out:** OCP findings are the ONLY lens findings permitted to cite a file path that is not directly part of the diff under review. This carve-out is the OCP lens's defining shape (an OCP finding requires pointing at the registry as an alternative). For all other lenses (Surgical, DRY, SRP), every cited file path must be a file appearing in the diff.
+>
+> **Do not flag:**
+> - Conditional chains where no registry exists — extending the only dispatch site is fine.
+> - Chains dispatching on a value that is not a discriminator (e.g., `if x > threshold`).
+>
+> **Severity ceiling:** Minor (or Suggestion).
+>
+> **L / I / D out of scope:** Liskov, Interface-Segregation, and Dependency-Inversion are explicitly NOT part of this lens.
+
+### Lens precedence and co-fire resolution
+
+> When a single set of lines triggers multiple lenses, resolve attribution as follows:
+>
+> 1. **Surgical Changes wins** over DRY/SRP/OCP on the same lines. The other lens may surface the concern as a separate Minor/Suggestion finding on different lines, but MUST NOT recommend the fix at higher severity.
+> 2. **Function- or class-level SRP that fully contains a DRY block wins over DRY** when the unit mixes two clearly separable concerns AND the duplicated block is entirely inside it. Module-level SRP NEVER displaces DRY.
+> 3. **All other co-fires: DRY wins** (including SRP-vs-DRY where SRP is module-level or where SRP unit does not contain the DRY block).
+>
+> | Co-fire condition | Attribute to |
+> |---|---|
+> | Surgical Changes triggers + any other lens (same lines) | Surgical Changes |
+> | Function-SRP fully contains DRY block | SRP |
+> | Class-SRP fully contains DRY block | SRP |
+> | Module-SRP overlaps DRY (any extent) | DRY (module-SRP surfaced separately as architectural observation) |
+> | SRP and DRY apply, SRP unit does NOT contain DRY block | DRY |
+> | OCP and any other lens | Both fire independently (OCP carve-out is structural, not overlapping) |
+>
+> **Worked examples:**
+>
+> - *Drive-by reformat that also collapses duplication.* A diff adds a feature, and also reformats a neighboring function whose old body happened to be duplicated. Attribute to **Surgical Changes** (the reformat is the violation; the duplication-collapse is a side effect). DRY does not fire on these lines.
+> - *New function does parsing + emitting and has a duplicated regex.* A new function `process_record()` parses a row and emits a serialized result, and contains the same regex pattern in two branches. Attribute to **SRP** (function-level, fully contains the DRY block). DRY does not fire as a separate finding.
+> - *New module does parsing + emitting; parsing duplicates an existing util.* A new module mixes parsing and emitting; its parsing function duplicates an existing util elsewhere. Attribute to **DRY** for the duplication (module-SRP never displaces DRY). Surface module-SRP as a separate architectural observation Minor finding.
 
 ### AI Slop Signals
 AI agents produce characteristic padding patterns that aren't bugs but inflate diffs, obscure real changes, and accumulate as maintenance burden. These are typically Minor or Suggestion severity; escalate to Important only when padding materially obscures real changes in the diff. Common patterns include:
@@ -73,10 +173,11 @@ AI agents produce characteristic padding patterns that aren't bugs but inflate d
 ## Report Format
 
 **For each issue found:**
-- File:line reference (be specific, not vague)
+- File:line reference, in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (numeric line refs from the diff's `@@` hunks — function/class names are NOT acceptable substitutes)
 - What's wrong
 - Why it matters
 - Severity classification
+- Lens: Surgical | DRY | SRP | OCP — required when finding originates from a Targeted Lens; omit otherwise. Re-attributed findings use 'Lens: <name> (re-attributed)' on its own line immediately after Severity:.
 - How to fix (if not obvious)
 
 **Report structure:**

--- a/skills/temper/evals/evals.json
+++ b/skills/temper/evals/evals.json
@@ -1,0 +1,113 @@
+{
+  "skill_name": "temper",
+  "evals": [
+    {
+      "id": "1a",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`.\n\n```diff\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -1,28 +1,46 @@\n-import json\n+import json\n+import logging\n+\n+log = logging.getLogger(__name__)\n \n \n def load_config(path):\n-    with open(path) as f:\n-        return json.load(f)\n+    with open(path) as f:\n+        return json.load(f)\n+\n+\n+def get_timeout_seconds(config):\n+    \"\"\"Return the configured request timeout in seconds.\n+\n+    Reads `config['timeout_ms']` (preferred) and falls back to a\n+    30s default if absent. Logs the chosen value once at DEBUG.\n+    \"\"\"\n+    ms = config.get(\"timeout_ms\")\n+    if ms is None:\n+        log.debug(\"timeout_ms missing; defaulting to 30000\")\n+        return 30.0\n+    return float(ms) / 1000.0\n \n \n-def render_banner(title,subtitle=None):\n-    if subtitle:\n-      return title+' - '+subtitle\n-    return title\n+def render_banner(title, subtitle=None):\n+    if subtitle:\n+        return f\"{title} - {subtitle}\"\n+    return title\n \n \n def save_state(path, state):\n     with open(path, \"w\") as f:\n         json.dump(state, f, indent=2)\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "Surgical lens fires at Important on the reformatted render_banner block; no DRY/SRP/OCP findings.",
+      "files": ["src/foo.py"],
+      "allowed_files": ["src/foo.py"],
+      "lens_under_test": "surgical",
+      "replicate_rule": {"trials": 5, "threshold": 3},
+      "expectations": [
+        {"type": "mechanical", "check": "lens-finding-fires", "params": {"lens": "Surgical", "severity": "Important"}},
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "DRY", "include_reattributed": true}},
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "SRP", "include_reattributed": true}},
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "OCP", "include_reattributed": true}},
+        {"type": "mechanical", "check": "lens-findings-in-allowed-files", "params": {"ocp_carveout": false}},
+        {"type": "mechanical", "check": "all-findings-have-file-line"}
+      ]
+    },
+    {
+      "id": "1b",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`.\n\n```diff\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -1,40 +1,72 @@\n-import json\n+import json\n+import logging\n+\n+log = logging.getLogger(__name__)\n \n \n def load_config(path):\n-    with open(path) as f:\n-        return json.load(f)\n+    with open(path) as f:\n+        return json.load(f)\n+\n+\n+def get_timeout_seconds(config):\n+    \"\"\"Return the configured request timeout in seconds.\"\"\"\n+    ms = config.get(\"timeout_ms\")\n+    if ms is None:\n+        log.debug(\"timeout_ms missing; defaulting to 30000\")\n+        return 30.0\n+    return float(ms) / 1000.0\n \n \n-def render_banner(title,subtitle=None):\n-    if subtitle:\n-      s = title.strip()\n-      t = subtitle.strip()\n-      return s+' - '+t\n-    return title.strip()\n+def render_banner(title, subtitle=None):\n+    if subtitle:\n+        s = title.strip()\n+        t = subtitle.strip()\n+        return f\"{s} - {t}\"\n+    return title.strip()\n \n \n-def render_footer(left,right=None):\n-    if right:\n-      s = left.strip()\n-      t = right.strip()\n-      return s+' - '+t\n-    return left.strip()\n+def render_footer(left, right=None):\n+    if right:\n+        s = left.strip()\n+        t = right.strip()\n+        return f\"{s} - {t}\"\n+    return left.strip()\n \n \n def save_state(path, state):\n     with open(path, \"w\") as f:\n         json.dump(state, f, indent=2)\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "Surgical lens fires at Important on the reformatted banner+footer region; DRY does NOT fire on the same lines (Surgical precedence).",
+      "files": ["src/foo.py"],
+      "allowed_files": ["src/foo.py"],
+      "lens_under_test": "surgical-precedence",
+      "replicate_rule": {"trials": 5, "threshold": 3},
+      "expectations": [
+        {"type": "mechanical", "check": "lens-finding-fires", "params": {"lens": "Surgical", "severity": "Important"}},
+        {"type": "mechanical", "check": "no-lens-findings-overlap-region", "params": {"primary_lens": "Surgical", "secondary_lens": "DRY"}, "prerequisite": {"type": "mechanical", "check": "lens-finding-fires", "params": {"lens": "Surgical", "severity": "Important"}}},
+        {"type": "mechanical", "check": "lens-findings-in-allowed-files", "params": {"ocp_carveout": false}},
+        {"type": "mechanical", "check": "all-findings-have-file-line"}
+      ]
+    },
+    {
+      "id": "2",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`.\n\n```diff\n--- a/src/util.py\n+++ b/src/util.py\n@@ -1,18 +1,18 @@\n import re\n \n _WS_RE = re.compile(r\"\\s+\")\n \n \n def normalize_input(s):\n     \"\"\"Strip surrounding whitespace, collapse internal runs, and lowercase.\"\"\"\n     if s is None:\n         return \"\"\n     s = s.strip()\n     s = _WS_RE.sub(\" \", s)\n     return s.lower()\n \n \n def is_blank(s):\n     return not s or not s.strip()\n--- a/src/parser.py\n+++ b/src/parser.py\n@@ -1,12 +1,30 @@\n import re\n \n+_PARSER_WS_RE = re.compile(r\"\\s+\")\n+\n+\n+def _clean_token(s):\n+    \"\"\"Strip surrounding whitespace, collapse internal runs, lowercase.\"\"\"\n+    if s is None:\n+        return \"\"\n+    s = s.strip()\n+    s = _PARSER_WS_RE.sub(\" \", s)\n+    return s.lower()\n+\n \n def parse_header(line):\n     name, _, value = line.partition(\":\")\n-    return name.strip().lower(), value.strip()\n+    return _clean_token(name), _clean_token(value)\n \n \n def parse_record(text):\n     parts = text.split(\"|\")\n-    return [p.strip().lower() for p in parts]\n+    return [_clean_token(p) for p in parts]\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "DRY lens fires at Minor; finding cites src/util.py as the existing duplicate source.",
+      "files": ["src/parser.py", "src/util.py"],
+      "allowed_files": ["src/parser.py", "src/util.py"],
+      "lens_under_test": "dry",
+      "replicate_rule": {"trials": 5, "threshold": 3},
+      "expectations": [
+        {"type": "mechanical", "check": "lens-finding-fires", "params": {"lens": "DRY", "severity": "Minor"}},
+        {"type": "mechanical", "check": "lens-finding-cites-file", "params": {"lens": "DRY", "file": "src/util.py"}},
+        {"type": "mechanical", "check": "lens-findings-in-allowed-files", "params": {"ocp_carveout": false}},
+        {"type": "mechanical", "check": "all-findings-have-file-line"}
+      ]
+    },
+    {
+      "id": "2-reattrib",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`.\n\n```diff\n--- a/src/util.py\n+++ b/src/util.py\n@@ -1,20 +1,20 @@\n import re\n \n _WS_RE = re.compile(r\"\\s+\")\n MAX_LEN = 1024\n \n \n def normalize_input(s):\n     \"\"\"Strip, collapse, lowercase. Truncates to MAX_LEN to protect downstream buffers.\"\"\"\n     if s is None:\n         return \"\"\n     s = s.strip()\n     s = _WS_RE.sub(\" \", s)\n     s = s.lower()\n     if len(s) > MAX_LEN:\n         s = s[:MAX_LEN]\n     return s\n--- a/src/parser.py\n+++ b/src/parser.py\n@@ -1,12 +1,28 @@\n import re\n \n+_PARSER_WS_RE = re.compile(r\"\\s+\")\n+\n+\n+def _clean_token(s):\n+    \"\"\"Strip, collapse, lowercase. NOTE: does NOT enforce MAX_LEN.\"\"\"\n+    if s is None:\n+        return \"\"\n+    s = s.strip()\n+    s = _PARSER_WS_RE.sub(\" \", s)\n+    return s.lower()\n+\n \n def parse_header(line):\n     name, _, value = line.partition(\":\")\n-    return name.strip().lower(), value.strip()\n+    return _clean_token(name), _clean_token(value)\n \n \n def parse_record(text):\n     parts = text.split(\"|\")\n-    return [p.strip().lower() for p in parts]\n+    # Untrusted user input flows through here from the HTTP layer.\n+    return [_clean_token(p) for p in parts]\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "No direct DRY finding; the duplication is re-attributed to a Correctness/Security finding (DRY (re-attributed)) at Important because parser silently skips MAX_LEN bound that util enforces.",
+      "files": ["src/parser.py", "src/util.py"],
+      "allowed_files": ["src/parser.py", "src/util.py"],
+      "lens_under_test": "dry-reattribution",
+      "replicate_rule": {"trials": 5, "threshold": 3},
+      "expectations": [
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "DRY", "include_reattributed": false}},
+        {"type": "mechanical", "check": "reattributed-finding-fires", "params": {"lens": "DRY", "severity": "Important"}},
+        {"type": "mechanical", "check": "lens-findings-in-allowed-files", "params": {"ocp_carveout": false}},
+        {"type": "mechanical", "check": "all-findings-have-file-line"}
+      ]
+    },
+    {
+      "id": "3",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`.\n\n```diff\n--- a/src/processor.py\n+++ b/src/processor.py\n@@ -1,8 +1,42 @@\n import json\n+import sys\n \n \n def load_records(path):\n     with open(path) as f:\n         return json.load(f)\n+\n+\n+def process_record(raw, out=sys.stdout):\n+    \"\"\"Parse a raw record string and emit a formatted line.\n+\n+    Does two things:\n+      (1) Parse: split on '|', strip each field, coerce the second\n+          field to int, validate that the third field is a known\n+          status code, and assemble a dict.\n+      (2) Emit: format the dict as 'id=<id> qty=<qty> status=<status>'\n+          and write it to `out` with a trailing newline.\n+    \"\"\"\n+    # --- parsing ---\n+    parts = [p.strip() for p in raw.split(\"|\")]\n+    if len(parts) != 3:\n+        raise ValueError(f\"expected 3 fields, got {len(parts)}\")\n+    rec_id = parts[0]\n+    try:\n+        qty = int(parts[1])\n+    except ValueError as e:\n+        raise ValueError(f\"qty must be int: {parts[1]!r}\") from e\n+    status = parts[2]\n+    if status not in {\"OK\", \"WARN\", \"ERR\"}:\n+        raise ValueError(f\"unknown status {status!r}\")\n+    record = {\"id\": rec_id, \"qty\": qty, \"status\": status}\n+\n+    # --- emitting ---\n+    line = f\"id={record['id']} qty={record['qty']} status={record['status']}\\n\"\n+    out.write(line)\n+    return record\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "SRP lens fires at Minor on process_record (parsing and emitting are clearly separable concerns).",
+      "files": ["src/processor.py"],
+      "allowed_files": ["src/processor.py"],
+      "lens_under_test": "srp",
+      "replicate_rule": {"trials": 5, "threshold": 3},
+      "expectations": [
+        {"type": "mechanical", "check": "lens-finding-fires", "params": {"lens": "SRP", "severity": "Minor"}},
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "DRY", "include_reattributed": true}},
+        {"type": "mechanical", "check": "lens-findings-in-allowed-files", "params": {"ocp_carveout": false}},
+        {"type": "mechanical", "check": "all-findings-have-file-line"}
+      ]
+    },
+    {
+      "id": "4",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`. The diff includes one unchanged file (src/registry.py) shown as context so you can see the existing dispatch infrastructure.\n\n```diff\ndiff --git a/src/registry.py b/src/registry.py\n--- a/src/registry.py\n+++ b/src/registry.py\n@@ -1,18 +1,18 @@\n # Existing handler registry — unchanged in this diff, shown for context.\n \n from .handlers import handle_create, handle_update, handle_delete, handle_archive\n \n HANDLERS = {\n     \"create\": handle_create,\n     \"update\": handle_update,\n     \"delete\": handle_delete,\n     \"archive\": handle_archive,\n }\n \n \n def dispatch(op, payload):\n     fn = HANDLERS.get(op)\n     if fn is None:\n         raise KeyError(f\"no handler for {op!r}\")\n     return fn(payload)\n--- a/src/handler.py\n+++ b/src/handler.py\n@@ -1,20 +1,32 @@\n from .handlers import (\n     handle_create,\n     handle_update,\n     handle_delete,\n     handle_archive,\n+    handle_restore,\n )\n \n \n def handle_op(op, payload):\n     if op == \"create\":\n         return handle_create(payload)\n     elif op == \"update\":\n         return handle_update(payload)\n     elif op == \"delete\":\n         return handle_delete(payload)\n     elif op == \"archive\":\n         return handle_archive(payload)\n+    elif op == \"restore\":\n+        return handle_restore(payload)\n     else:\n         raise KeyError(f\"no handler for {op!r}\")\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "OCP lens fires at Minor on handler.py recommending the new arm be added to the existing registry in src/registry.py; finding cites src/registry.py (allowed via ocp carve-out).",
+      "files": ["src/handler.py", "src/registry.py"],
+      "allowed_files": ["src/handler.py"],
+      "lens_under_test": "ocp",
+      "replicate_rule": {"trials": 5, "threshold": 3},
+      "expectations": [
+        {"type": "mechanical", "check": "lens-finding-fires", "params": {"lens": "OCP", "severity": "Minor"}},
+        {"type": "mechanical", "check": "lens-finding-cites-file", "params": {"lens": "OCP", "file": "src/registry.py"}},
+        {"type": "mechanical", "check": "lens-findings-in-allowed-files", "params": {"ocp_carveout": true}},
+        {"type": "mechanical", "check": "all-findings-have-file-line"}
+      ]
+    },
+    {
+      "id": "5",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`.\n\n```diff\n--- a/src/clean.py\n+++ b/src/clean.py\n@@ -12,9 +12,15 @@ def slugify(text):\n     text = text.strip().lower()\n     text = _SLUG_NON_ALNUM_RE.sub(\"-\", text)\n     text = _SLUG_DASH_COLLAPSE_RE.sub(\"-\", text)\n     return text.strip(\"-\")\n \n \n+def slugify_with_max_length(text, max_length):\n+    \"\"\"Slugify `text` and truncate at the last full word fitting under max_length.\"\"\"\n+    slug = slugify(text)\n+    if len(slug) <= max_length:\n+        return slug\n+    truncated = slug[:max_length].rsplit(\"-\", 1)[0]\n+    return truncated or slug[:max_length]\n+\n+\n def is_valid_slug(s):\n     return bool(s) and _SLUG_VALID_RE.match(s) is not None\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "No lens findings — clean, surgical, single-responsibility addition that reuses existing slugify().",
+      "files": ["src/clean.py"],
+      "allowed_files": ["src/clean.py"],
+      "lens_under_test": "negative",
+      "replicate_rule": {"trials": 1, "threshold": 1},
+      "expectations": [
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "Surgical", "include_reattributed": true}},
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "DRY", "include_reattributed": true}},
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "SRP", "include_reattributed": true}},
+        {"type": "mechanical", "check": "lens-finding-does-not-fire", "params": {"lens": "OCP", "include_reattributed": true}},
+        {"type": "mechanical", "check": "all-findings-have-file-line"}
+      ]
+    }
+  ]
+}

--- a/skills/temper/evals/lens_runner.py
+++ b/skills/temper/evals/lens_runner.py
@@ -1,0 +1,334 @@
+"""Mechanical-check matcher module for temper lens evals (Task 5).
+
+Implements the v1 mechanical check set per Design D7. Drives the
+structured-expectation discriminator in `skills/temper/evals/evals.json`.
+
+Parser assumptions (documented inline rather than in a doc block so
+maintainers reading the regexes see them immediately):
+
+- Findings are list items under an `### Issues` or `### Code Review`/
+  similar section. We accept three numbered-item shapes: `N.`, `**N.**`,
+  and `- N.` because reviewer output varies in markdown decoration.
+- A finding "block" runs from its header line until the next finding
+  header OR the next `###` heading OR EOF — whichever comes first.
+- Inside a block we scan child lines (any indentation) for
+  `File: <path>:<lo>-<hi>` (or `:<line>`), `Severity: <Word>`,
+  `Lens: <Name>` or `Lens: <Name> (re-attributed)`.
+- The `section` field is the text of the nearest preceding `###`
+  heading (e.g., "Correctness", "Code Review"). It scopes the
+  reattributed_finding_fires check.
+- Substring-collision guard: lens matching uses an anchored regex
+  `^Lens:\\s+<lens>\\s*(\\(re-attributed\\))?\\s*$` (per Design D7),
+  so `Lens: DRY (re-attributed)` cannot leak into a `lens="DRY"`
+  direct-fire query without the `include_reattributed` opt-in.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+Verdict = Literal["PASS", "FAIL", "N/A"]
+Result = tuple[Verdict, str]
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+_HEADING_RE = re.compile(r"^###\s+(.+?)\s*$")
+# Finding header: numbered item, optionally bold/bulleted.
+_FINDING_HEADER_RE = re.compile(r"^\s*(?:-\s+)?(?:\*\*)?(\d+)\.\s+")
+_FILE_RE = re.compile(r"^\s*[-*]?\s*File:\s+(\S+?):(\d+)(?:-(\d+))?\s*$")
+_SEVERITY_RE = re.compile(r"^\s*[-*]?\s*Severity:\s+(\w+)\s*$")
+_LENS_RE = re.compile(r"^\s*[-*]?\s*Lens:\s+(\S+)\s*(\(re-attributed\))?\s*$")
+
+
+def _parse_findings(output: str) -> list[dict]:
+    """Return list of findings with keys file, line_range, severity, lens,
+    lens_reattributed, section. Pathless findings include file=None."""
+    lines = output.splitlines()
+
+    # Pre-pass: identify boundary line indices (finding headers + ### headings).
+    boundaries: list[int] = []
+    for i, line in enumerate(lines):
+        if _FINDING_HEADER_RE.match(line) or _HEADING_RE.match(line):
+            boundaries.append(i)
+    boundaries.append(len(lines))
+
+    findings: list[dict] = []
+    current_section: str | None = None
+
+    for idx, line in enumerate(lines):
+        h = _HEADING_RE.match(line)
+        if h:
+            current_section = h.group(1)
+            continue
+
+        if not _FINDING_HEADER_RE.match(line):
+            continue
+
+        # Find this finding's end: next boundary strictly after idx.
+        end = next(b for b in boundaries if b > idx)
+
+        block = lines[idx + 1 : end]
+        file_path: str | None = None
+        line_range: tuple[int, int] | None = None
+        severity: str | None = None
+        lens: str | None = None
+        reattributed = False
+
+        for child in block:
+            m = _FILE_RE.match(child)
+            if m:
+                file_path = m.group(1)
+                lo = int(m.group(2))
+                hi = int(m.group(3)) if m.group(3) else lo
+                line_range = (lo, hi)
+                continue
+            m = _SEVERITY_RE.match(child)
+            if m:
+                severity = m.group(1)
+                continue
+            m = _LENS_RE.match(child)
+            if m:
+                lens = m.group(1)
+                reattributed = m.group(2) is not None
+                continue
+
+        findings.append(
+            {
+                "file": file_path,
+                "line_range": line_range,
+                "severity": severity,
+                "lens": lens,
+                "lens_reattributed": reattributed,
+                "section": current_section,
+            }
+        )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check functions
+# ---------------------------------------------------------------------------
+
+
+def all_findings_have_file_line(output: str) -> Result:
+    findings = _parse_findings(output)
+    if not findings:
+        return ("N/A", "no findings parsed")
+    missing = [f for f in findings if f["file"] is None or f["line_range"] is None]
+    if missing:
+        return ("FAIL", f"{len(missing)} finding(s) without File:line")
+    return ("PASS", f"all {len(findings)} finding(s) cite File:line")
+
+
+def lens_findings_in_allowed_files(
+    output: str, fixture: dict, ocp_carveout: bool = True
+) -> Result:
+    allowed = set(fixture.get("allowed_files", []))
+    findings = _parse_findings(output)
+    lens_findings = [f for f in findings if f["lens"]]
+    if not lens_findings:
+        return ("N/A", "no lens-tagged findings")
+
+    violations: list[str] = []
+    for f in lens_findings:
+        if f["file"] is None:
+            continue  # covered by all_findings_have_file_line
+        if f["file"] in allowed:
+            continue
+        if ocp_carveout and f["lens"] == "OCP":
+            continue  # carve-out applies to both direct and re-attributed
+        violations.append(f"{f['lens']}{' (re-attributed)' if f['lens_reattributed'] else ''} cites {f['file']}")
+
+    if violations:
+        return ("FAIL", "; ".join(violations))
+    return ("PASS", f"all {len(lens_findings)} lens finding(s) in allowed_files")
+
+
+def lens_finding_fires(
+    output: str,
+    lens: str,
+    severity: str,
+    include_reattributed: bool = False,
+) -> Result:
+    findings = _parse_findings(output)
+    for f in findings:
+        if f["lens"] != lens:
+            continue
+        if f["lens_reattributed"] and not include_reattributed:
+            continue
+        if f["severity"] == severity:
+            return ("PASS", f"Lens: {lens} at {severity} fires")
+    return ("FAIL", f"no Lens: {lens} finding at Severity: {severity}")
+
+
+def lens_finding_does_not_fire(
+    output: str, lens: str, include_reattributed: bool = False
+) -> Result:
+    findings = _parse_findings(output)
+    for f in findings:
+        if f["lens"] != lens:
+            continue
+        if f["lens_reattributed"] and not include_reattributed:
+            continue
+        return ("FAIL", f"unexpected Lens: {lens} finding at {f['file']}")
+    return ("PASS", f"no Lens: {lens} direct findings")
+
+
+def reattributed_finding_fires(
+    output: str,
+    lens: str,
+    severity: str,
+    section: str | None = None,
+) -> Result:
+    findings = _parse_findings(output)
+    for f in findings:
+        if f["lens"] != lens or not f["lens_reattributed"]:
+            continue
+        if f["severity"] != severity:
+            continue
+        if section is not None and f["section"] != section:
+            continue
+        return ("PASS", f"Lens: {lens} (re-attributed) at {severity} fires")
+    scope = f" in section {section!r}" if section else ""
+    return ("FAIL", f"no Lens: {lens} (re-attributed) at {severity}{scope}")
+
+
+def lens_finding_cites_file(
+    output: str, lens: str, file: str, include_reattributed: bool = False
+) -> Result:
+    findings = _parse_findings(output)
+    for f in findings:
+        if f["lens"] != lens:
+            continue
+        if f["lens_reattributed"] and not include_reattributed:
+            continue
+        if f["file"] == file:
+            return ("PASS", f"Lens: {lens} cites {file}")
+    return ("FAIL", f"no Lens: {lens} finding cites {file}")
+
+
+def _ranges_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    return a[0] <= b[1] and b[0] <= a[1]
+
+
+def no_lens_findings_overlap_region(
+    output: str, primary_lens: str, secondary_lens: str
+) -> Result:
+    findings = _parse_findings(output)
+    primary = [
+        f for f in findings
+        if f["lens"] == primary_lens and not f["lens_reattributed"]
+        and f["file"] and f["line_range"]
+    ]
+    secondary = [
+        f for f in findings
+        if f["lens"] == secondary_lens and not f["lens_reattributed"]
+        and f["file"] and f["line_range"]
+    ]
+    for p in primary:
+        for s in secondary:
+            if p["file"] == s["file"] and _ranges_overlap(p["line_range"], s["line_range"]):
+                return (
+                    "FAIL",
+                    f"{primary_lens} {p['file']}:{p['line_range']} overlaps "
+                    f"{secondary_lens} {s['file']}:{s['line_range']}",
+                )
+    return ("PASS", f"no overlap between {primary_lens} and {secondary_lens} regions")
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher + replicate aggregator
+# ---------------------------------------------------------------------------
+
+# Registry keyed by canonical kebab-case check names (per Design D7). Snake-case
+# aliases accepted for ergonomic Python use; both forms route to the same fn.
+_CHECK_REGISTRY = {
+    "all-findings-have-file-line": all_findings_have_file_line,
+    "lens-findings-in-allowed-files": lens_findings_in_allowed_files,
+    "lens-finding-fires": lens_finding_fires,
+    "lens-finding-does-not-fire": lens_finding_does_not_fire,
+    "reattributed-finding-fires": reattributed_finding_fires,
+    "lens-finding-cites-file": lens_finding_cites_file,
+    "no-lens-findings-overlap-region": no_lens_findings_overlap_region,
+}
+
+# Checks that take (output, fixture, ocp_carveout) — fixture-aware.
+_FIXTURE_AWARE_CHECKS = {"lens-findings-in-allowed-files"}
+
+
+def _normalize_check_name(name: str | None) -> str | None:
+    if name is None:
+        return None
+    return name.replace("_", "-")
+
+
+def evaluate_expectation(
+    expectation: dict, reviewer_output: str, fixture: dict
+) -> Result:
+    """Dispatch by expectation['type']='mechanical' + expectation['check'].
+
+    Schema (per Design D7):
+      {"type": "mechanical", "check": "<kebab-case-name>", "params": {...},
+       "prerequisite": <inline-expectation-dict> | <kebab-name>}
+
+    Both 'params' (canonical per design) and 'args' (legacy) accepted.
+    Both kebab-case and snake_case check names accepted.
+
+    Prerequisite resolution:
+      - If 'prerequisite' is a dict (an inline expectation object), it is
+        evaluated via evaluate_expectation recursively — carrying its own
+        params. This is the production path; required for checks like
+        lens-finding-fires that need lens/severity args.
+      - If 'prerequisite' is a string (legacy by-name reference), the named
+        check is re-run with no args. Only works for zero-arg checks like
+        all-findings-have-file-line.
+    """
+    if expectation.get("type") != "mechanical":
+        return ("N/A", f"unsupported expectation type {expectation.get('type')!r}")
+
+    prereq = expectation.get("prerequisite")
+    if prereq is not None:
+        if isinstance(prereq, dict):
+            prereq_verdict, _ = evaluate_expectation(prereq, reviewer_output, fixture)
+            prereq_label = _normalize_check_name(prereq.get("check")) or "<inline>"
+        else:
+            prereq_name = _normalize_check_name(prereq)
+            overrides = fixture.get("_prereq_overrides", {})
+            if prereq in overrides or prereq_name in overrides:
+                prereq_verdict = overrides.get(prereq, overrides.get(prereq_name))[0]
+            else:
+                prereq_fn = _CHECK_REGISTRY.get(prereq_name)
+                if prereq_fn is None:
+                    return ("N/A", f"unknown prerequisite {prereq!r}")
+                prereq_verdict, _ = prereq_fn(reviewer_output)  # type: ignore[call-arg]
+            prereq_label = str(prereq)  # preserve original casing in rationale
+        if prereq_verdict != "PASS":
+            return ("N/A", f"prereq {prereq_label} failed")
+
+    check_name = _normalize_check_name(expectation.get("check"))
+    fn = _CHECK_REGISTRY.get(check_name)
+    if fn is None:
+        return ("FAIL", f"unknown check {expectation.get('check')!r}")
+
+    # Accept both 'params' (canonical) and 'args' (legacy); params wins on collision.
+    args = {**expectation.get("args", {}), **expectation.get("params", {})}
+    if check_name in _FIXTURE_AWARE_CHECKS:
+        return fn(reviewer_output, fixture, **args)
+    return fn(reviewer_output, **args)
+
+
+def aggregate_replicates(
+    per_trial_verdicts: list[Verdict], threshold: int
+) -> Verdict:
+    """Returns N/A if all trials N/A; PASS if ≥threshold of non-N/A trials
+    are PASS; FAIL otherwise."""
+    non_na = [v for v in per_trial_verdicts if v != "N/A"]
+    if not non_na:
+        return "N/A"
+    passes = sum(1 for v in non_na if v == "PASS")
+    return "PASS" if passes >= threshold else "FAIL"

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -1,0 +1,325 @@
+"""Per-fixture temper lens eval runner (Task 6).
+
+Dispatches the temper-reviewer prompt against each fixture in
+`evals.json`, collects reviewer outputs across N replicate trials, and
+evaluates the fixture's structured expectations via `lens_runner`.
+
+Supports three execution modes:
+  - live: subprocess `claude -p <prompt>` per trial (default)
+  - mock: read canned outputs from `--mock-reviewer <dir>/<id>.txt`
+  - replay: re-evaluate cached outputs from a prior `last_run.json`
+
+Stdlib only; produces human-readable stdout + machine-readable
+`last_run.json` for downstream tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import lens_runner
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EVALS_DIR = Path(__file__).resolve().parent
+_EVALS_JSON = _EVALS_DIR / "evals.json"
+_REVIEWER_PROMPT = _REPO_ROOT / "skills" / "temper" / "temper-reviewer.md"
+_LAST_RUN = _EVALS_DIR / "last_run.json"
+
+_FIXTURE_CONTENT_HEADER = (
+    "## Fixture content (synthetic — review this in lieu of running git commands):\n\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly + dispatch
+# ---------------------------------------------------------------------------
+
+
+def _synth_plan_reference(fixture: dict) -> str:
+    """Synthesize a PR-body-equivalent scope statement from fixture metadata.
+    Ensures the reviewer is NOT in degraded mode (per Design D8) for fixtures
+    that test gating behavior — Surgical Changes at Important requires a
+    stated scope to gate against."""
+    desc = fixture.get("expected_output", "")
+    allowed = fixture.get("allowed_files", [])
+    allowed_str = ", ".join(f"`{p}`" for p in allowed)
+    return (
+        f"## What was requested\n\n{desc}\n\n"
+        f"## Scope\n\nChanges should be confined to: {allowed_str}. "
+        f"Drive-by edits to other files or unrelated changes within these files "
+        f"are out of scope.\n"
+    )
+
+
+def _render_prompt(template: str, fixture: dict) -> str:
+    """Substitute placeholders and append fixture content."""
+    rendered = (
+        template.replace("{DESCRIPTION}", f"Synthetic lens eval fixture: {fixture['id']}")
+        .replace("{PLAN_REFERENCE}", _synth_plan_reference(fixture))
+        .replace("{BASE_SHA}", "FIXTURE_BASE")
+        .replace("{HEAD_SHA}", "FIXTURE_HEAD")
+    )
+    return rendered + "\n\n" + _FIXTURE_CONTENT_HEADER + fixture["prompt"]
+
+
+def _dispatch_live(prompt: str, fixture_id: str, trial: int, timeout: int) -> str | None:
+    """Live-dispatch via `claude -p`. Returns stdout, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["claude", "-p", prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"  [dispatch] timeout on {fixture_id} trial {trial}", file=sys.stderr)
+        return None
+    except FileNotFoundError:
+        print("  [dispatch] `claude` CLI not found on PATH", file=sys.stderr)
+        return None
+    if result.returncode != 0:
+        print(
+            f"  [dispatch] non-zero exit {result.returncode} on {fixture_id} trial {trial}: "
+            f"{result.stderr[:200]}",
+            file=sys.stderr,
+        )
+        return None
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Per-fixture orchestration
+# ---------------------------------------------------------------------------
+
+
+def _resolve_output(
+    fixture: dict,
+    trial: int,
+    *,
+    template: str | None,
+    mock_dir: Path | None,
+    replay_outputs: list[str] | None,
+    timeout: int,
+) -> str | None:
+    if replay_outputs is not None:
+        if trial - 1 < len(replay_outputs):
+            return replay_outputs[trial - 1]
+        return None
+    if mock_dir is not None:
+        path = mock_dir / f"{fixture['id']}.txt"
+        try:
+            return path.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"  [mock] cannot read {path}: {e}", file=sys.stderr)
+            return None
+    assert template is not None
+    prompt = _render_prompt(template, fixture)
+    return _dispatch_live(prompt, fixture["id"], trial, timeout)
+
+
+def _run_fixture(
+    fixture: dict,
+    *,
+    template: str | None,
+    mock_dir: Path | None,
+    replay_outputs: list[str] | None,
+    trials_override: int | None,
+    timeout: int,
+) -> dict:
+    rule = fixture.get("replicate_rule", {"trials": 1, "threshold": 1})
+    n_trials = trials_override if trials_override is not None else rule.get("trials", 1)
+    threshold = rule.get("threshold", 1)
+    if trials_override is not None and threshold > n_trials:
+        threshold = n_trials  # clamp
+
+    reviewer_outputs: list[str | None] = []
+    for trial in range(1, n_trials + 1):
+        out = _resolve_output(
+            fixture,
+            trial,
+            template=template,
+            mock_dir=mock_dir,
+            replay_outputs=replay_outputs,
+            timeout=timeout,
+        )
+        reviewer_outputs.append(out)
+
+    expectation_results: list[dict] = []
+    for expectation in fixture.get("expectations", []):
+        per_trial_verdicts: list[str] = []
+        per_trial_rationales: list[str] = []
+        for out in reviewer_outputs:
+            if out is None:
+                per_trial_verdicts.append("N/A")
+                per_trial_rationales.append("dispatch failure: no reviewer output")
+                continue
+            verdict, rationale = lens_runner.evaluate_expectation(expectation, out, fixture)
+            per_trial_verdicts.append(verdict)
+            per_trial_rationales.append(rationale)
+        aggregated = lens_runner.aggregate_replicates(per_trial_verdicts, threshold)  # type: ignore[arg-type]
+        passes = sum(1 for v in per_trial_verdicts if v == "PASS")
+        rationale = f"{passes}/{n_trials} trials PASS (threshold {threshold})"
+        expectation_results.append(
+            {
+                "expectation": expectation,
+                "per_trial_verdicts": per_trial_verdicts,
+                "per_trial_rationales": per_trial_rationales,
+                "aggregated_verdict": aggregated,
+                "aggregated_rationale": rationale,
+            }
+        )
+
+    # Fixture verdict: FAIL if any expectation FAIL; else PASS if ≥1 PASS; else N/A.
+    verdicts = [r["aggregated_verdict"] for r in expectation_results]
+    if any(v == "FAIL" for v in verdicts):
+        fixture_verdict = "FAIL"
+    elif any(v == "PASS" for v in verdicts):
+        fixture_verdict = "PASS"
+    else:
+        fixture_verdict = "N/A"
+
+    return {
+        "id": fixture["id"],
+        "verdict": fixture_verdict,
+        "trials": n_trials,
+        "threshold": threshold,
+        "expectations": expectation_results,
+        "reviewer_outputs": reviewer_outputs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _format_expectation_label(expectation: dict) -> str:
+    check = expectation.get("check", "?")
+    params = expectation.get("params") or expectation.get("args") or {}
+    if not params:
+        return check
+    inside = ", ".join(f"{k}={v}" for k, v in params.items())
+    return f"{check} {{{inside}}}"
+
+
+def _render_summary(fixture_results: list[dict]) -> str:
+    lines: list[str] = []
+    for fr in fixture_results:
+        lines.append(f"Fixture {fr['id']} [trials={fr['trials']}/{fr['threshold']}]")
+        for er in fr["expectations"]:
+            label = _format_expectation_label(er["expectation"])
+            lines.append(
+                f"  [{er['aggregated_verdict']}] {label} — {er['aggregated_rationale']}"
+            )
+        lines.append(f"  VERDICT: {fr['verdict']}")
+        lines.append("")
+    n_pass = sum(1 for f in fixture_results if f["verdict"] == "PASS")
+    n_fail = sum(1 for f in fixture_results if f["verdict"] == "FAIL")
+    n_na = sum(1 for f in fixture_results if f["verdict"] == "N/A")
+    lines.append("===")
+    lines.append(
+        f"{n_pass}/{len(fixture_results)} fixtures PASS, {n_fail} FAIL, {n_na} N/A"
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run temper lens evals.")
+    p.add_argument("--fixture", help="run only one fixture by id")
+    p.add_argument("--mock-reviewer", help="dir containing <fixture-id>.txt canned outputs")
+    p.add_argument("--replay", help="path to last_run.json to re-evaluate")
+    p.add_argument("--trials-override", type=int, help="override replicate_rule.trials")
+    p.add_argument("--timeout", type=int, default=120, help="per-dispatch timeout in seconds")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    # Load fixtures
+    try:
+        evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"[fatal] cannot load evals.json: {e}", file=sys.stderr)
+        return 2
+
+    fixtures = evals_data.get("evals", [])
+    if args.fixture:
+        fixtures = [f for f in fixtures if f["id"] == args.fixture]
+        if not fixtures:
+            print(f"[fatal] no fixture with id {args.fixture!r}", file=sys.stderr)
+            return 2
+
+    # Resolve mode
+    template: str | None = None
+    mock_dir: Path | None = None
+    replay_by_fixture: dict[str, list[str]] = {}
+
+    if args.replay:
+        try:
+            replay_data = json.loads(Path(args.replay).read_text(encoding="utf-8"))
+            for entry in replay_data.get("fixtures", []):
+                replay_by_fixture[entry["id"]] = entry.get("reviewer_outputs", [])
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"[fatal] cannot load replay file: {e}", file=sys.stderr)
+            return 2
+    elif args.mock_reviewer:
+        mock_dir = Path(args.mock_reviewer)
+        if not mock_dir.is_dir():
+            print(f"[fatal] mock-reviewer dir not found: {mock_dir}", file=sys.stderr)
+            return 2
+    else:
+        try:
+            template = _REVIEWER_PROMPT.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"[fatal] cannot read reviewer template: {e}", file=sys.stderr)
+            return 2
+
+    # Run each fixture
+    fixture_results: list[dict] = []
+    for fixture in fixtures:
+        replay_outputs = replay_by_fixture.get(fixture["id"]) if args.replay else None
+        result = _run_fixture(
+            fixture,
+            template=template,
+            mock_dir=mock_dir,
+            replay_outputs=replay_outputs,
+            trials_override=args.trials_override,
+            timeout=args.timeout,
+        )
+        fixture_results.append(result)
+
+    # Stdout summary
+    print(_render_summary(fixture_results))
+
+    # Persist last_run.json
+    payload: dict[str, Any] = {
+        "run_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "args": vars(args),
+        "fixtures": fixture_results,
+    }
+    try:
+        _LAST_RUN.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError as e:
+        print(f"[warn] cannot write last_run.json: {e}", file=sys.stderr)
+
+    # Exit code
+    if any(fr["verdict"] == "FAIL" for fr in fixture_results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/temper/evals/test_lens_runner.py
+++ b/skills/temper/evals/test_lens_runner.py
@@ -1,0 +1,455 @@
+"""TDD test suite for lens_runner.py (Task 5b).
+
+Synthetic reviewer-output strings drive PASS/FAIL pairs for each
+mechanical check defined in Design D7. The substring-collision
+regression test is load-bearing: it guards against the (re-attributed)
+suffix being matched by a bare-lens `Lens: <name>` regex.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from skills.temper.evals.lens_runner import (
+    aggregate_replicates,
+    all_findings_have_file_line,
+    evaluate_expectation,
+    lens_finding_cites_file,
+    lens_finding_does_not_fire,
+    lens_finding_fires,
+    lens_findings_in_allowed_files,
+    no_lens_findings_overlap_region,
+    reattributed_finding_fires,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic reviewer-output fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_DRY_DIRECT = """
+### Code Review
+- Verdict: Issues Found
+- Issues:
+
+1. **Duplicate helper logic**
+   - File: src/util.py:42-48
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: Same five-line guard appears in two call sites.
+"""
+
+SAMPLE_DRY_REATTRIBUTED = """
+### Code Review
+- Verdict: Issues Found
+
+### Correctness
+- Verdict: Issues Found
+- Issues:
+
+1. **Divergent bound check across copies**
+   - File: src/util.py:42-48
+   - Severity: Important
+   - Lens: DRY (re-attributed)
+   - Issue: Two copies of the bound check disagree on the upper bound.
+"""
+
+SAMPLE_NO_FINDINGS = """
+### Code Review
+- Verdict: Clean
+- Issues: none
+"""
+
+SAMPLE_PATHLESS_FINDING = """
+### Code Review
+- Verdict: Issues Found
+- Issues:
+
+1. **Something vague**
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: No file cited.
+"""
+
+SAMPLE_OCP_DIRECT = """
+### Code Review
+- Verdict: Issues Found
+- Issues:
+
+1. **Dispatch table grew**
+   - File: src/dispatch.py:10-12
+   - Severity: Minor
+   - Lens: OCP
+   - Issue: New case added to switch.
+"""
+
+SAMPLE_SRP_AND_DRY_DISJOINT = """
+### Code Review
+- Verdict: Issues Found
+- Issues:
+
+1. **SRP mixing**
+   - File: src/svc.py:10-20
+   - Severity: Minor
+   - Lens: SRP
+   - Issue: Two responsibilities.
+
+2. **DRY repeat**
+   - File: src/svc.py:50-55
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: Helper duplicated.
+"""
+
+SAMPLE_SRP_AND_DRY_OVERLAP = """
+### Code Review
+- Verdict: Issues Found
+- Issues:
+
+1. **SRP mixing**
+   - File: src/svc.py:10-20
+   - Severity: Minor
+   - Lens: SRP
+   - Issue: Two responsibilities.
+
+2. **DRY repeat**
+   - File: src/svc.py:15-25
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: Helper duplicated.
+"""
+
+FIXTURE_DRY = {"allowed_files": ["src/util.py"]}
+FIXTURE_OCP = {"allowed_files": ["src/feature.py"]}  # dispatch.py NOT listed
+FIXTURE_SVC = {"allowed_files": ["src/svc.py"]}
+
+
+# ---------------------------------------------------------------------------
+# all_findings_have_file_line
+# ---------------------------------------------------------------------------
+
+
+def test_all_findings_have_file_line_pass():
+    verdict, _ = all_findings_have_file_line(SAMPLE_DRY_DIRECT)
+    assert verdict == "PASS"
+
+
+def test_all_findings_have_file_line_fail():
+    verdict, _ = all_findings_have_file_line(SAMPLE_PATHLESS_FINDING)
+    assert verdict == "FAIL"
+
+
+def test_all_findings_have_file_line_na_when_no_findings():
+    verdict, _ = all_findings_have_file_line(SAMPLE_NO_FINDINGS)
+    assert verdict == "N/A"
+
+
+# ---------------------------------------------------------------------------
+# lens_findings_in_allowed_files
+# ---------------------------------------------------------------------------
+
+
+def test_lens_findings_in_allowed_files_pass():
+    verdict, _ = lens_findings_in_allowed_files(
+        SAMPLE_DRY_DIRECT, FIXTURE_DRY, ocp_carveout=True
+    )
+    assert verdict == "PASS"
+
+
+def test_lens_findings_in_allowed_files_fail():
+    # DRY finding cites src/util.py but allowlist is src/feature.py
+    verdict, _ = lens_findings_in_allowed_files(
+        SAMPLE_DRY_DIRECT, FIXTURE_OCP, ocp_carveout=True
+    )
+    assert verdict == "FAIL"
+
+
+def test_lens_findings_in_allowed_files_ocp_carveout_permits_out_of_scope():
+    # OCP finding cites src/dispatch.py NOT in allowed_files → carve-out allows it
+    verdict, _ = lens_findings_in_allowed_files(
+        SAMPLE_OCP_DIRECT, FIXTURE_OCP, ocp_carveout=True
+    )
+    assert verdict == "PASS"
+
+
+def test_lens_findings_in_allowed_files_ocp_reattributed_carveout():
+    sample = SAMPLE_OCP_DIRECT.replace("Lens: OCP", "Lens: OCP (re-attributed)")
+    verdict, _ = lens_findings_in_allowed_files(
+        sample, FIXTURE_OCP, ocp_carveout=True
+    )
+    assert verdict == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# lens_finding_fires
+# ---------------------------------------------------------------------------
+
+
+def test_lens_finding_fires_pass():
+    verdict, _ = lens_finding_fires(SAMPLE_DRY_DIRECT, lens="DRY", severity="Minor")
+    assert verdict == "PASS"
+
+
+def test_lens_finding_fires_fail_wrong_severity():
+    verdict, _ = lens_finding_fires(
+        SAMPLE_DRY_DIRECT, lens="DRY", severity="Important"
+    )
+    assert verdict == "FAIL"
+
+
+def test_lens_finding_fires_excludes_reattributed_by_default():
+    # Re-attributed DRY should NOT count as direct DRY fire
+    verdict, _ = lens_finding_fires(
+        SAMPLE_DRY_REATTRIBUTED, lens="DRY", severity="Important"
+    )
+    assert verdict == "FAIL"
+
+
+def test_lens_finding_fires_includes_reattributed_when_opted_in():
+    verdict, _ = lens_finding_fires(
+        SAMPLE_DRY_REATTRIBUTED,
+        lens="DRY",
+        severity="Important",
+        include_reattributed=True,
+    )
+    assert verdict == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# lens_finding_does_not_fire (incl. load-bearing substring test)
+# ---------------------------------------------------------------------------
+
+
+def test_lens_finding_does_not_fire_pass():
+    verdict, _ = lens_finding_does_not_fire(SAMPLE_NO_FINDINGS, lens="DRY")
+    assert verdict == "PASS"
+
+
+def test_lens_finding_does_not_fire_fail():
+    verdict, _ = lens_finding_does_not_fire(SAMPLE_DRY_DIRECT, lens="DRY")
+    assert verdict == "FAIL"
+
+
+def test_lens_finding_does_not_fire_excludes_reattributed():
+    """Load-bearing substring-collision regression test.
+
+    A `Lens: DRY (re-attributed)` line must NOT match a bare `lens="DRY"`
+    direct-fire check. If the matcher uses `Lens: DRY` as a substring/prefix,
+    this test will fail.
+    """
+    verdict, _ = lens_finding_does_not_fire(
+        SAMPLE_DRY_REATTRIBUTED, lens="DRY", include_reattributed=False
+    )
+    assert verdict == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# reattributed_finding_fires
+# ---------------------------------------------------------------------------
+
+
+def test_reattributed_finding_fires_pass():
+    verdict, _ = reattributed_finding_fires(
+        SAMPLE_DRY_REATTRIBUTED, lens="DRY", severity="Important"
+    )
+    assert verdict == "PASS"
+
+
+def test_reattributed_finding_fires_fail_when_only_direct():
+    verdict, _ = reattributed_finding_fires(
+        SAMPLE_DRY_DIRECT, lens="DRY", severity="Minor"
+    )
+    assert verdict == "FAIL"
+
+
+def test_reattributed_finding_fires_with_section_scoping_pass():
+    verdict, _ = reattributed_finding_fires(
+        SAMPLE_DRY_REATTRIBUTED,
+        lens="DRY",
+        severity="Important",
+        section="Correctness",
+    )
+    assert verdict == "PASS"
+
+
+def test_reattributed_finding_fires_with_section_scoping_fail():
+    verdict, _ = reattributed_finding_fires(
+        SAMPLE_DRY_REATTRIBUTED,
+        lens="DRY",
+        severity="Important",
+        section="Performance",
+    )
+    assert verdict == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# lens_finding_cites_file
+# ---------------------------------------------------------------------------
+
+
+def test_lens_finding_cites_file_pass():
+    verdict, _ = lens_finding_cites_file(
+        SAMPLE_DRY_DIRECT, lens="DRY", file="src/util.py"
+    )
+    assert verdict == "PASS"
+
+
+def test_lens_finding_cites_file_fail():
+    verdict, _ = lens_finding_cites_file(
+        SAMPLE_DRY_DIRECT, lens="DRY", file="src/other.py"
+    )
+    assert verdict == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# no_lens_findings_overlap_region
+# ---------------------------------------------------------------------------
+
+
+def test_no_lens_findings_overlap_region_pass():
+    verdict, _ = no_lens_findings_overlap_region(
+        SAMPLE_SRP_AND_DRY_DISJOINT, primary_lens="SRP", secondary_lens="DRY"
+    )
+    assert verdict == "PASS"
+
+
+def test_no_lens_findings_overlap_region_fail():
+    verdict, _ = no_lens_findings_overlap_region(
+        SAMPLE_SRP_AND_DRY_OVERLAP, primary_lens="SRP", secondary_lens="DRY"
+    )
+    assert verdict == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Prerequisite-N/A dispatch path
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_expectation_prerequisite_na():
+    """When prereq FAILs, expectation returns N/A — not vacuous pass."""
+    expectation = {
+        "type": "mechanical",
+        "check": "lens_finding_does_not_fire",
+        "args": {"lens": "DRY"},
+        "prerequisite": "surgical_fires",
+    }
+    # Force prereq FAIL by registering the named check via fixture
+    fixture = {
+        "allowed_files": ["src/util.py"],
+        "_prereq_overrides": {"surgical_fires": ("FAIL", "stub")},
+    }
+    verdict, rationale = evaluate_expectation(
+        expectation, SAMPLE_DRY_DIRECT, fixture
+    )
+    assert verdict == "N/A"
+    assert "surgical_fires" in rationale
+
+
+def test_evaluate_expectation_dispatches_check():
+    expectation = {
+        "type": "mechanical",
+        "check": "lens_finding_fires",
+        "args": {"lens": "DRY", "severity": "Minor"},
+    }
+    verdict, _ = evaluate_expectation(expectation, SAMPLE_DRY_DIRECT, FIXTURE_DRY)
+    assert verdict == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# Schema-form regression: kebab-case check names + 'params' field (D7 canonical)
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_expectation_kebab_case_check_name():
+    """Canonical kebab-case check names per Design D7 must dispatch."""
+    expectation = {
+        "type": "mechanical",
+        "check": "lens-finding-fires",
+        "params": {"lens": "DRY", "severity": "Minor"},
+    }
+    verdict, _ = evaluate_expectation(expectation, SAMPLE_DRY_DIRECT, FIXTURE_DRY)
+    assert verdict == "PASS"
+
+
+def test_evaluate_expectation_params_field_canonical():
+    """'params' is the canonical field per D7; must be honored."""
+    expectation = {
+        "type": "mechanical",
+        "check": "lens-finding-does-not-fire",
+        "params": {"lens": "Surgical"},
+    }
+    verdict, _ = evaluate_expectation(expectation, SAMPLE_DRY_DIRECT, FIXTURE_DRY)
+    assert verdict == "PASS"
+
+
+def test_evaluate_expectation_inline_prerequisite_with_args():
+    """Production prereq path: prereq is a dict carrying its own args.
+    Required for fixture 1b: surgical-fires prereq needs lens+severity."""
+    # Output where Surgical fires at Important → prereq passes → expectation evaluates
+    output_with_surgical = (
+        "### Code Review\n- Verdict: Issues Found\n\n"
+        "### Issues\n\n"
+        "1. **Drive-by reformat**\n"
+        "   - File: src/foo.py:10-20\n"
+        "   - Severity: Important\n"
+        "   - Lens: Surgical\n"
+        "   - Issue: ...\n"
+    )
+    expectation = {
+        "type": "mechanical",
+        "check": "lens-finding-does-not-fire",
+        "params": {"lens": "DRY"},
+        "prerequisite": {
+            "type": "mechanical",
+            "check": "lens-finding-fires",
+            "params": {"lens": "Surgical", "severity": "Important"},
+        },
+    }
+    fixture = {"allowed_files": ["src/foo.py"]}
+    verdict, _ = evaluate_expectation(expectation, output_with_surgical, fixture)
+    assert verdict == "PASS"  # prereq passed AND DRY did not fire
+
+
+def test_evaluate_expectation_inline_prerequisite_fails_returns_na():
+    """When inline prereq FAILs, expectation returns N/A (not vacuous pass)."""
+    output_no_surgical = SAMPLE_DRY_DIRECT  # no Surgical finding
+    expectation = {
+        "type": "mechanical",
+        "check": "lens-finding-does-not-fire",
+        "params": {"lens": "DRY"},
+        "prerequisite": {
+            "type": "mechanical",
+            "check": "lens-finding-fires",
+            "params": {"lens": "Surgical", "severity": "Important"},
+        },
+    }
+    fixture = {"allowed_files": ["src/util.py"]}
+    verdict, rationale = evaluate_expectation(expectation, output_no_surgical, fixture)
+    assert verdict == "N/A"
+    assert "prereq" in rationale
+
+
+# ---------------------------------------------------------------------------
+# aggregate_replicates
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_replicates_pass_majority():
+    assert aggregate_replicates(["PASS", "PASS", "PASS", "FAIL", "FAIL"], 3) == "PASS"
+
+
+def test_aggregate_replicates_fail_when_below_threshold():
+    assert aggregate_replicates(["PASS", "FAIL", "FAIL", "FAIL", "FAIL"], 3) == "FAIL"
+
+
+def test_aggregate_replicates_all_na_returns_na():
+    assert aggregate_replicates(["N/A", "N/A", "N/A"], 2) == "N/A"
+
+
+def test_aggregate_replicates_na_excluded_from_denominator():
+    # 2 of 3 non-N/A trials PASS, threshold 2 → PASS
+    assert aggregate_replicates(["PASS", "PASS", "N/A", "FAIL"], 2) == "PASS"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/skills/temper/temper-reviewer.md
+++ b/skills/temper/temper-reviewer.md
@@ -52,11 +52,114 @@ git diff {BASE_SHA}..{HEAD_SHA}
 - No scope creep -- implementation matches what was requested?
 
 ### Quality
-- Clean separation of concerns? Single responsibility per component?
+- Clean separation of concerns? Single responsibility per component? (See Targeted Lenses → SRP for the new-function/new-class trigger and OCP carve-out.)
 - Clear naming that matches what things DO, not how they work?
 - Proportional error handling? (validate at boundaries, trust internal contracts — see AI Slop Signals for specific diff-level patterns)
-- DRY principle followed?
+- DRY violations? (See Targeted Lenses → DRY for the formal trigger threshold and co-fire rules.)
 - No overengineering or YAGNI violations?
+
+<!-- CANONICAL: shared/reviewer-common.md — Targeted Lenses -->
+### Targeted Lenses
+
+> Four named lenses focus the review on disciplines code-review agents reliably drift on. Each lens emits findings tagged with the lens name (`Lens: <name>`) in addition to the standard finding fields. **Every finding emitted from any lens MUST include a `File:` line in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (e.g., `File: src/foo.py:42` or `File: src/foo.py:42-58`). Function names, class names, or parenthetical locators (e.g., `src/foo.py (render_banner)` or `src/foo.py:get_timeout_seconds`) are INVALID — use the actual line number from the diff's `@@` hunks. Findings without a numeric `File:` line are invalid and MUST be dropped before emit.** Prose-only suggestions ("consider being more DRY") are not findings.
+
+#### Surgical Changes (precedence: highest)
+
+> Every changed line should trace to what the user asked for. Drive-by reformatting and adjacent-code "improvements" muddy diffs and increase review burden disproportionately.
+>
+> **Flag:**
+> - Reformatting / rewriting of code adjacent to the task but not part of the request.
+> - Deletion of pre-existing dead code that was not orphaned BY this change (mention it instead — do not delete).
+> - Style "corrections" to match the reviewer's taste when existing style is internally consistent.
+> - Modifications to files that share no edited symbols with the rest of the diff and were not named in the request.
+>
+> **Do not flag:**
+> - Removal of imports, variables, or functions orphaned BY this change (in-scope cleanup).
+> - Renames or refactors that the request explicitly called for.
+> - Adjacent-line changes mechanically required by the new code (e.g., adjusting a function signature also updates its one caller).
+>
+> **Severity:** Critical/Important when scope-bleed materially obscures the requested change or introduces regression risk. Minor/Suggestion when bleed is cosmetic.
+>
+> **Degraded mode (no scope context in this prompt):** When the prompt above does NOT contain a clear statement of what was requested (no PR body, no task spec, no plan reference — only the diff and a placeholder), reserve Important/Critical for surgical findings about structural breakage. Scope-bleed findings drop to Suggestion-severity in degraded mode — without a stated request, "in scope" is unknowable for borderline cases.
+>
+> *(In temper, this means `{PLAN_REFERENCE}` rendered as `(none provided — review against general production-readiness criteria)`.)*
+>
+> **Precedence:** When this lens conflicts with DRY/SRP/OCP on the same lines, this lens wins. The other lens may surface the underlying concern as a Minor/Suggestion comment but MUST NOT recommend the fix at higher severity.
+
+#### DRY
+
+> Flag duplication introduced by this diff and new code that bypasses an existing helper.
+>
+> **Flag:**
+> - New code that duplicates an existing helper or utility instead of calling it.
+> - Two near-identical blocks introduced in the same diff (same file or across files).
+> - **Syntactic trigger:** two or more sequences of 5+ contiguous code tokens (excluding whitespace, punctuation, and comments) that are identical or differ only in identifier names. The bar above the trigger: a maintainer would predictably fix the same bug in both places.
+>
+> **Do not flag (over-DRY):**
+> - Two or three similar lines. Inlined repetition under 5 tokens is fine.
+> - Coincidental syntactic similarity where the two blocks express semantically distinct operations and would not co-evolve under a bug fix.
+> - A copy-of-a-pattern that *names* a thing (e.g., two route registrations look similar but the similarity is the framework's API, not the user's code).
+>
+> **Severity ceiling:** Minor (or Suggestion). DRY findings from this lens MUST NOT exceed Minor. If duplication rises to Important (e.g., the two diverging copies will silently behave differently in production), **DROP the Targeted-Lens DRY finding entirely** (do NOT emit it at Minor in parallel — avoids double-counting) and re-emit ONE finding under the appropriate non-lens checklist section (Correctness for behavioral divergence, Architecture and Patterns for structural mixing) at the appropriate severity, tagged on its own line `Lens: DRY (re-attributed)` immediately after the Severity: line. The escape hatch is mutually exclusive with the direct lens finding: emit EITHER a Minor `Lens: DRY` finding OR an Important+ `Lens: DRY (re-attributed)` finding, never both.
+
+#### SRP
+
+> Flag new declarative units (functions, classes, modules) that do two clearly separable jobs.
+>
+> **Flag:**
+> - A new function with two distinct responsibilities (e.g., parses input AND emits output; validates AND persists).
+> - A new class that aggregates two unrelated concerns (e.g., HTTP routing AND business-rule evaluation).
+> - **Module-level SRP** (a new module mixes concerns): surface as an **architectural observation**, not as a refactor recommendation. Module-level SRP NEVER displaces DRY on co-fire.
+>
+> **Do not flag:**
+> - Existing units (this lens applies to NEW or substantially-rewritten declarative units only).
+> - Helpers that compose two operations as a deliberate convenience (e.g., `parse_and_validate(s)` where parsing and validating are tightly coupled by domain).
+>
+> **Severity ceiling:** Minor (or Suggestion). Function- and class-level SRP findings are primary; module-level is architectural observation only.
+
+#### OCP
+
+> Flag a new `elif`, `case`, or `match` arm added to a chain dispatching on a discriminator IFF a registry / strategy table for that discriminator exists elsewhere in the codebase.
+>
+> **Flag conditions (ALL must hold):**
+> - The arm is NEW in this diff (not a modification of an existing arm).
+> - The chain dispatches on a discriminator (string tag, enum, type name).
+> - A registry / strategy dispatch table for the same discriminator exists in the diff's context — and **the finding cites the registry file path in a `File:` line**. The OCP finding's `File:` lines MUST include both the new arm's location AND the registry file path (use two `File:` lines if needed: one for the elif site, one for the registry). Without the registry path explicitly in a `File:` line, the OCP finding is incomplete.
+>
+> **If the cited registry file cannot be located** (the reviewer does not have access to it, or it does not exist), DROP the finding. No false positives.
+>
+> **Out-of-scope-reference carve-out:** OCP findings are the ONLY lens findings permitted to cite a file path that is not directly part of the diff under review. This carve-out is the OCP lens's defining shape (an OCP finding requires pointing at the registry as an alternative). For all other lenses (Surgical, DRY, SRP), every cited file path must be a file appearing in the diff.
+>
+> **Do not flag:**
+> - Conditional chains where no registry exists — extending the only dispatch site is fine.
+> - Chains dispatching on a value that is not a discriminator (e.g., `if x > threshold`).
+>
+> **Severity ceiling:** Minor (or Suggestion).
+>
+> **L / I / D out of scope:** Liskov, Interface-Segregation, and Dependency-Inversion are explicitly NOT part of this lens.
+
+### Lens precedence and co-fire resolution
+
+> When a single set of lines triggers multiple lenses, resolve attribution as follows:
+>
+> 1. **Surgical Changes wins** over DRY/SRP/OCP on the same lines. The other lens may surface the concern as a separate Minor/Suggestion finding on different lines, but MUST NOT recommend the fix at higher severity.
+> 2. **Function- or class-level SRP that fully contains a DRY block wins over DRY** when the unit mixes two clearly separable concerns AND the duplicated block is entirely inside it. Module-level SRP NEVER displaces DRY.
+> 3. **All other co-fires: DRY wins** (including SRP-vs-DRY where SRP is module-level or where SRP unit does not contain the DRY block).
+>
+> | Co-fire condition | Attribute to |
+> |---|---|
+> | Surgical Changes triggers + any other lens (same lines) | Surgical Changes |
+> | Function-SRP fully contains DRY block | SRP |
+> | Class-SRP fully contains DRY block | SRP |
+> | Module-SRP overlaps DRY (any extent) | DRY (module-SRP surfaced separately as architectural observation) |
+> | SRP and DRY apply, SRP unit does NOT contain DRY block | DRY |
+> | OCP and any other lens | Both fire independently (OCP carve-out is structural, not overlapping) |
+>
+> **Worked examples:**
+>
+> - *Drive-by reformat that also collapses duplication.* A diff adds a feature, and also reformats a neighboring function whose old body happened to be duplicated. Attribute to **Surgical Changes** (the reformat is the violation; the duplication-collapse is a side effect). DRY does not fire on these lines.
+> - *New function does parsing + emitting and has a duplicated regex.* A new function `process_record()` parses a row and emits a serialized result, and contains the same regex pattern in two branches. Attribute to **SRP** (function-level, fully contains the DRY block). DRY does not fire as a separate finding.
+> - *New module does parsing + emitting; parsing duplicates an existing util.* A new module mixes parsing and emitting; its parsing function duplicates an existing util elsewhere. Attribute to **DRY** for the duplication (module-SRP never displaces DRY). Surface module-SRP as a separate architectural observation Minor finding.
 
 ### AI Slop Signals
 AI agents produce characteristic padding patterns that aren't bugs but inflate diffs, obscure real changes, and accumulate as maintenance burden. These are typically Minor or Suggestion severity; escalate to Important only when padding materially obscures real changes in the diff. Common patterns include:
@@ -110,10 +213,11 @@ AI agents produce characteristic padding patterns that aren't bugs but inflate d
 ## Report Format
 
 **For each issue found:**
-- File:line reference (be specific, not vague)
+- File:line reference, in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (numeric line refs from the diff's `@@` hunks — function/class names are NOT acceptable substitutes)
 - What's wrong
 - Why it matters
 - Severity classification
+- Lens: Surgical | DRY | SRP | OCP — required when finding originates from a Targeted Lens; omit otherwise. Re-attributed findings use 'Lens: <name> (re-attributed)' on its own line immediately after Severity:.
 - How to fix (if not obvious)
 
 **Report structure:**


### PR DESCRIPTION
## Summary

Adds four named code-review lenses to the canonical reviewer checklist, propagated to both render targets (`temper-reviewer.md`, `build-reviewer-prompt.md`):

- **Surgical Changes** (gating): every changed line should trace to the user's request
- **DRY** (advisory, Minor ceiling): flag duplication / unused existing helpers
- **SRP** (advisory, Minor ceiling): flag mixed-concern new functions/classes
- **OCP** (advisory, Minor ceiling): flag new `elif` arms when a registry exists

Genuinely-Important DRY/SRP/OCP findings re-attribute to Correctness/Architecture with a `Lens: <name> (re-attributed)` audit-trail tag (mutually exclusive with the direct Minor finding). Convergence math is unchanged — the Minor ceiling makes existing severity-mapping (which excludes Minor/Suggestion from gating) treat the advisory lenses correctly with zero orchestrator changes.

## Eval gate

`skills/temper/evals/` ships a full eval harness:
- **7 synthetic fixtures**: surgical (pure + precedence), DRY (direct + re-attribution), SRP, OCP, negative
- **Mechanical matchers** (`lens_runner.py`) with exact-token `Lens:` matching to prevent re-attributed-vs-direct substring collisions; 32 unit tests
- **5-replicate majority rule** for LLM-judged paths
- **Live `claude -p` dispatch** via `run_evals.py` CLI (modes: live / `--mock-reviewer` / `--replay`)

**Acceptance: 7/7 fixtures PASS on live eval run.**

Drift checker (`scripts/check_canonical_drift.py`) guards canonical/build-paraphrase alignment.

## Build pipeline evidence

This PR was built through the full Crucible /build pipeline:
- **Phase 1 (Design):** 4 quality-gate rounds — 17 substantive issues fixed (e.g., `{PLAN_REFERENCE}` leaking into canonical, eval-matcher substring collisions, build-paraphrase budget under-specification)
- **Phase 2 (Plan):** 2 quality-gate rounds — 8+ issues including fixture count off-by-one, missing pre-flight dispatch smoke test, hidden TDD test task. Innovate adopted: matchers-first reordering, `--mock-reviewer` + `--replay` flags, drift-check script
- **Phase 3 (Execute):** 9 tasks across matchers (TDD red→green), canonical+propagation, drift checker, fixtures, runner. Per-task review caught 3 silent-failure bugs (kebab/snake check names, `args` vs `params` field, by-name prereq broken for parameterized checks)
- **Phase 3 (Live eval):** first run 1/7 PASS — surfaced 4 product issues invisible to static review (File: format strictness reviewer-interpretation gap, runner-side degraded-mode bleed-through, D2 drop-direct rule not honored, OCP citation discipline). Fixed in one iteration. Second run 7/7 PASS.
- **Phase 4 (Temper):** 1 fresh-eyes round — Minor prose fix ("Three named lenses" → "Four") and dead-tmpfile cleanup.

## Closes

- Closes #287
- Closes #276 (original simplify-skill version; refiled here)

## Out-of-scope follow-ups identified during innovate

- Lens registry extraction (when temper has 5+ lenses or a second skill wants reuse)
- Real-PR-derived eval fixtures (mining merged Crucible PRs vs synthetic)
- Lens-health telemetry / sunset criteria (per-lens eval pass-rate over time)
- External-review prompt lens awareness (`shared/external-review-prompt.md` uses Fatal/Significant/Minor; needs separate edit + severity mapping)

## Test plan

- [x] `python3 -m pytest skills/temper/evals/test_lens_runner.py` → 32 tests pass
- [x] `python3 -m skills.temper.evals.run_evals` → 7/7 fixtures PASS (15m21s wall clock; `last_run.json` evidence captured locally)
- [x] `python3 scripts/check_canonical_drift.py` → exit 0
- [ ] Manual /temper invocation on a non-lens diff confirms no regression in existing reviewer behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)