### PR TITLE
feat(temper): replace claude -p with stage/collect/score transport (#297)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ eval/**/__pycache__/
 scripts/__pycache__/
 skills/**/__pycache__/
 mcp-servers/**/__pycache__/
+# #297 temper eval calibrate state + baseline + opus-ceiling
+/skills/temper/evals/.calibrate-state/
+/skills/temper/evals/baseline.json
+/skills/temper/evals/.opus-ceiling.json

--- a/skills/temper-eval-calibrate/SKILL.md
+++ b/skills/temper-eval-calibrate/SKILL.md
@@ -97,7 +97,13 @@ On successful score, write `skills/temper/evals/.calibrate-state/<prefix>-<i>-co
 
 ### Step 4: Final consolidation (M-3)
 
-After ALL k iterations succeed (every iteration's `.calibrate-state/<prefix>-<i>-complete` sentinel is present), ALWAYS copy `skills/temper/evals/.calibrate-state/last_run-<prefix>-<k>.json` to `skills/temper/evals/last_run.json` (the shared output the `--compare-baseline` workflow expects). This is unconditional on success — not optional.
+After ALL k iterations succeed (every iteration's `.calibrate-state/<prefix>-<i>-complete` sentinel is present), copy `skills/temper/evals/.calibrate-state/last_run-<prefix>-<k>.json` to `skills/temper/evals/last_run.json` (the shared output the `--compare-baseline` workflow expects). This is unconditional on success — not optional.
+
+**Pre-copy verification (mirrors the sentinel-pair discipline in Step 3b):**
+1. Verify `last_run-<prefix>-<k>.json` exists. If absent, refuse to clobber `last_run.json` and exit with the fatal error `"iteration k completion sentinel present but per-iter file missing at <path>; refusing to consolidate."`
+2. Parse the file as JSON. If parsing fails, refuse with `"per-iter file at <path> is malformed JSON; refusing to consolidate."`
+3. Confirm the `run_id` field equals `<prefix>-<k>`. If it does not, refuse with `"per-iter file at <path> carries run_id=<actual>, expected <prefix>-<k>; refusing to consolidate."`
+4. Only after all three checks pass, perform the copy.
 
 If ANY iteration failed (sentinel missing, score returned 2, or stage refused), do NOTHING in this step: leave `last_run.json` untouched so the operator can inspect the per-iter files manually without a clobbered shared state.
 

--- a/skills/temper-eval-calibrate/SKILL.md
+++ b/skills/temper-eval-calibrate/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: temper-eval-calibrate
+description: Wrapper skill that runs k iterations of (stage → collect-behavior → score) for #290 calibration sweeps. Replaces bash for-loops that cannot invoke session skills. Default k=3. Inlines collect-dispatch behavior per iteration. Idempotent resume via per-iteration sentinels under skills/temper/evals/.calibrate-state/.
+model: opus
+---
+
+<!-- CANONICAL: shared/dispatch-convention.md -->
+
+# Temper Eval Harness — Calibrate Wrapper
+
+**Invocation:**
+```
+/temper-eval-calibrate <run-id-prefix> [--k N] [--source SOURCE] [--fixture <id>]
+                                       [--write-baseline] [--compare-baseline]
+                                       [--trials-override N] [--max-parallel N]
+                                       [--timeout N]
+```
+
+**Pre-conditions:**
+- A Claude Code session is active
+- `<run-id-prefix>` matches `^[A-Za-z0-9_][A-Za-z0-9_-]{0,28}$` (I-9; aligned with `_runid.py`'s `_PREFIX_RE`; reserves 3 chars for `-<i>` suffix)
+
+**Post-conditions:**
+- For each `i in 1..k`, `skills/temper/evals/.calibrate-state/<prefix>-<i>-complete` exists AND `skills/temper/evals/.calibrate-state/last_run-<prefix>-<i>.json` exists with `run_id == <prefix>-<i>`
+- A per-iteration summary line is emitted to stdout
+
+## Procedure
+
+### Step 0: Ordering precondition (2P-FE-6 R3 + F-R4-1, S-1 R5)
+
+**Task 13 (per-iter wiring) lands BEFORE this skill is invoked — verified by sequential task numbering.** Per F-R4-1, Task 13 lands BOTH the `--per-iter` argparse declaration AND the `main()` wiring in a SINGLE atomic commit (Task 4 intentionally omits the argparse declaration to eliminate any silent-drop window). Because Task 13 is numbered ahead of Task 14, operators following the plan sequentially will have `--per-iter` wired before this skill's SKILL.md exists to be invoked. Defense-in-depth: if Task 13 is somehow skipped, `score --per-iter` will raise an argparse "unrecognized arguments" error (no silent drop) — the calibrate skill's Step 3e shell-out will fail loud rather than clobbering shared state.
+
+### Step 1: Validate prefix and k (I-9, M-2)
+
+- `<run-id-prefix>` must match `^[A-Za-z0-9_][A-Za-z0-9_-]{0,28}$` (M-FE-3 R3); refuse with explicit error if not.
+- `--k` (default 3) must be in `[1, 99]` inclusive; refuse if out-of-range. <!-- 2P-R4-2: k cap 99 ties to _PREFIX_RE's 3-char suffix reservation; k>=100 would overflow into a 4-char suffix and silently push the resulting run-id past the 32-char _RUN_ID_RE ceiling. -->
+
+### Step 2: Resolve calibrate-state directory
+
+`STATE_DIR = skills/temper/evals/.calibrate-state/`. If it does not exist, create it (`mkdir -p`).
+
+### Step 3: For each iteration `i in 1..k`
+
+#### 3a. Compute RUN_ID
+
+`RUN_ID = "<prefix>-<i>"`.
+
+#### 3b. Resume idempotency check (SP-β, SP-4, AC-12)
+
+If BOTH of the following are true, **skip iteration entirely** (no stage, no collect, no score, no billing):
+- `skills/temper/evals/.calibrate-state/<prefix>-<i>-complete` exists
+- `skills/temper/evals/.calibrate-state/last_run-<prefix>-<i>.json` exists AND its `run_id` field equals `<prefix>-<i>`
+
+Print: `[skip] iteration <i>: already complete`.
+
+#### 3c. Stage
+
+Shell out via Bash tool: `python -m skills.temper.evals.run_evals stage "$RUN_ID" [--source ...] [--fixture ...] [--trials-override ...] [--timeout ...]`
+
+Pass through whatever flags the user supplied.
+
+#### 3d. Collect-dispatch behavior (inlined; see /temper-eval-collect spec)
+
+Execute the full procedure documented in `skills/temper-eval-collect/SKILL.md` Steps 1–8 against `RUN_ID`.
+
+**Version pin (M1 R8):** this inline-execution reference is pinned to the Steps-1–8 shape at calibrate-skill author time. If `skills/temper-eval-collect/SKILL.md` is later edited (e.g. a Step 4.5 is added, or steps are renumbered), this calibrate skill MUST be re-validated against the new step set — there is NO automatic inheritance. Treat collect SKILL.md edits as breaking changes for the calibrate skill until re-verified.
+
+This includes:
+- Run-id validation (I-9)
+- Dispatch-dir stat (SP-3 step 1)
+- Atomicity probe (SP-3 step 2, F-1)
+- Stale `.tmp` cleanup
+- Stage-manifest read with optional `--timeout` override
+- Idempotency-aware wave dispatch (max_parallel default 6)
+- Atomic per-seq result-file writes with DISPATCH_STATUS sentinels
+- `manifest.jsonl` per-dispatch appends
+- I-10 10 MB result-size ceiling
+- `.collect-status` write with `fsync` (I-12)
+
+The inlined behavior satisfies I-7, I-8, I-10, I-12 identically to standalone `/temper-eval-collect`.
+
+#### 3e. Score (with per-iteration output)
+
+Shell out: `python -m skills.temper.evals.run_evals score "$RUN_ID" --per-iter [--write-baseline] [--compare-baseline]`
+
+The `--per-iter` flag is REQUIRED here (F1): it tells `score` to write to `skills/temper/evals/.calibrate-state/last_run-<prefix>-<i>.json` instead of the shared `last_run.json`. Without `--per-iter`, iterations would clobber each other's output AND collide with operator-owned `last_run.json` artifacts. There is NO run-id-shape heuristic; the routing is explicit.
+
+If score returns 2 (fatal), abort all remaining iterations and surface the error.
+
+#### 3f. Write completion sentinel
+
+On successful score, write `skills/temper/evals/.calibrate-state/<prefix>-<i>-complete` with content `complete-<ISO-8601>`.
+
+#### 3g. Print per-iteration summary
+
+`[iter <i>/<k>] RUN_ID=<RUN_ID> score=<rc>`
+
+### Step 4: Final consolidation (M-3)
+
+After ALL k iterations succeed (every iteration's `.calibrate-state/<prefix>-<i>-complete` sentinel is present), ALWAYS copy `skills/temper/evals/.calibrate-state/last_run-<prefix>-<k>.json` to `skills/temper/evals/last_run.json` (the shared output the `--compare-baseline` workflow expects). This is unconditional on success — not optional.
+
+If ANY iteration failed (sentinel missing, score returned 2, or stage refused), do NOTHING in this step: leave `last_run.json` untouched so the operator can inspect the per-iter files manually without a clobbered shared state.
+
+Rationale: the original "optionally copy" wording produced two equally-valid downstream states (shared file = last iter vs. shared file = stale) with no operator signal to disambiguate. The all-or-nothing rule eliminates the ambiguity. Revisit only if best-or-median canonicalization is genuinely needed (defer to a follow-up ticket).
+
+## Failure Modes
+
+- **Stage fails:** abort remaining iterations; surface the stage error.
+- **Collect crashes mid-wave:** next invocation resumes from missing seqs in that iteration's dispatch dir; once that iteration completes, the calibrate sentinel is written and subsequent iterations proceed.
+- **Score fails (rc=1):** continue to next iteration (a single iteration FAIL is data, not a blocker for k=3).
+- **Score returns rc=2 (fatal):** abort all remaining iterations.
+
+## Invariants
+
+This skill enforces: M-2 (k cap 1..99), I-9 (prefix regex), AC-12 (resume idempotency).

--- a/skills/temper-eval-collect/SKILL.md
+++ b/skills/temper-eval-collect/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: temper-eval-collect
+description: Live-dispatch phase of temper eval harness. Reads stage-manifest.json from a pre-staged dispatch dir; fans Task-tool reviewer dispatches in parallel (max 6); writes per-seq result files; exits. Single bounded session. Pairs with `python -m skills.temper.evals.run_evals stage` and `score`.
+model: opus
+---
+
+<!-- CANONICAL: shared/dispatch-convention.md -->
+
+# Temper Eval Harness — Collect Phase
+
+**Invocation:** `/temper-eval-collect <run-id> [--max-parallel N] [--timeout N]`
+
+**Pre-conditions:**
+- `python -m skills.temper.evals.run_evals stage <run-id>` has run successfully
+- Dispatch dir exists at `${XDG_RUNTIME_DIR:-/tmp}/${USER:-$(id -u)}-crucible-dispatch-<run-id>/`
+- `stage-manifest.json` is present
+
+**Post-conditions:**
+- Each `trials[].seq` in the manifest has either a `<NNN>-result.md` file OR an `<NNN>-result.md` whose first line begins `DISPATCH_STATUS: ERROR:`
+- `.collect-status` exists with two lines: `complete` and `errors: <N>/<total>`
+
+## Procedure
+
+### Step 1: Validate run-id (I-9)
+
+The run-id must match `^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$` (M-FE-3 R3: aligned with `_runid.py`'s `_RUN_ID_RE`; same shape disallows leading `-` to avoid argparse confusion). If not, refuse with explicit error and exit.
+
+### Step 2: Resolve and stat the dispatch directory (SP-3 step 1)
+
+Compute `dispatch_dir = ${XDG_RUNTIME_DIR:-/tmp}/${USER:-$(id -u)}-crucible-dispatch-<run-id>/`.
+
+If `dispatch_dir` does NOT exist, refuse with the explicit error message `no staged run with id <X>` and exit. DO NOT proceed to the atomicity probe — this distinguishes "operator typo / not-yet-staged" from "filesystem cannot do atomic renames."
+
+### Step 3: Behavioral atomicity probe (SP-3 step 2, F-1, SP-α, S-R4-4)
+
+Inside `dispatch_dir`:
+1. Write `.atomicity-probe.tmp` with content `probe`
+2. Call `os.replace(.atomicity-probe.tmp, .atomicity-probe)`
+3. If the rename raises `EXDEV`, `EPERM`, `PermissionError`, or any other `OSError`, refuse with explicit error naming the errno and exit
+4. **S-R4-4 fsync structural probe:** open `.atomicity-probe` for read (or retain the fd from step 1's write), call `os.fsync(fd)`, and catch `OSError` / `EINVAL`. If fsync raises, refuse with the explicit error: `"filesystem rejects fsync (.collect-status happens-before barrier (I-12) cannot be guaranteed); refusing to proceed."` and exit. This catches the case where fsync is structurally rejected on certain FUSE/9P/drvfs mounts. The probe still does NOT prove crash-time durability (kernel/FS guarantee, outside Python introspection) — but it catches the structural-rejection case which would otherwise silently void I-12.
+5. Delete `.atomicity-probe` on success.
+
+This probe verifies same-directory rename returns success without errno AND that fsync is at least structurally accepted by the underlying FS. It does NOT prove crash-time atomicity or durability — those are kernel/FS guarantees outside Python introspection.
+
+**M2 R6 — mixed errno/exception vocabulary is intentional:** the probe lists both Python exception classes (`PermissionError`, `OSError`) and POSIX errno names (`EXDEV`, `EPERM`, `EINVAL`). This is deliberate, not sloppy. Exception classes are what Python-side `except` clauses actually catch; errno names give documentation-side specificity (e.g. `EXDEV` is the precise signal for a cross-device rename, which `OSError` alone does not narrate). Keep both vocabularies side by side — operators reading this skill see the errno, code maintainers writing the catch see the exception class. Do not "normalize" to one or the other.
+
+### Step 4: Clean stale `.tmp` files AND stale `.atomicity-probe` (SP4)
+
+Glob `dispatch_dir/*.tmp` and delete any matches. Stale `.tmp` files are residue from prior crashed runs.
+
+Also delete any stale `dispatch_dir/.atomicity-probe` file (residue from a prior probe that crashed before its cleanup step). The probe in Step 3 writes a fresh one; leaving a stale file behind could mask a probe-side write failure.
+
+### Step 5: Read stage-manifest.json
+
+Load `dispatch_dir / "stage-manifest.json"`. Extract:
+- `trials` list
+- `dispatch_timeout` (default 300)
+- If `--timeout N` was passed on invocation, override dispatch_timeout to N and append `{"event": "timeout-override", "value": N}` to `manifest.jsonl`. Do NOT rewrite stage-manifest.json itself.
+
+### Step 6: Determine missing seqs (idempotency)
+
+For each `trial` in `trials`:
+- If `dispatch_dir / trial.result_file` EXISTS, skip (idempotent resume)
+- Otherwise add to the dispatch queue
+
+If the queue is empty, jump to Step 8.
+
+### Step 7: Dispatch in waves of max_parallel
+
+**M-R7-4 cross-reference:** Task-tool parallel-dispatch limits at 6-way fanout for opus subagents are empirically untested within crucible — see the "Task-tool parallel-dispatch limits" entry in the "Risks + Mitigations" section near the end of this plan. The wave-based dispatch keeps surface bounded; `max_parallel` is operator-tunable via CLI flag without code changes if the 6-way default proves unreliable.
+
+Default `max_parallel = 6`. For each wave (up to ceil(queue_size / max_parallel) waves):
+1. Pre-allocate next `max_parallel` seqs from the queue
+2. For each seq, dispatch a Task tool call:
+   - `subagent_type: general-purpose`
+   - `model: opus`
+   - `prompt`: a pointer prompt of the form `You are a temper reviewer. Read your full instructions at <dispatch_dir>/<NNN>-reviewer.md. Begin by reading that file.`
+   - Carry per-dispatch timeout: dispatch_timeout (default 300)
+3. **Dispatch all in the wave in a single message with parallel tool calls.**
+4. Await all wave results.
+5. For each completed dispatch:
+   - **Result-size check (I-10):** if the subagent's response exceeds 10 MB (10,485,760 bytes), write the ERROR sentinel below instead of the body.
+   - Write the result file atomically:
+     - On OK with non-empty body: write `dispatch_dir / "<NNN>-result.md.tmp"` with content `"DISPATCH_STATUS: OK\n\n" + body`, then `os.replace()` to `<NNN>-result.md`
+     - On OK with EMPTY body (S1): if `body.strip() == ""` (empty OR whitespace-only — aligns with `_parse_result_file`'s strip-check, Task 7 S1 R10 alignment), promote to `"DISPATCH_STATUS: ERROR: empty-body\n\n"` — do NOT write a bare `OK\n\n` result. This ensures `_parse_result_file` sees an explicit ERROR sentinel rather than treating empty-body OK as ambiguous. Same `strip()` semantics on both sides; no silent-N/A whitespace path.
+     - On timeout: write content `"DISPATCH_STATUS: ERROR: timeout\n\n"`
+     - On other error: write content `"DISPATCH_STATUS: ERROR: <reason-token>\n\n"`
+     - On oversize: write content `"DISPATCH_STATUS: ERROR: output-too-large\n\n"`
+   - Append to `manifest.jsonl`: `{"seq": N, "file": "<NNN>-reviewer.md", "role": "temper-reviewer", "phase": "collect", "task": <N>, "status": "completed" | "failed", "duration_s": <s>, "summary": "<one-line>"}`
+
+**S2 — manifest.jsonl serial-append discipline:**
+- All `manifest.jsonl` appends are performed by the main agent SERIALLY after `await all wave dispatches` completes. Do NOT delegate appends to subagents — interleaved writes from N parallel processes corrupt JSONL.
+
+**2P-FE-5 R3 / S-R4-5 — sanitize `summary` to prevent DISPATCH_STATUS confusion:**
+- The `summary` field captures a one-line reviewer-output excerpt. Reviewer outputs may legitimately contain the literal substring `DISPATCH_STATUS:` (e.g. in a citation, a code review note about this very harness, or copy-pasted dispatch headers). If the substring survives into `manifest.jsonl`'s `summary` field, future audit tools that grep `manifest.jsonl` for `DISPATCH_STATUS:` will mis-attribute the summary text as a sentinel line.
+- **Enforcement (S-R4-5):** the sanitize transform lives in `skills/temper/evals/_runid.py` as the pure-Python helper `sanitize_summary(s: str) -> str` (added in Task 1). The skill MUST invoke this helper before writing the `summary` field. Do NOT re-derive the transform inline in the skill body; the helper module is the single source of truth and is covered by `test_sanitize_summary_replaces_literal` in `test_runid.py`.
+- **Concrete shell invocation (2P-5 R5):** when composing a manifest.jsonl entry from the skill body, sanitize the raw summary via:
+
+  ```bash
+  summary_sanitized=$(python -c 'from skills.temper.evals._runid import sanitize_summary; import sys; sys.stdout.write(sanitize_summary(sys.stdin.read()))' <<< "$raw_summary")
+  ```
+
+  Note: `sys.stdout.write(...)` (rather than `print(...)`) preserves the original string byte-for-byte without an appended newline, so the sanitized text round-trips cleanly into a JSON `summary` field. If the skill is composing manifest.jsonl inside a Python helper that already runs in the same process, prefer direct `from skills.temper.evals._runid import sanitize_summary` over shell-out (cheaper, no subprocess).
+- The transform itself: replaces any literal `DISPATCH_STATUS:` substring (case-sensitive, since the sentinel is uppercase-only) with `[DISPATCH_STATUS_LITERAL]`. One-way and lossy by design — auditors who need the raw reviewer output should read the `<NNN>-result.md` file (where the sentinel is unambiguously on the FIRST LINE), not the `manifest.jsonl` summary field.
+
+**S-1 — stage-manifest fingerprint concurrent-restage detection (replaces mtime rule):**
+
+The original mtime-based rule ("refuse if `manifest.jsonl` mtime > start-of-run") self-conflicts because collect's own appends update manifest.jsonl's mtime. Replace with a fingerprint check against `stage-manifest.json` (which is only written by `stage`, never by `collect`):
+
+1. At collect start, compute `stage_manifest_sha = sha256(stage-manifest.json bytes)` and retain in memory.
+2. Before each `manifest.jsonl` append AND before each Task-tool dispatch, re-read `stage-manifest.json` and recompute its sha256. If the sha differs from the start-of-run fingerprint, refuse with the explicit error: `"stage-manifest.json mutated mid-collect (concurrent re-stage detected); aborting."` — and exit WITHOUT writing `.collect-status`.
+3. This works because `stage-manifest.json` is only written by `stage`, never by `collect` — any mtime/content change reflects an external `stage --force` or manual edit.
+
+Re-staging (`stage --force`) while a `/temper-eval-collect` invocation is mid-run is undefined behavior and the fingerprint check catches it loud.
+
+### Step 8: Compute error ratio and write `.collect-status`
+
+After all seqs have result files:
+- Count seqs whose result file's first line begins with `DISPATCH_STATUS: ERROR:` → `errors`
+- `total` = total number of trials in stage-manifest
+
+Write `dispatch_dir / ".collect-status"` with content:
+```
+complete
+errors: <errors>/<total>
+```
+
+Then `fsync(.collect-status)` — this serves as the happens-before barrier for `score` (I-12).
+
+Exit cleanly.
+
+## Failure Modes
+
+- **Dispatch dir missing:** refuse with "no staged run with id <X>"; do NOT probe.
+- **Non-atomic rename:** refuse with the errno reported by os.replace.
+- **Subagent crash mid-wave:** the partial wave's missing seqs are picked up on re-invocation (idempotency).
+- **Compaction during a wave:** orphaned subagent risk (Q-O4); resume re-dispatches missing seqs. Empirically unverified.
+
+## Invariants
+
+This skill enforces: I-7 (atomicity probe), I-8 (`.collect-status` written), I-9 (run-id regex), I-10 (10 MB result-size ceiling), I-12 (`.collect-status` fsync barrier).
+
+## Note on wave-parallelism verification (2P-2)
+
+Wave-parallelism is a skill-execution-time behavior — the Task tool fan-out happens inside an agentic loop and is not introspectable from pytest. AC-5 (collect produces result files) alone does NOT verify parallelism; it only verifies completeness. True parallelism verification requires manual post-merge inspection of an actual `/temper-eval-collect` run (e.g. wall-clock measurement: 6 dispatches at 60 s each should complete in ~60-90 s, not 360 s). Treat the manual measurement as a one-time post-merge validation, not as a per-PR gate.

--- a/skills/temper/evals/_dispatch_paths.py
+++ b/skills/temper/evals/_dispatch_paths.py
@@ -1,0 +1,26 @@
+"""Dispatch-dir path resolution + fixture hashing. M-α, S-A, I-9."""
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+def resolve_dispatch_dir(run_id: str) -> Path:
+    """Resolve XDG_RUNTIME_DIR or /tmp + USER or UID namespacing.
+
+    M-α: USER may be unset in container environments.
+    """
+    base = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+    user = os.environ.get("USER") or str(os.getuid())
+    return Path(base) / f"{user}-crucible-dispatch-{run_id}"
+
+
+def fixture_sha(fixture_record: dict) -> str:
+    """S-A: sha256 of canonical JSON of the evals.json fixture record."""
+    canonical = json.dumps(fixture_record, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def template_sha(template_path: Path) -> str:
+    """sha256 of temper-reviewer.md at stage time."""
+    return hashlib.sha256(template_path.read_bytes()).hexdigest()

--- a/skills/temper/evals/_runid.py
+++ b/skills/temper/evals/_runid.py
@@ -1,0 +1,43 @@
+"""Run-id validation utilities. I-9 enforcement."""
+import re
+
+# 2P-4: first char must NOT be `-` (else run-id parses as a CLI flag downstream).
+# Subsequent chars may include `-`.
+# M-R7-1: leading underscore is technically legal; treated equivalent to alphanumeric for path-traversal safety (`_foo` resolves identically to `foo` w.r.t. directory escape).
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$")
+# 2P-R4-1: 29 chars max = 32 (RUN_ID cap) - 3 ("-<i>" suffix where i=1..99).
+# M-1 R5: 3 chars is the WORST-CASE suffix budget (i=10..99 → "-NN" = 3 chars).
+# For i=1..9 the suffix is only "-N" (2 chars), so a 30-char prefix would still
+# fit for those iterations — but we use the worst-case bound uniformly to keep
+# the validator simple and avoid leaking the k value into prefix validation.
+_PREFIX_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,28}$")
+
+
+def validate_run_id(run_id: str) -> None:
+    """Raise ValueError if run-id violates I-9."""
+    if not _RUN_ID_RE.fullmatch(run_id):
+        raise ValueError(
+            f"invalid run-id {run_id!r}: must match {_RUN_ID_RE.pattern}"
+        )
+
+
+def validate_prefix(prefix: str) -> None:
+    """Raise ValueError if calibrate prefix violates I-9 + 3-char iter suffix budget."""
+    if not _PREFIX_RE.fullmatch(prefix):
+        raise ValueError(
+            f"invalid run-id prefix {prefix!r}: must match {_PREFIX_RE.pattern} "
+            f"(reserves 3 chars for `-<i>` iteration suffix)"
+        )
+
+
+# S-R4-5: pure-Python sanitize helper. Lives here (not just in SKILL.md docs)
+# so it is testable + invokable by any future tooling that writes manifest.jsonl
+# summary fields. SKILL.md Step 7 invokes this helper rather than re-deriving the
+# transform inline.
+def sanitize_summary(s: str) -> str:
+    """2P-FE-5 R3 / S-R4-5: prevent reviewer text from spoofing the DISPATCH_STATUS
+    sentinel when grepped from manifest.jsonl. Replaces any literal
+    `DISPATCH_STATUS:` substring (case-sensitive) with `[DISPATCH_STATUS_LITERAL]`.
+    One-way and lossy by design — auditors who need the raw reviewer output
+    should read the `<NNN>-result.md` file, not the manifest.jsonl summary."""
+    return s.replace("DISPATCH_STATUS:", "[DISPATCH_STATUS_LITERAL]")

--- a/skills/temper/evals/bootstrap_snapshot.py
+++ b/skills/temper/evals/bootstrap_snapshot.py
@@ -1,0 +1,97 @@
+"""Canonical snapshot bootstrap + verify for F2 regression coverage.
+
+Reviewer outputs are deterministic via the committed mock-fixtures/, so the snapshot
+encodes the verdict-tier of the pre-#297 legacy path. Commit BOTH this script and the
+generated `mock_snapshot.json` in the same commit.
+
+Modes (S1 R8):
+  python -m skills.temper.evals.bootstrap_snapshot           # VERIFY: re-execute
+                                                              # mock-reviewer, diff
+                                                              # against existing
+                                                              # snapshot, exit
+                                                              # nonzero on drift.
+                                                              # Bootstraps if file
+                                                              # is absent.
+  python -m skills.temper.evals.bootstrap_snapshot --force   # Overwrite existing
+                                                              # snapshot (intentional
+                                                              # re-bootstrap).
+Verify-mode is the canonical pre-Task-9 invocation: idempotent + drift-detecting.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# 2P-R4-3: Path(__file__).resolve() handles symlinked checkouts uniformly
+# (matches the resolution used by test_legacy_modes.py).
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_SNAPSHOT = _REPO_ROOT / "skills" / "temper" / "evals" / "mock_snapshot.json"
+_MOCK_DIR = _REPO_ROOT / "skills" / "temper" / "evals" / "mock-fixtures"
+
+def main() -> int:
+    # S1 R8: default behavior = VERIFY mode (idempotent re-run, compares against
+    # existing snapshot). `--force` overwrites. Verify-mode is the canonical pre-
+    # Task-9 invocation; it catches snapshot drift from environment/code changes
+    # even when the Python-pin assertion would otherwise pass.
+    force = "--force" in sys.argv[1:]
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "last_run.json"
+        env = {**os.environ, "TEMPER_LAST_RUN_OVERRIDE": str(out)}
+        subprocess.run(
+            [sys.executable, "-m", "skills.temper.evals.run_evals",
+             "--mock-reviewer", str(_MOCK_DIR)],
+            check=True, cwd=str(_REPO_ROOT), env=env,
+        )
+        data = json.loads(out.read_text())
+        verdicts = {f["id"]: f["verdict"] for f in data["fixtures"]}
+
+    # S1 R8: VERIFY mode — snapshot exists and no --force. Re-execute mock-reviewer,
+    # compare against the committed snapshot; exit nonzero with diff on mismatch.
+    if _SNAPSHOT.exists() and not force:
+        existing = json.loads(_SNAPSHOT.read_text())
+        existing_verdicts = existing.get("verdicts", {})
+        if existing_verdicts != verdicts:
+            print(f"[bootstrap][drift] snapshot at {_SNAPSHOT} disagrees with "
+                  f"freshly-executed mock-reviewer output.", file=sys.stderr)
+            all_ids = sorted(set(existing_verdicts) | set(verdicts))
+            for fid in all_ids:
+                e, n = existing_verdicts.get(fid), verdicts.get(fid)
+                if e != n:
+                    print(f"  {fid}: snapshot={e!r} current={n!r}", file=sys.stderr)
+            print(f"[bootstrap] investigate before re-bootstrapping. To overwrite "
+                  f"intentionally, re-run with --force.", file=sys.stderr)
+            return 3
+        print(f"[bootstrap] verify-mode OK: snapshot matches current output.", file=sys.stderr)
+        return 0
+    # S-R7-2: pin the snapshot to the bootstrapping Python's MAJOR.MINOR so cross-env
+    # drift surfaces loudly at test time rather than as a mysterious CI failure.
+    snapshot_payload = {
+        "bootstrap_python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "verdicts": verdicts,
+    }
+    # S-R4-2: refuse to write a hollow snapshot. If the subprocess silently
+    # produced <7 fixtures or missing verdicts, the test would later pass
+    # trivially — catch it at bootstrap time instead.
+    if len(verdicts) < 7:
+        print(f"[bootstrap][fatal] only {len(verdicts)} fixtures captured; expected >=7. "
+              f"Refusing to write a hollow snapshot.", file=sys.stderr)
+        return 2
+    if not all(isinstance(v, str) and v for v in verdicts.values()):
+        print(f"[bootstrap][fatal] one or more fixtures missing verdict strings. "
+              f"Refusing to write a hollow snapshot.", file=sys.stderr)
+        return 2
+    _SNAPSHOT.write_text(json.dumps(snapshot_payload, indent=2, sort_keys=True))
+    # Re-read and re-assert post-write (defense in depth against partial-write/IO truncation)
+    reread = json.loads(_SNAPSHOT.read_text())
+    reread_verdicts = reread.get("verdicts", {})
+    assert len(reread_verdicts) >= 7 and all(reread_verdicts.values()), \
+        "post-write snapshot validation failed; refuse to declare success"
+    assert reread.get("bootstrap_python"), "missing bootstrap_python pin in snapshot"
+    print(f"[bootstrap] wrote {_SNAPSHOT}", file=sys.stderr)
+    print(f"[bootstrap] REVIEW THE DIFF then `git add` and commit.", file=sys.stderr)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/temper/evals/bootstrap_snapshot.py
+++ b/skills/temper/evals/bootstrap_snapshot.py
@@ -29,6 +29,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 _SNAPSHOT = _REPO_ROOT / "skills" / "temper" / "evals" / "mock_snapshot.json"
 _MOCK_DIR = _REPO_ROOT / "skills" / "temper" / "evals" / "mock-fixtures"
+_EVALS_JSON = _REPO_ROOT / "skills" / "temper" / "evals" / "evals.json"
 
 def main() -> int:
     # S1 R8: default behavior = VERIFY mode (idempotent re-run, compares against
@@ -46,6 +47,8 @@ def main() -> int:
         )
         data = json.loads(out.read_text())
         verdicts = {f["id"]: f["verdict"] for f in data["fixtures"]}
+
+    expected_n = len(json.loads(_EVALS_JSON.read_text())["evals"])
 
     # S1 R8: VERIFY mode — snapshot exists and no --force. Re-execute mock-reviewer,
     # compare against the committed snapshot; exit nonzero with diff on mismatch.
@@ -72,10 +75,10 @@ def main() -> int:
         "verdicts": verdicts,
     }
     # S-R4-2: refuse to write a hollow snapshot. If the subprocess silently
-    # produced <7 fixtures or missing verdicts, the test would later pass
+    # produced fewer fixtures than evals.json declares, the test would later pass
     # trivially — catch it at bootstrap time instead.
-    if len(verdicts) < 7:
-        print(f"[bootstrap][fatal] only {len(verdicts)} fixtures captured; expected >=7. "
+    if len(verdicts) < expected_n:
+        print(f"[bootstrap][fatal] only {len(verdicts)} fixtures captured; expected >={expected_n}. "
               f"Refusing to write a hollow snapshot.", file=sys.stderr)
         return 2
     if not all(isinstance(v, str) and v for v in verdicts.values()):
@@ -86,7 +89,7 @@ def main() -> int:
     # Re-read and re-assert post-write (defense in depth against partial-write/IO truncation)
     reread = json.loads(_SNAPSHOT.read_text())
     reread_verdicts = reread.get("verdicts", {})
-    assert len(reread_verdicts) >= 7 and all(reread_verdicts.values()), \
+    assert len(reread_verdicts) >= expected_n and all(reread_verdicts.values()), \
         "post-write snapshot validation failed; refuse to declare success"
     assert reread.get("bootstrap_python"), "missing bootstrap_python pin in snapshot"
     print(f"[bootstrap] wrote {_SNAPSHOT}", file=sys.stderr)

--- a/skills/temper/evals/bootstrap_snapshot.py
+++ b/skills/temper/evals/bootstrap_snapshot.py
@@ -89,9 +89,14 @@ def main() -> int:
     # Re-read and re-assert post-write (defense in depth against partial-write/IO truncation)
     reread = json.loads(_SNAPSHOT.read_text())
     reread_verdicts = reread.get("verdicts", {})
-    assert len(reread_verdicts) >= expected_n and all(reread_verdicts.values()), \
-        "post-write snapshot validation failed; refuse to declare success"
-    assert reread.get("bootstrap_python"), "missing bootstrap_python pin in snapshot"
+    # QG R1 Fix 5: `assert` is stripped under `python -O`, defeating the
+    # defense-in-depth check the comment promises. Use explicit raise.
+    if not (len(reread_verdicts) >= expected_n and all(reread_verdicts.values())):
+        raise RuntimeError(
+            "post-write snapshot validation failed; refuse to declare success"
+        )
+    if not reread.get("bootstrap_python"):
+        raise RuntimeError("missing bootstrap_python pin in snapshot")
     print(f"[bootstrap] wrote {_SNAPSHOT}", file=sys.stderr)
     print(f"[bootstrap] REVIEW THE DIFF then `git add` and commit.", file=sys.stderr)
     return 0

--- a/skills/temper/evals/mock-fixtures/1a.txt
+++ b/skills/temper/evals/mock-fixtures/1a.txt
@@ -1,0 +1,20 @@
+### Code Review
+
+Verdict: changes-requested
+
+The diff is mostly low-risk reformatting and an unrelated helper addition, but
+the `render_banner` rewrite mixes a behavioral string-format change with the
+PEP8 reformat — the Surgical lens flags the scope bleed.
+
+### Issues
+
+1. render_banner reformat couples whitespace fix with f-string conversion
+   - File: src/foo.py:20-23
+   - Severity: Important
+   - Lens: Surgical
+   The diff at `render_banner` simultaneously (a) fixes the indent + comma
+   spacing and (b) rewrites the return expression from string concatenation
+   to an f-string. Either change alone is fine, but combining them in one
+   commit makes the formatting churn hide a (trivially equivalent but still
+   distinct) expression rewrite. Split the f-string conversion into its own
+   commit so the formatter pass is purely mechanical.

--- a/skills/temper/evals/mock-fixtures/1b.txt
+++ b/skills/temper/evals/mock-fixtures/1b.txt
@@ -1,0 +1,21 @@
+### Code Review
+
+Verdict: changes-requested
+
+Surgical fires here for the same reason as in fixture 1a, but spanning the
+combined `render_banner` + `render_footer` region. DRY would be tempting
+(both functions share a near-identical shape) but Surgical precedence applies:
+the immediate problem is scope, not duplication.
+
+### Issues
+
+1. Banner+footer reformat couples whitespace fix with f-string conversion
+   - File: src/foo.py:20-40
+   - Severity: Important
+   - Lens: Surgical
+   `render_banner` and `render_footer` are both reformatted AND switched
+   from `+`-concatenation to f-strings in a single hunk. The formatting
+   churn and the expression rewrite should be separated. (Surgical
+   precedence: do not file a DRY finding for the banner/footer near-clone
+   here — the duplication is real but the immediate ask is to land the
+   reformat surgically; a DRY refactor belongs in a follow-up.)

--- a/skills/temper/evals/mock-fixtures/2-reattrib.txt
+++ b/skills/temper/evals/mock-fixtures/2-reattrib.txt
@@ -1,0 +1,20 @@
+### Correctness
+
+The duplication between `_clean_token` and `normalize_input` is real but
+re-attributed: this is a Correctness/Security issue, not a stylistic DRY
+nit. `util.normalize_input` enforces a `MAX_LEN` truncation on untrusted
+input; the new parser-side helper silently drops that bound.
+
+### Issues
+
+1. parser._clean_token bypasses util.MAX_LEN bound on untrusted input
+   - File: src/parser.py:15-22
+   - Severity: Important
+   - Lens: DRY (re-attributed)
+   `parse_record` now feeds untrusted HTTP-layer input through
+   `_clean_token`, which deliberately drops the `MAX_LEN` truncation
+   that `util.normalize_input` applies. Two near-identical helpers
+   exist (DRY), but the dangerous half of the divergence is that one
+   silently relaxes a bound the other enforces. Re-attributing this
+   from DRY → Correctness: either call `normalize_input` from
+   `parser.py` or apply the same `MAX_LEN` cap inline.

--- a/skills/temper/evals/mock-fixtures/2.txt
+++ b/skills/temper/evals/mock-fixtures/2.txt
@@ -1,0 +1,21 @@
+### Code Review
+
+Verdict: changes-requested
+
+The new `_clean_token` helper in `src/parser.py` duplicates the
+already-public `normalize_input` from `src/util.py` (strip → collapse
+whitespace → lowercase). The DRY lens fires at Minor — the right fix is
+to import `util.normalize_input` instead of re-rolling it.
+
+### Issues
+
+1. _clean_token re-implements util.normalize_input
+   - File: src/util.py:6-12
+   - Severity: Minor
+   - Lens: DRY
+   The body of `_clean_token` is the same algorithm as
+   `normalize_input` already exposed from `src/util.py` (strip,
+   regex-collapse runs of whitespace, lowercase). Import and reuse
+   the existing helper rather than copying it — the duplicate regex
+   `_PARSER_WS_RE` is also redundant. Drop `_clean_token` and call
+   `normalize_input` directly from `parse_header` and `parse_record`.

--- a/skills/temper/evals/mock-fixtures/3.txt
+++ b/skills/temper/evals/mock-fixtures/3.txt
@@ -1,0 +1,20 @@
+### Code Review
+
+Verdict: changes-requested
+
+`process_record` interleaves two clearly separable phases — parse and
+emit — in a single function. SRP fires at Minor: pull the parse step
+out into its own helper so each layer is independently testable.
+
+### Issues
+
+1. process_record mixes parsing and side-effecting emission
+   - File: src/processor.py:10-35
+   - Severity: Minor
+   - Lens: SRP
+   The function body is split into two commented sections (`--- parsing
+   ---` and `--- emitting ---`) — that comment structure is itself a
+   signal that two responsibilities live here. Extract a pure
+   `_parse_record(raw) -> dict` helper and let `process_record` only
+   handle the formatting + write. Tests for the parser then need not
+   capture stdout.

--- a/skills/temper/evals/mock-fixtures/4.txt
+++ b/skills/temper/evals/mock-fixtures/4.txt
@@ -1,0 +1,22 @@
+### Code Review
+
+Verdict: changes-requested
+
+The diff hardcodes a new `restore` branch into `handle_op`'s if/elif
+ladder while the project already exposes a `HANDLERS` registry in
+`src/registry.py` that does exactly this dispatch. OCP fires at Minor:
+add the new arm to the registry instead of growing the conditional.
+
+### Issues
+
+1. handle_op grows an if/elif chain instead of using the existing registry
+   - File: src/registry.py:5-10
+   - Severity: Minor
+   - Lens: OCP
+   `src/registry.py` already maintains a `HANDLERS` dict mapping op-name
+   to handler function, and exposes `dispatch(op, payload)` for callers.
+   The new `restore` arm should be added by registering
+   `"restore": handle_restore` in `HANDLERS` (and routing `handle_op`
+   through `dispatch`), not by extending the elif ladder in
+   `src/handler.py`. Each future op then becomes a one-line registry
+   entry — open for extension, closed for modification.

--- a/skills/temper/evals/mock-fixtures/5.txt
+++ b/skills/temper/evals/mock-fixtures/5.txt
@@ -1,0 +1,12 @@
+### Code Review
+
+Verdict: approve
+
+`slugify_with_max_length` is a clean, surgical addition: it reuses the
+existing `slugify` helper rather than re-implementing slug logic, owns
+a single responsibility (length-bounded truncation at a word boundary),
+and leaves the rest of the module untouched. No lens findings.
+
+### Issues
+
+No findings.

--- a/skills/temper/evals/mock-fixtures/6-tenancy-forged-callback.txt
+++ b/skills/temper/evals/mock-fixtures/6-tenancy-forged-callback.txt
@@ -1,0 +1,24 @@
+### Code Review
+
+Verdict: changes-requested
+
+The new `on_order_paid` webhook handler verifies the per-tenant
+signature correctly, but the SQL UPDATE only filters by `order_id`.
+A forged callback with a valid signature for tenant-A whose payload
+references an order_id owned by tenant-B will silently mutate
+tenant-B's row. Tenancy fires at Important.
+
+### Issues
+
+1. on_order_paid UPDATE missing tenant_id filter — cross-tenant write
+   - File: src/webhooks.py:12-22
+   - Severity: Important
+   - Category: Tenancy
+   The UPDATE statement filters only on `order_id`, but `orders` is a
+   multi-tenant table (rows carry both `tenant_id` and `order_id`).
+   Signature verification establishes WHICH tenant the caller speaks
+   for, but does not bind the affected row to that tenant. Resolve
+   the tenant from the verified auth context and add
+   `AND tenant_id = :tenant_id` to the WHERE clause; otherwise a
+   correctly-signed callback from tenant-A can mutate any order whose
+   id is known/guessable across the whole table.

--- a/skills/temper/evals/mock-fixtures/7-rollback-orphan-fk.txt
+++ b/skills/temper/evals/mock-fixtures/7-rollback-orphan-fk.txt
@@ -1,0 +1,25 @@
+### Code Review
+
+Verdict: changes-requested
+
+The `downgrade()` step drops `regions` with CASCADE (which drops the
+foreign-key constraint) but does NOT drop the `customers.region_id`
+column. After a downgrade, re-running `upgrade()` will fail at
+`op.add_column("customers", ...)` because the column still exists.
+Rollback fires at Important.
+
+### Issues
+
+1. downgrade() leaves customers.region_id orphaned — re-upgrade fails
+   - File: migrations/20260521_add_regions.py:28-31
+   - Severity: Important
+   - Category: Rollback
+   `op.execute("DROP TABLE regions CASCADE")` removes the parent
+   table and the FK constraint, but the child column
+   `customers.region_id` survives. A subsequent `upgrade()` then
+   collides on `add_column` with "column already exists". The
+   downgrade must also `op.drop_constraint("fk_customers_region",
+   "customers", type_="foreignkey")` and
+   `op.drop_column("customers", "region_id")` before dropping
+   `regions`. Reversibility of migrations is a hard requirement —
+   without it, prod rollback ladders break.

--- a/skills/temper/evals/mock-fixtures/8-defense-in-depth-not-slop.txt
+++ b/skills/temper/evals/mock-fixtures/8-defense-in-depth-not-slop.txt
@@ -1,0 +1,22 @@
+### Code Review
+
+Verdict: approve-with-nits
+
+The added `assert_can_read_tenant` call is a deliberate belt-and-
+suspenders layer alongside the RLS enforcement at the connection
+level — that is correct defense in depth, not duplicated work, and
+should not be flagged. The unrelated rename of `get_orderr` →
+`get_order_legacy` is a scope bleed worth noting.
+
+### Issues
+
+1. Typo-fix rename mixed into a security-layer change
+   - File: src/orders.py:21-22
+   - Severity: Minor
+   - Lens: Surgical
+   The rename from `get_orderr` to `get_order_legacy` is a
+   reasonable cleanup but it lands in the same commit as the
+   tenancy belt-and-suspenders addition. Either change alone is
+   fine; combining them makes the diff harder to bisect if the
+   security-layer change ever needs to be reverted. Split the
+   rename into its own commit.

--- a/skills/temper/evals/mock_snapshot.json
+++ b/skills/temper/evals/mock_snapshot.json
@@ -1,0 +1,15 @@
+{
+  "bootstrap_python": "3.12",
+  "verdicts": {
+    "1a": "PASS",
+    "1b": "PASS",
+    "2": "PASS",
+    "2-reattrib": "PASS",
+    "3": "PASS",
+    "4": "PASS",
+    "5": "PASS",
+    "6-tenancy-forged-callback": "PASS",
+    "7-rollback-orphan-fk": "PASS",
+    "8-defense-in-depth-not-slop": "PASS"
+  }
+}

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -38,6 +38,11 @@ _LAST_RUN = (
     if os.environ.get("TEMPER_LAST_RUN_OVERRIDE")
     else _EVALS_DIR / "last_run.json"
 )
+# SP-R7-C: declared in Task 6 (not Task 8) so test_run_evals_score.py's
+# `_seed_dispatch_dir` helper can `monkeypatch.setattr(run_evals, "_BASELINE_PATH", ...)`
+# without raising AttributeError. The `_write_baseline` / `_compare_baseline` helper
+# functions that USE this constant are still added in Task 8 (stubs added below in Task 6).
+_BASELINE_PATH = _EVALS_DIR / "baseline.json"
 
 _FIXTURE_CONTENT_HEADER = (
     "## Fixture content (synthetic — review this in lieu of running git commands):\n\n"
@@ -309,8 +314,28 @@ def _run_fixture(
         )
         reviewer_outputs.append(out)
 
+    return _aggregate_from_outputs(
+        fixture, reviewer_outputs, n_trials=n_trials, threshold=threshold
+    )
+
+
+def _aggregate_from_outputs(
+    fix: dict,
+    reviewer_outputs: list[str | None],
+    *,
+    # S2 R8/R9: closure deps identified in Step 0 (/tmp/_aggregate_closure_deps.txt).
+    # Explicit kwargs eliminate the implicit-lexical-capture footgun that would
+    # surface as NameError at first call rather than a clean assertion failure.
+    n_trials: int,
+    threshold: int,
+) -> dict:
+    """Behavioral equivalent of _run_fixture's post-resolution aggregation.
+
+    Takes already-resolved per-trial reviewer outputs (None for missing/ERROR).
+    Returns the per-fixture result dict.
+    """
     expectation_results: list[dict] = []
-    for expectation in fixture.get("expectations", []):
+    for expectation in fix.get("expectations", []):
         per_trial_verdicts: list[str] = []
         per_trial_rationales: list[str] = []
         for out in reviewer_outputs:
@@ -318,7 +343,7 @@ def _run_fixture(
                 per_trial_verdicts.append("N/A")
                 per_trial_rationales.append("dispatch failure: no reviewer output")
                 continue
-            verdict, rationale = lens_runner.evaluate_expectation(expectation, out, fixture)
+            verdict, rationale = lens_runner.evaluate_expectation(expectation, out, fix)
             per_trial_verdicts.append(verdict)
             per_trial_rationales.append(rationale)
         aggregated = lens_runner.aggregate_replicates(per_trial_verdicts, threshold)  # type: ignore[arg-type]
@@ -334,7 +359,6 @@ def _run_fixture(
             }
         )
 
-    # Fixture verdict: FAIL if any expectation FAIL; else PASS if ≥1 PASS; else N/A.
     verdicts = [r["aggregated_verdict"] for r in expectation_results]
     if any(v == "FAIL" for v in verdicts):
         fixture_verdict = "FAIL"
@@ -344,13 +368,202 @@ def _run_fixture(
         fixture_verdict = "N/A"
 
     return {
-        "id": fixture["id"],
+        "id": fix["id"],
         "verdict": fixture_verdict,
         "trials": n_trials,
         "threshold": threshold,
         "expectations": expectation_results,
         "reviewer_outputs": reviewer_outputs,
     }
+
+
+# ---------------------------------------------------------------------------
+# score() — Task 6 of #297
+# ---------------------------------------------------------------------------
+
+
+def _parse_result_file(path: Path) -> str | None:
+    """Read a per-trial result file and return reviewer output (or None on sentinel).
+
+    Task 6: minimal impl — Task 7 lands the structural parser with whitespace
+    handling, collision detection, etc. For now: any body starting with
+    `DISPATCH_STATUS:` (e.g. ERROR/EMPTY) is treated as a failed trial.
+    """
+    try:
+        body = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not body.strip():
+        return None
+    if body.lstrip().startswith("DISPATCH_STATUS:"):
+        return None
+    return body
+
+
+# S-R4-1: stubs replaced in Task 8 with real impl. Between Task 6 and Task 8
+# commits, --write-baseline / --compare-baseline raise loudly rather than
+# NameError-ing deep in score().
+def _write_baseline(payload: dict, current_template_sha: str) -> None:
+    raise NotImplementedError("Baseline writing implemented in Task 8")
+
+
+def _compare_baseline(payload: dict, current_template_sha: str, *, incomplete: bool) -> int:
+    raise NotImplementedError("Baseline comparison implemented in Task 8")
+
+
+def score(
+    run_id: str,
+    *,
+    write_baseline: bool = False,
+    compare_baseline: bool = False,
+    force_rescore: bool = False,
+    allow_incomplete: bool = False,
+    per_iter: bool = False,
+) -> int:
+    """Read stage-manifest.json + result files; aggregate; write last_run.json.
+
+    Returns: 0=PASS, 1=any FAIL, 2=fatal
+    """
+    validate_run_id(run_id)
+    dispatch_dir = resolve_dispatch_dir(run_id)
+    manifest_path = dispatch_dir / "stage-manifest.json"
+    if not manifest_path.exists():
+        print(f"[fatal] no stage-manifest.json at {manifest_path}", file=sys.stderr)
+        return 2
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    # I-8 + I-11 precedence (S-2)
+    status_path = dispatch_dir / ".collect-status"
+    incomplete = False
+    incomplete_cause: str | None = None
+    # 2P-2 R5: use `return 2` consistently (NOT sys.exit).
+    if not status_path.exists():
+        if not allow_incomplete:
+            print(
+                "[fatal] dispatch run incomplete: `.collect-status` absent. "
+                "Pass --allow-incomplete to override.",
+                file=sys.stderr,
+            )
+            return 2
+        incomplete = True  # cause undetermined per S-2
+    else:
+        first = status_path.read_text(encoding="utf-8").splitlines()
+        if not first or first[0].strip() != "complete":
+            if not allow_incomplete:
+                print("[fatal] .collect-status does not contain 'complete'", file=sys.stderr)
+                return 2
+            incomplete = True
+        # Parse "errors: N/total" line if present (I-11)
+        if len(first) >= 2 and first[1].startswith("errors:"):
+            n_str, total_str = first[1].removeprefix("errors:").strip().split("/")
+            n_err, total = int(n_str), int(total_str)
+            if total > 0 and n_err == total:
+                if not allow_incomplete:
+                    print(
+                        f"[fatal] all {total} dispatches errored (incomplete-cause: all-error). "
+                        f"Pass --allow-incomplete to score anyway.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                incomplete = True
+                incomplete_cause = "all-error"
+            # M-FE-2 R3: ceil-half threshold so exactly half also triggers.
+            elif total > 0 and 2 * n_err >= total:
+                print(
+                    f"[warn] {n_err}/{total} dispatches errored (>= half)",
+                    file=sys.stderr,
+                )
+
+    # Recompute per-trial fixture_sha; refuse mismatches unless --force-rescore
+    evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
+    fixtures_by_id = {f["id"]: f for f in evals_data.get("evals", [])}
+
+    # Template_sha drift advisory (S-1)
+    current_template_sha = template_sha(_REVIEWER_PROMPT)
+    if current_template_sha != manifest.get("template_sha"):
+        if not force_rescore:
+            print(
+                f"[warn] template_sha drift detected (manifest: {manifest['template_sha'][:12]}…, "
+                f"current: {current_template_sha[:12]}…). ADVISORY ONLY — current run's prompts are "
+                f"frozen at stage-time and unaffected. Pass --force-rescore to suppress.",
+                file=sys.stderr,
+            )
+
+    # Reassemble per-fixture trials
+    by_fixture: dict[str, list[tuple[int, dict, str | None]]] = {}
+    for entry in manifest["trials"]:
+        seq = entry["seq"]
+        fid = entry["fixture_id"]
+        fix = fixtures_by_id.get(fid)
+        if fix is None:
+            print(f"[fatal] unknown fixture id {fid!r} in manifest", file=sys.stderr)
+            return 2
+
+        # Per-trial fixture_sha refusal (I-3)
+        current_fsha = fixture_sha(fix)
+        if current_fsha != entry["fixture_sha"] and not force_rescore:
+            print(
+                f"[warn] fixture {fid!r} sha mismatch on seq {seq}: REFUSED. "
+                f"Pass --force-rescore to override.",
+                file=sys.stderr,
+            )
+            by_fixture.setdefault(fid, []).append((entry["trial"], entry, None))
+            continue
+
+        result_path = dispatch_dir / entry["result_file"]
+        out = _parse_result_file(result_path) if result_path.exists() else None
+        by_fixture.setdefault(fid, []).append((entry["trial"], entry, out))
+
+    # Run lens_runner per fixture
+    fixture_results: list[dict] = []
+    for fid, trials_list in by_fixture.items():
+        fix = fixtures_by_id[fid]
+        trials_list.sort(key=lambda t: t[0])
+        reviewer_outputs = [out for _, _, out in trials_list]
+        rule = fix.get("replicate_rule", {"trials": 1, "threshold": 1})
+        n_trials = rule.get("trials", 1)
+        threshold = rule.get("threshold", 1)
+        result = _aggregate_from_outputs(
+            fix, reviewer_outputs, n_trials=n_trials, threshold=threshold
+        )
+        fixture_results.append(result)
+
+    # Write last_run.json
+    payload: dict[str, Any] = {
+        "run_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "run_id": run_id,
+        "fixtures": fixture_results,
+    }
+    if incomplete:
+        payload["incomplete"] = True
+        if incomplete_cause:
+            payload["incomplete-cause"] = incomplete_cause
+    if force_rescore:
+        payload["force_rescore"] = True
+
+    # F1 / S-FE-5 R3: per-iter outputs under .calibrate-state/ (blanket-gitignored)
+    if per_iter:
+        per_iter_dir = _EVALS_DIR / ".calibrate-state"
+        per_iter_dir.mkdir(parents=True, exist_ok=True)
+        out_path = per_iter_dir / f"last_run-{run_id}.json"
+        print(
+            f"[info] writing per-iter output to {out_path} (gitignored via .calibrate-state/)",
+            file=sys.stderr,
+        )
+    else:
+        out_path = _LAST_RUN
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    # --write-baseline + --compare-baseline — see Task 8 (stubs raise NotImplementedError)
+    if write_baseline:
+        _write_baseline(payload, current_template_sha)
+    if compare_baseline:
+        return _compare_baseline(payload, current_template_sha, incomplete=incomplete)
+
+    if any(fr["verdict"] == "FAIL" for fr in fixture_results):
+        return 1
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -451,9 +664,17 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
     if args.cmd == "score":
-        # Task 6 implements `score()`; until then, surface a clear error.
-        print("[fatal] `score` subcommand not yet implemented (Task 6)", file=sys.stderr)
-        return 2
+        try:
+            return score(
+                args.run_id,
+                write_baseline=args.write_baseline,
+                compare_baseline=args.compare_baseline,
+                force_rescore=args.force_rescore,
+                allow_incomplete=args.allow_incomplete,
+            )
+        except ValueError as e:
+            print(f"[fatal] {e}", file=sys.stderr)
+            return 2
 
     # Legacy mock/replay path — preserved unchanged
     return _legacy_main(args)

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -19,12 +19,15 @@ import argparse
 import datetime as _dt
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 from . import lens_runner
+from ._dispatch_paths import fixture_sha, resolve_dispatch_dir, template_sha
+from ._runid import validate_run_id
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _EVALS_DIR = Path(__file__).resolve().parent
@@ -92,6 +95,135 @@ def _dispatch_live(prompt: str, fixture_id: str, trial: int, timeout: int) -> st
         )
         return None
     return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# stage(): render dispatch files + manifest (Task 3 of #297)
+# ---------------------------------------------------------------------------
+
+
+_DISPATCH_HEADER_TEMPLATE = """\
+# Dispatch: temper-reviewer
+**Pipeline:** temper-eval | **Phase:** collect | **Task:** {seq}
+**Timestamp:** {ts}
+**Dispatch-Dir:** {dispatch_dir}
+
+---
+
+"""
+
+
+def _validate_rendered_prompt(rendered: str) -> None:
+    """I-T9 stub — proper impl in Task 5."""
+    pass
+
+
+def stage(
+    run_id: str,
+    *,
+    force: bool = False,
+    source: str = "all",
+    fixture: str | None = None,
+    trials_override: int | None = None,
+    timeout: int = 300,
+) -> Path:
+    """Render fixtures × trials to dispatch files; write stage-manifest.json.
+
+    Returns: dispatch directory path.
+    Raises:
+        ValueError: invalid run_id (I-9) or source+fixture intersection (M-1)
+        FileExistsError: dispatch dir exists and force=False
+    """
+    validate_run_id(run_id)
+
+    # Load fixtures
+    evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
+    fixtures = evals_data.get("evals", [])
+
+    # --source filter
+    if source != "all":
+        fixtures = [f for f in fixtures if f.get("source", "synthetic") == source]
+
+    # --fixture filter + M-1 intersection check
+    if fixture is not None:
+        matching = [f for f in fixtures if f["id"] == fixture]
+        if not matching:
+            raise ValueError(
+                f"--fixture {fixture!r} not found in --source {source!r} "
+                f"(M-1: intersection produces zero trials)"
+            )
+        fixtures = matching
+
+    # Resolve + prepare dispatch dir
+    dispatch_dir = resolve_dispatch_dir(run_id)
+    if dispatch_dir.exists():
+        if not force:
+            raise FileExistsError(
+                f"dispatch dir {dispatch_dir} already exists; pass force=True to overwrite"
+            )
+        shutil.rmtree(dispatch_dir)
+    dispatch_dir.mkdir(parents=True)
+
+    # Read template once
+    template = _REVIEWER_PROMPT.read_text(encoding="utf-8")
+    tpl_sha = template_sha(_REVIEWER_PROMPT)
+    ts = _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+    # Render trials
+    trials: list[dict] = []
+    seq = 0
+    for fix in fixtures:
+        rule = fix.get("replicate_rule", {"trials": 1, "threshold": 1})
+        n_trials = trials_override if trials_override is not None else rule.get("trials", 1)
+        for trial_idx in range(1, n_trials + 1):
+            seq += 1
+            dispatch_file = f"{seq:03d}-reviewer.md"
+            result_file = f"{seq:03d}-result.md"
+            body = _render_prompt(template, fix)
+            header = _DISPATCH_HEADER_TEMPLATE.format(
+                seq=seq, ts=ts, dispatch_dir=dispatch_dir
+            )
+            rendered = header + body
+            _validate_rendered_prompt(rendered)  # I-T9 — see Task 5
+            (dispatch_dir / dispatch_file).write_text(rendered, encoding="utf-8")
+            trials.append({
+                "seq": seq,
+                "fixture_id": fix["id"],
+                "trial": trial_idx,
+                "dispatch_file": dispatch_file,
+                "result_file": result_file,
+                "fixture_sha": fixture_sha(fix),
+            })
+
+    # Write stage-manifest.json
+    # stage(): non-atomic writes accepted — see plan M-FE-1 R3
+    manifest = {
+        "run_id": run_id,
+        "stage_timestamp": ts,
+        "dispatch_timeout": timeout,
+        "reviewer_model": "opus",
+        "template_sha": tpl_sha,
+        "trials": trials,
+    }
+    (dispatch_dir / "stage-manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+
+    # Initial manifest.jsonl entries (stage-side).
+    # S-R4-3: `manifest.jsonl` is informational/audit only — score does NOT consume it.
+    # S-4 R5: `"w"` mode is safe ONLY because rmtree+mkdir above guarantees an
+    # empty dispatch dir at this point. Do NOT relocate this open() call above
+    # the rmtree without re-evaluating the truncation hazard.
+    # stage(): non-atomic writes accepted — see plan M-FE-1 R3
+    with (dispatch_dir / "manifest.jsonl").open("w", encoding="utf-8") as f:
+        for t in trials:
+            f.write(json.dumps({
+                "seq": t["seq"], "file": t["dispatch_file"],
+                "role": "temper-reviewer", "phase": "stage", "task": None,
+                "status": "dispatched", "duration_s": None, "summary": None,
+            }) + "\n")
+
+    return dispatch_dir
 
 
 # ---------------------------------------------------------------------------

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -33,7 +33,11 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _EVALS_DIR = Path(__file__).resolve().parent
 _EVALS_JSON = _EVALS_DIR / "evals.json"
 _REVIEWER_PROMPT = _REPO_ROOT / "skills" / "temper" / "temper-reviewer.md"
-_LAST_RUN = _EVALS_DIR / "last_run.json"
+_LAST_RUN = (
+    Path(os.environ["TEMPER_LAST_RUN_OVERRIDE"])
+    if os.environ.get("TEMPER_LAST_RUN_OVERRIDE")
+    else _EVALS_DIR / "last_run.json"
+)
 
 _FIXTURE_CONTENT_HEADER = (
     "## Fixture content (synthetic — review this in lieu of running git commands):\n\n"
@@ -369,17 +373,71 @@ def _render_summary(fixture_results: list[dict]) -> str:
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Run temper lens evals.")
-    p.add_argument("--fixture", help="run only one fixture by id")
+    sub = p.add_subparsers(dest="cmd")
+
+    # stage
+    sp_stage = sub.add_parser("stage", help="Render fixtures × trials to dispatch files")
+    sp_stage.add_argument("run_id")
+    sp_stage.add_argument("--force", action="store_true")
+    sp_stage.add_argument("--source", choices=["synthetic", "real-pr", "all"], default="all")
+    sp_stage.add_argument("--fixture", default=None)
+    sp_stage.add_argument("--trials-override", type=int, default=None)
+    sp_stage.add_argument("--timeout", type=int, default=300)
+
+    # score — Task 6
+    sp_score = sub.add_parser("score", help="Aggregate results + write last_run.json")
+    sp_score.add_argument("run_id")
+    sp_score.add_argument("--write-baseline", action="store_true")
+    sp_score.add_argument("--compare-baseline", action="store_true")
+    sp_score.add_argument("--force-rescore", action="store_true")
+    sp_score.add_argument("--allow-incomplete", action="store_true")
+    # F-R4-1: `--per-iter` argparse declaration is intentionally NOT added here.
+    # Both the argparse declaration AND the main() wiring land atomically in Task 13
+    # (S-1 R5: per-iter wiring lands BEFORE the calibrate skill) to eliminate a
+    # silent-drop window where the flag would be parseable but unwired (silently
+    # clobbering shared last_run.json).
+
+    # Legacy mock/replay paths (back-compat, no subcommand)
+    # S3: All legacy flags use --legacy-* prefix to eliminate collision with subcommand flags.
+    p.add_argument("--legacy-fixture", dest="legacy_fixture", help="(legacy) run one fixture by id (with mock/replay)")
     p.add_argument("--mock-reviewer", help="dir containing <fixture-id>.txt canned outputs")
     p.add_argument("--replay", help="path to last_run.json to re-evaluate")
-    p.add_argument("--trials-override", type=int, help="override replicate_rule.trials")
-    p.add_argument("--timeout", type=int, default=120, help="per-dispatch timeout in seconds")
+    # S-3 R5: dest matches the flag's full name (`legacy_trials_override`) to
+    # eliminate the prior `legacy_trials` vs `args.trials_override` naming confusion.
+    p.add_argument("--legacy-trials-override", dest="legacy_trials_override", type=int, help="(legacy)")
+    p.add_argument("--legacy-timeout", dest="legacy_timeout", type=int, default=120, help="(legacy)")
+
     return p.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv if argv is not None else sys.argv[1:])
 
+    if args.cmd == "stage":
+        try:
+            stage(
+                args.run_id,
+                force=args.force,
+                source=args.source,
+                fixture=args.fixture,
+                trials_override=args.trials_override,
+                timeout=args.timeout,
+            )
+            return 0
+        except (FileExistsError, ValueError) as e:
+            print(f"[fatal] {e}", file=sys.stderr)
+            return 2
+
+    if args.cmd == "score":
+        # Task 6 implements `score()`; until then, surface a clear error.
+        print("[fatal] `score` subcommand not yet implemented (Task 6)", file=sys.stderr)
+        return 2
+
+    # Legacy mock/replay path — preserved unchanged
+    return _legacy_main(args)
+
+
+def _legacy_main(args: argparse.Namespace) -> int:
     # Load fixtures
     try:
         evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
@@ -388,10 +446,10 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     fixtures = evals_data.get("evals", [])
-    if args.fixture:
-        fixtures = [f for f in fixtures if f["id"] == args.fixture]
+    if args.legacy_fixture:
+        fixtures = [f for f in fixtures if f["id"] == args.legacy_fixture]
         if not fixtures:
-            print(f"[fatal] no fixture with id {args.fixture!r}", file=sys.stderr)
+            print(f"[fatal] no fixture with id {args.legacy_fixture!r}", file=sys.stderr)
             return 2
 
     # Resolve mode
@@ -428,8 +486,8 @@ def main(argv: list[str] | None = None) -> int:
             template=template,
             mock_dir=mock_dir,
             replay_outputs=replay_outputs,
-            trials_override=args.trials_override,
-            timeout=args.timeout,
+            trials_override=args.legacy_trials_override,
+            timeout=args.legacy_timeout,
         )
         fixture_results.append(result)
 

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -383,19 +383,45 @@ def _aggregate_from_outputs(
 
 
 def _parse_result_file(path: Path) -> str | None:
-    """Read a per-trial result file and return reviewer output (or None on sentinel).
+    """Parse <NNN>-result.md. Returns reviewer markdown body or None on ERROR.
 
-    Task 6: minimal impl — Task 7 lands the structural parser with whitespace
-    handling, collision detection, etc. For now: any body starting with
-    `DISPATCH_STATUS:` (e.g. ERROR/EMPTY) is treated as a failed trial.
+    Task 7 (S-1, I-T6): structural first-line prefix match. The body may
+    contain literal `DISPATCH_STATUS:` substrings without collision because
+    only line 0 is inspected for the sentinel.
+
+    Layout assumed:
+        DISPATCH_STATUS: <STATE>[: detail]
+        <blank line>
+        <reviewer markdown body...>
+
+    Return value:
+      - None when the sentinel is ERROR (or malformed / missing).
+      - None when the sentinel is OK but the body is empty / whitespace-only
+        (collect skill SHOULD have promoted this to ERROR upstream — defense
+        in depth).
+      - The body string when the sentinel is OK and the body is non-empty.
     """
     try:
-        body = path.read_text(encoding="utf-8")
+        text = path.read_text(encoding="utf-8")
     except OSError:
         return None
-    if not body.strip():
+    lines = text.split("\n", 2)  # split at most twice: first, blank, rest
+    if not lines:
         return None
-    if body.lstrip().startswith("DISPATCH_STATUS:"):
+    first = lines[0]
+    if first.startswith("DISPATCH_STATUS: ERROR"):
+        return None
+    if not first.startswith("DISPATCH_STATUS: OK"):
+        # Malformed sentinel — treat as None (no claim about content)
+        return None
+    # Body starts after the blank line (lines[2] if present).
+    # S1: empty body is treated as None (not empty string) — collect skill
+    # should have promoted empty-body to DISPATCH_STATUS: ERROR: empty-body
+    # before this point.
+    if len(lines) < 3:
+        return None
+    body = lines[2]
+    if body.strip() == "":
         return None
     return body
 

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -40,6 +40,23 @@ _LAST_RUN = (
 )
 
 
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Atomic write via tmp + os.replace. POSIX-atomic on same filesystem.
+
+    QG R2 Fix 1: SIGINT/OOM/disk-full mid-write previously left truncated JSON,
+    which the next `--compare-baseline` would crash on (R1 try/except converted
+    crash to rc=2, but lost the baseline-correctness signal). This helper
+    ensures readers never observe a partial file.
+
+    Used for: score() out_path (last_run/per-iter), _write_baseline,
+    _legacy_main's last_run write. NOT used for stage-manifest.json or
+    reviewer dispatch files (different lifecycle — write-once-never-reread).
+    """
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
 def _resolve_output_path(run_id: str, *, per_iter: bool) -> Path:
     """S4 R6: resolves output path at call time using CURRENT _EVALS_DIR.
 
@@ -444,10 +461,17 @@ def _write_baseline(payload: dict, current_template_sha: str) -> None:
     """SP-1: baseline header carries template_sha."""
     baseline = dict(payload)
     baseline["template_sha"] = current_template_sha
-    _BASELINE_PATH.write_text(json.dumps(baseline, indent=2), encoding="utf-8")
+    # QG R2 Fix 1: atomic write — prevents truncated baseline.json mid-write
+    _atomic_write_text(_BASELINE_PATH, json.dumps(baseline, indent=2))
 
 
-def _compare_baseline(payload: dict, current_template_sha: str, *, incomplete: bool) -> int:
+def _compare_baseline(
+    payload: dict,
+    current_template_sha: str,
+    *,
+    incomplete: bool,
+    allow_fixture_drift: bool = False,
+) -> int:
     """Return 1 on regression, 2 if refused (incomplete / missing baseline), 0 if clean.
 
     M3 R6 caveat — fixture-set drift: this function compares verdicts by fixture id.
@@ -490,6 +514,32 @@ def _compare_baseline(payload: dict, current_template_sha: str, *, incomplete: b
     # Per-fixture verdict comparison
     current_verdicts = {f["id"]: f["verdict"] for f in payload["fixtures"]}
     base_verdicts = {f["id"]: f["verdict"] for f in baseline.get("fixtures", [])}
+
+    # QG R2 Fix 3: fixture-set drift detection. Closes the silent-deletion gap
+    # documented in the prior M3 R6 caveat — an operator can no longer "fix" a
+    # regression by deleting the fixture from evals.json without explicit opt-in.
+    base_ids = set(base_verdicts.keys())
+    current_ids = set(current_verdicts.keys())
+    removed = base_ids - current_ids
+    added = current_ids - base_ids
+    if removed:
+        print(
+            f"[warn] fixture-set drift: removed from baseline: {sorted(removed)}",
+            file=sys.stderr,
+        )
+    if added:
+        print(
+            f"[warn] fixture-set drift: added since baseline: {sorted(added)}",
+            file=sys.stderr,
+        )
+    if removed and not allow_fixture_drift:
+        print(
+            "[fatal] baseline regression-check refuses removed fixtures "
+            "without --allow-fixture-drift",
+            file=sys.stderr,
+        )
+        return 2
+
     regressions = []
     for fid, base_v in base_verdicts.items():
         cur_v = current_verdicts.get(fid)
@@ -510,6 +560,7 @@ def score(
     force_rescore: bool = False,
     allow_incomplete: bool = False,
     per_iter: bool = False,
+    allow_fixture_drift: bool = False,
 ) -> int:
     """Read stage-manifest.json + result files; aggregate; write last_run.json.
 
@@ -661,13 +712,19 @@ def score(
             f"[info] writing per-iter output to {out_path} (gitignored via .calibrate-state/)",
             file=sys.stderr,
         )
-    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    # QG R2 Fix 1: atomic write — prevents truncated last_run/per-iter on SIGINT/OOM/disk-full
+    _atomic_write_text(out_path, json.dumps(payload, indent=2))
 
     # --write-baseline + --compare-baseline — see Task 8 (stubs raise NotImplementedError)
     if write_baseline:
         _write_baseline(payload, current_template_sha)
     if compare_baseline:
-        return _compare_baseline(payload, current_template_sha, incomplete=incomplete)
+        return _compare_baseline(
+            payload,
+            current_template_sha,
+            incomplete=incomplete,
+            allow_fixture_drift=allow_fixture_drift,
+        )
 
     if any(fr["verdict"] == "FAIL" for fr in fixture_results):
         return 1
@@ -734,6 +791,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     sp_score.add_argument("--compare-baseline", action="store_true")
     sp_score.add_argument("--force-rescore", action="store_true")
     sp_score.add_argument("--allow-incomplete", action="store_true")
+    sp_score.add_argument("--allow-fixture-drift", action="store_true",
+        help="Permit --compare-baseline when fixtures have been removed from evals.json. "
+             "Without this flag, removed fixtures cause rc=2 (prevents silent regression-laundering).")
     sp_score.add_argument("--per-iter", action="store_true",
         help="Write last_run-<run_id>.json under .calibrate-state/ instead of shared last_run.json. Set by /temper-eval-calibrate.")
 
@@ -777,6 +837,7 @@ def main(argv: list[str] | None = None) -> int:
                 force_rescore=args.force_rescore,
                 allow_incomplete=args.allow_incomplete,
                 per_iter=args.per_iter,
+                allow_fixture_drift=args.allow_fixture_drift,
             )
         except ValueError as e:
             print(f"[fatal] {e}", file=sys.stderr)
@@ -851,8 +912,12 @@ def _legacy_main(args: argparse.Namespace) -> int:
         "args": vars(args),
         "fixtures": fixture_results,
     }
+    # QG R2 Fix 2: route via _resolve_output_path() to mirror score() — honors
+    # TEMPER_LAST_RUN_OVERRIDE set after import AND uses the current _EVALS_DIR
+    # (monkeypatchable in tests). Eliminates legacy-vs-score asymmetry.
     try:
-        _LAST_RUN.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        out_path = _resolve_output_path("legacy", per_iter=False)
+        _atomic_write_text(out_path, json.dumps(payload, indent=2, default=str))
     except OSError as e:
         print(f"[warn] cannot write last_run.json: {e}", file=sys.stderr)
 

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -679,11 +679,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     sp_score.add_argument("--compare-baseline", action="store_true")
     sp_score.add_argument("--force-rescore", action="store_true")
     sp_score.add_argument("--allow-incomplete", action="store_true")
-    # F-R4-1: `--per-iter` argparse declaration is intentionally NOT added here.
-    # Both the argparse declaration AND the main() wiring land atomically in Task 13
-    # (S-1 R5: per-iter wiring lands BEFORE the calibrate skill) to eliminate a
-    # silent-drop window where the flag would be parseable but unwired (silently
-    # clobbering shared last_run.json).
+    sp_score.add_argument("--per-iter", action="store_true",
+        help="Write last_run-<run_id>.json under .calibrate-state/ instead of shared last_run.json. Set by /temper-eval-calibrate.")
 
     # Legacy mock/replay paths (back-compat, no subcommand)
     # S3: All legacy flags use --legacy-* prefix to eliminate collision with subcommand flags.
@@ -724,6 +721,7 @@ def main(argv: list[str] | None = None) -> int:
                 compare_baseline=args.compare_baseline,
                 force_rescore=args.force_rescore,
                 allow_incomplete=args.allow_incomplete,
+                per_iter=args.per_iter,
             )
         except ValueError as e:
             print(f"[fatal] {e}", file=sys.stderr)

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -4,8 +4,8 @@ Dispatches the temper-reviewer prompt against each fixture in
 `evals.json`, collects reviewer outputs across N replicate trials, and
 evaluates the fixture's structured expectations via `lens_runner`.
 
-Supports three execution modes:
-  - live: subprocess `claude -p <prompt>` per trial (default)
+Supports two execution modes (live dispatch removed in #297 —
+use `stage` + `/temper-eval-collect` + `score` subcommands instead):
   - mock: read canned outputs from `--mock-reviewer <dir>/<id>.txt`
   - replay: re-evaluate cached outputs from a prior `last_run.json`
 
@@ -20,7 +20,6 @@ import datetime as _dt
 import json
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -86,31 +85,6 @@ def _render_prompt(template: str, fixture: dict) -> str:
     )
     _validate_rendered_prompt(rendered)  # I-T9: validate BEFORE appending fixture body
     return rendered + "\n\n" + _FIXTURE_CONTENT_HEADER + fixture["prompt"]
-
-
-def _dispatch_live(prompt: str, fixture_id: str, trial: int, timeout: int) -> str | None:
-    """Live-dispatch via `claude -p`. Returns stdout, or None on failure."""
-    try:
-        result = subprocess.run(
-            ["claude", "-p", prompt],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired:
-        print(f"  [dispatch] timeout on {fixture_id} trial {trial}", file=sys.stderr)
-        return None
-    except FileNotFoundError:
-        print("  [dispatch] `claude` CLI not found on PATH", file=sys.stderr)
-        return None
-    if result.returncode != 0:
-        print(
-            f"  [dispatch] non-zero exit {result.returncode} on {fixture_id} trial {trial}: "
-            f"{result.stderr[:200]}",
-            file=sys.stderr,
-        )
-        return None
-    return result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -266,11 +240,22 @@ def _resolve_output(
     fixture: dict,
     trial: int,
     *,
-    template: str | None,
+    template: str | None,  # noqa: ARG001 — kept for legacy callers post-#297
     mock_dir: Path | None,
     replay_outputs: list[str] | None,
-    timeout: int,
+    timeout: int,  # noqa: ARG001 — kept for legacy callers post-#297
 ) -> str | None:
+    """Resolve a per-trial reviewer output from mock-dir or replay cache.
+
+    Post-#297: subprocess-based live dispatch is removed. Live runs now go
+    through the `stage` subcommand + `/temper-eval-collect` skill + `score`
+    subcommand. When neither `replay_outputs` nor `mock_dir` applies this
+    returns `None`; legacy callers should error out before calling.
+
+    `template` and `timeout` are kept in the signature as vestigial kwargs
+    so legacy `_run_fixture` callers don't need a parallel-edit; they are
+    intentionally ignored.
+    """
     if replay_outputs is not None:
         if trial - 1 < len(replay_outputs):
             return replay_outputs[trial - 1]
@@ -282,9 +267,7 @@ def _resolve_output(
         except OSError as e:
             print(f"  [mock] cannot read {path}: {e}", file=sys.stderr)
             return None
-    assert template is not None
-    prompt = _render_prompt(template, fixture)
-    return _dispatch_live(prompt, fixture["id"], trial, timeout)
+    return None
 
 
 def _run_fixture(
@@ -784,11 +767,16 @@ def _legacy_main(args: argparse.Namespace) -> int:
             print(f"[fatal] mock-reviewer dir not found: {mock_dir}", file=sys.stderr)
             return 2
     else:
-        try:
-            template = _REVIEWER_PROMPT.read_text(encoding="utf-8")
-        except OSError as e:
-            print(f"[fatal] cannot read reviewer template: {e}", file=sys.stderr)
-            return 2
+        # Post-#297: subprocess-based live dispatch is removed. The legacy
+        # entry point only supports `--mock-reviewer` or `--replay`. Live
+        # runs go through `stage` + `/temper-eval-collect` + `score`.
+        print(
+            "[fatal] legacy entry point requires --mock-reviewer or --replay; "
+            "live dispatch was removed in #297 — use the `stage` subcommand "
+            "+ /temper-eval-collect + `score` for live runs.",
+            file=sys.stderr,
+        )
+        return 2
 
     # Run each fixture
     fixture_results: list[dict] = []

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -470,19 +470,16 @@ def _compare_baseline(
     current_template_sha: str,
     *,
     incomplete: bool,
+    evals_fixture_ids: set[str],
     allow_fixture_drift: bool = False,
 ) -> int:
     """Return 1 on regression, 2 if refused (incomplete / missing baseline), 0 if clean.
 
-    M3 R6 caveat — fixture-set drift: this function compares verdicts by fixture id.
-    If a fixture is DELETED from evals.json post-baseline, that fixture appears in
-    `base_verdicts` but is absent from `current_verdicts.get(fid)` → resolves to
-    `None`, which does not match the `("FAIL", "N/A")` regression set, so the
-    deletion is currently SILENT. Conversely, fixtures ADDED post-baseline are
-    not compared at all (no baseline entry). Operators changing the fixture set
-    must re-baseline explicitly (`--write-baseline`) — otherwise comparisons
-    drift apples-to-oranges without warning. Future work: emit an explicit
-    `[warn] fixture-set drift` line when `set(base_verdicts) != set(current_verdicts)`.
+    QG R3 Fix 1: fixture-set drift is now checked by the caller (score()) against
+    the live evals.json keyset (evals_fixture_ids), not against the possibly-filtered
+    manifest payload. This function receives the already-validated evals_fixture_ids
+    and operates on the intersection of baseline keys + current manifest scope, which
+    is the correct behavior — the drift gate has already passed at the outer scope.
     """
     if incomplete:
         print(
@@ -511,34 +508,10 @@ def _compare_baseline(
             f"{current_template_sha[:12]}…); verdict comparison may be apples-to-oranges",
             file=sys.stderr,
         )
-    # Per-fixture verdict comparison
+    # Per-fixture verdict comparison against the current manifest scope.
+    # Drift against evals.json has already been checked in score() before this call.
     current_verdicts = {f["id"]: f["verdict"] for f in payload["fixtures"]}
     base_verdicts = {f["id"]: f["verdict"] for f in baseline.get("fixtures", [])}
-
-    # QG R2 Fix 3: fixture-set drift detection. Closes the silent-deletion gap
-    # documented in the prior M3 R6 caveat — an operator can no longer "fix" a
-    # regression by deleting the fixture from evals.json without explicit opt-in.
-    base_ids = set(base_verdicts.keys())
-    current_ids = set(current_verdicts.keys())
-    removed = base_ids - current_ids
-    added = current_ids - base_ids
-    if removed:
-        print(
-            f"[warn] fixture-set drift: removed from baseline: {sorted(removed)}",
-            file=sys.stderr,
-        )
-    if added:
-        print(
-            f"[warn] fixture-set drift: added since baseline: {sorted(added)}",
-            file=sys.stderr,
-        )
-    if removed and not allow_fixture_drift:
-        print(
-            "[fatal] baseline regression-check refuses removed fixtures "
-            "without --allow-fixture-drift",
-            file=sys.stderr,
-        )
-        return 2
 
     regressions = []
     for fid, base_v in base_verdicts.items():
@@ -719,10 +692,45 @@ def score(
     if write_baseline:
         _write_baseline(payload, current_template_sha)
     if compare_baseline:
+        # QG R3 Fix 1: fixture-set drift must be checked against the LIVE evals.json
+        # keyset, not against the (possibly-filtered) manifest payload. A scoped
+        # `stage R-x --fixture foo-id` run followed by `score R-x --compare-baseline`
+        # against a full-scope baseline would previously trigger false rc=2 "removed
+        # from baseline" for every fixture not in the subset. The correct threat model
+        # is: was a fixture DELETED from evals.json? We detect that here using
+        # fixtures_by_id (already loaded above from _EVALS_JSON) and pass the keyset
+        # into _compare_baseline so it can operate on the manifest-scope intersection.
+        if _BASELINE_PATH.exists():
+            try:
+                _base_data = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+                _base_ids = {f["id"] for f in _base_data.get("fixtures", [])}
+                _evals_ids = set(fixtures_by_id.keys())
+                _removed = _base_ids - _evals_ids
+                _added = _evals_ids - _base_ids
+                if _removed:
+                    print(
+                        f"[warn] fixture-set drift: removed from evals.json: {sorted(_removed)}",
+                        file=sys.stderr,
+                    )
+                if _added:
+                    print(
+                        f"[warn] fixture-set drift: added to evals.json since baseline: {sorted(_added)}",
+                        file=sys.stderr,
+                    )
+                if _removed and not allow_fixture_drift:
+                    print(
+                        "[fatal] baseline regression-check refuses removed fixtures "
+                        "without --allow-fixture-drift",
+                        file=sys.stderr,
+                    )
+                    return 2
+            except (json.JSONDecodeError, OSError):
+                pass  # malformed baseline handled inside _compare_baseline
         return _compare_baseline(
             payload,
             current_template_sha,
             incomplete=incomplete,
+            evals_fixture_ids=set(fixtures_by_id.keys()),
             allow_fixture_drift=allow_fixture_drift,
         )
 
@@ -916,6 +924,8 @@ def _legacy_main(args: argparse.Namespace) -> int:
     # TEMPER_LAST_RUN_OVERRIDE set after import AND uses the current _EVALS_DIR
     # (monkeypatchable in tests). Eliminates legacy-vs-score asymmetry.
     try:
+        # Legacy invocation has no user-provided run-id; literal "legacy" steers env-override path,
+        # never reaches the per-iter branch where run_id is used in the path. Validation intentionally skipped.
         out_path = _resolve_output_path("legacy", per_iter=False)
         _atomic_write_text(out_path, json.dumps(payload, indent=2, default=str))
     except OSError as e:

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -66,13 +66,20 @@ def _synth_plan_reference(fixture: dict) -> str:
 
 
 def _render_prompt(template: str, fixture: dict) -> str:
-    """Substitute placeholders and append fixture content."""
+    """Substitute placeholders, validate (template portion only), then append
+    fixture content.
+
+    I-T9 (M-4): validation applies to the substituted template — NOT the
+    appended fixture body. Fixture diffs legitimately contain `{` (f-strings,
+    dict literals); validating after concat would false-positive.
+    """
     rendered = (
         template.replace("{DESCRIPTION}", f"Synthetic lens eval fixture: {fixture['id']}")
         .replace("{PLAN_REFERENCE}", _synth_plan_reference(fixture))
         .replace("{BASE_SHA}", "FIXTURE_BASE")
         .replace("{HEAD_SHA}", "FIXTURE_HEAD")
     )
+    _validate_rendered_prompt(rendered)  # I-T9: validate BEFORE appending fixture body
     return rendered + "\n\n" + _FIXTURE_CONTENT_HEADER + fixture["prompt"]
 
 
@@ -118,8 +125,23 @@ _DISPATCH_HEADER_TEMPLATE = """\
 
 
 def _validate_rendered_prompt(rendered: str) -> None:
-    """I-T9 stub — proper impl in Task 5."""
-    pass
+    """I-T9 (M-4): length-floor + placeholder-residual check.
+
+    Template-evolution-tolerant. Catches catastrophically-empty renders
+    and unsubstituted placeholders without binding to specific placeholder names.
+    """
+    if len(rendered) <= 200:
+        raise ValueError(
+            f"rendered prompt has length {len(rendered)} ≤ 200 bytes "
+            f"(I-T9 length-floor): suspect catastrophic-empty render"
+        )
+    if "{" in rendered:
+        idx = rendered.index("{")
+        context = rendered[max(0, idx - 20):idx + 40]
+        raise ValueError(
+            f"rendered prompt contains unsubstituted `{{` placeholder marker "
+            f"at offset {idx} (I-T9 placeholder-residual): {context!r}"
+        )
 
 
 def stage(
@@ -188,7 +210,7 @@ def stage(
                 seq=seq, ts=ts, dispatch_dir=dispatch_dir
             )
             rendered = header + body
-            _validate_rendered_prompt(rendered)  # I-T9 — see Task 5
+            # I-T9 validation runs inside _render_prompt on the template-only portion
             (dispatch_dir / dispatch_file).write_text(rendered, encoding="utf-8")
             trials.append({
                 "seq": seq,

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -260,21 +260,16 @@ def _resolve_output(
     fixture: dict,
     trial: int,
     *,
-    template: str | None,  # noqa: ARG001 — kept for legacy callers post-#297
     mock_dir: Path | None,
     replay_outputs: list[str] | None,
-    timeout: int,  # noqa: ARG001 — kept for legacy callers post-#297
 ) -> str | None:
     """Resolve a per-trial reviewer output from mock-dir or replay cache.
 
     Post-#297: subprocess-based live dispatch is removed. Live runs now go
     through the `stage` subcommand + `/temper-eval-collect` skill + `score`
     subcommand. When neither `replay_outputs` nor `mock_dir` applies this
-    returns `None`; legacy callers should error out before calling.
-
-    `template` and `timeout` are kept in the signature as vestigial kwargs
-    so legacy `_run_fixture` callers don't need a parallel-edit; they are
-    intentionally ignored.
+    returns `None`; legacy callers error out in `_legacy_main` before reaching
+    here.
     """
     if replay_outputs is not None:
         if trial - 1 < len(replay_outputs):
@@ -293,11 +288,9 @@ def _resolve_output(
 def _run_fixture(
     fixture: dict,
     *,
-    template: str | None,
     mock_dir: Path | None,
     replay_outputs: list[str] | None,
     trials_override: int | None,
-    timeout: int,
 ) -> dict:
     rule = fixture.get("replicate_rule", {"trials": 1, "threshold": 1})
     n_trials = trials_override if trials_override is not None else rule.get("trials", 1)
@@ -310,10 +303,8 @@ def _run_fixture(
         out = _resolve_output(
             fixture,
             trial,
-            template=template,
             mock_dir=mock_dir,
             replay_outputs=replay_outputs,
-            timeout=timeout,
         )
         reviewer_outputs.append(out)
 
@@ -764,7 +755,6 @@ def _legacy_main(args: argparse.Namespace) -> int:
             return 2
 
     # Resolve mode
-    template: str | None = None
     mock_dir: Path | None = None
     replay_by_fixture: dict[str, list[str]] = {}
 
@@ -799,11 +789,9 @@ def _legacy_main(args: argparse.Namespace) -> int:
         replay_outputs = replay_by_fixture.get(fixture["id"]) if args.replay else None
         result = _run_fixture(
             fixture,
-            template=template,
             mock_dir=mock_dir,
             replay_outputs=replay_outputs,
             trials_override=args.legacy_trials_override,
-            timeout=args.legacy_timeout,
         )
         fixture_results.append(result)
 

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -426,15 +426,59 @@ def _parse_result_file(path: Path) -> str | None:
     return body
 
 
-# S-R4-1: stubs replaced in Task 8 with real impl. Between Task 6 and Task 8
-# commits, --write-baseline / --compare-baseline raise loudly rather than
-# NameError-ing deep in score().
+# Task 8: real impls. SP-1 baseline header carries template_sha so
+# --compare-baseline can detect dispatch-template drift since baseline.
 def _write_baseline(payload: dict, current_template_sha: str) -> None:
-    raise NotImplementedError("Baseline writing implemented in Task 8")
+    """SP-1: baseline header carries template_sha."""
+    baseline = dict(payload)
+    baseline["template_sha"] = current_template_sha
+    _BASELINE_PATH.write_text(json.dumps(baseline, indent=2), encoding="utf-8")
 
 
 def _compare_baseline(payload: dict, current_template_sha: str, *, incomplete: bool) -> int:
-    raise NotImplementedError("Baseline comparison implemented in Task 8")
+    """Return 1 on regression, 2 if refused (incomplete / missing baseline), 0 if clean.
+
+    M3 R6 caveat — fixture-set drift: this function compares verdicts by fixture id.
+    If a fixture is DELETED from evals.json post-baseline, that fixture appears in
+    `base_verdicts` but is absent from `current_verdicts.get(fid)` → resolves to
+    `None`, which does not match the `("FAIL", "N/A")` regression set, so the
+    deletion is currently SILENT. Conversely, fixtures ADDED post-baseline are
+    not compared at all (no baseline entry). Operators changing the fixture set
+    must re-baseline explicitly (`--write-baseline`) — otherwise comparisons
+    drift apples-to-oranges without warning. Future work: emit an explicit
+    `[warn] fixture-set drift` line when `set(base_verdicts) != set(current_verdicts)`.
+    """
+    if incomplete:
+        print(
+            "[fatal] --compare-baseline refuses to compare an incomplete run "
+            "(last_run.json header has incomplete: true). Exit 2.",
+            file=sys.stderr,
+        )
+        return 2
+    if not _BASELINE_PATH.exists():
+        print(f"[fatal] no baseline at {_BASELINE_PATH}", file=sys.stderr)
+        return 2
+    baseline = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+    if baseline.get("template_sha") != current_template_sha:
+        print(
+            f"[warn] template_sha drift since baseline (baseline: "
+            f"{baseline.get('template_sha', '?')[:12]}…, current: "
+            f"{current_template_sha[:12]}…); verdict comparison may be apples-to-oranges",
+            file=sys.stderr,
+        )
+    # Per-fixture verdict comparison
+    current_verdicts = {f["id"]: f["verdict"] for f in payload["fixtures"]}
+    base_verdicts = {f["id"]: f["verdict"] for f in baseline.get("fixtures", [])}
+    regressions = []
+    for fid, base_v in base_verdicts.items():
+        cur_v = current_verdicts.get(fid)
+        if base_v == "PASS" and cur_v in ("FAIL", "N/A"):
+            regressions.append((fid, base_v, cur_v))
+    if regressions:
+        for fid, b, c in regressions:
+            print(f"[regression] {fid}: baseline {b} → current {c}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def score(

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -19,6 +19,7 @@ import argparse
 import datetime as _dt
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -123,23 +124,29 @@ _DISPATCH_HEADER_TEMPLATE = """\
 """
 
 
+_PLACEHOLDER_RE = re.compile(r"\{[A-Z_][A-Z0-9_]*\}")
+
+
 def _validate_rendered_prompt(rendered: str) -> None:
     """I-T9 (M-4): length-floor + placeholder-residual check.
 
     Template-evolution-tolerant. Catches catastrophically-empty renders
     and unsubstituted placeholders without binding to specific placeholder names.
+
+    QG R1 Fix 6: narrowed to `{UPPER_SNAKE_CASE}` placeholder shape only —
+    bare `{` characters (JSON examples, prose, `${VAR}` syntax) no longer
+    false-positive.
     """
     if len(rendered) <= 200:
         raise ValueError(
             f"rendered prompt has length {len(rendered)} ≤ 200 bytes "
             f"(I-T9 length-floor): suspect catastrophic-empty render"
         )
-    if "{" in rendered:
-        idx = rendered.index("{")
-        context = rendered[max(0, idx - 20):idx + 40]
+    leftover = _PLACEHOLDER_RE.findall(rendered)
+    if leftover:
         raise ValueError(
-            f"rendered prompt contains unsubstituted `{{` placeholder marker "
-            f"at offset {idx} (I-T9 placeholder-residual): {context!r}"
+            f"rendered prompt contains unsubstituted placeholders "
+            f"(I-T9 placeholder-residual): {leftover}"
         )
 
 
@@ -158,8 +165,16 @@ def stage(
     Raises:
         ValueError: invalid run_id (I-9) or source+fixture intersection (M-1)
         FileExistsError: dispatch dir exists and force=False
+        ValueError: trials_override < 1 or timeout < 1 (QG R1 Fix 4)
     """
     validate_run_id(run_id)
+    # QG R1 Fix 4: reject zero/negative trials_override + timeout (false-green guard)
+    if trials_override is not None and trials_override < 1:
+        raise ValueError(
+            f"--trials-override must be >= 1 (got {trials_override})"
+        )
+    if timeout < 1:
+        raise ValueError(f"--timeout must be >= 1 (got {timeout})")
 
     # Load fixtures
     evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
@@ -228,6 +243,9 @@ def stage(
         "dispatch_timeout": timeout,
         "reviewer_model": "opus",
         "template_sha": tpl_sha,
+        # QG R1 Fix 2: record trials_override so score() can honor manifest's
+        # actual trial count, not recompute from evals.json replicate_rule.
+        "trials_override": trials_override,
         "trials": trials,
     }
     (dispatch_dir / "stage-manifest.json").write_text(
@@ -452,7 +470,16 @@ def _compare_baseline(payload: dict, current_template_sha: str, *, incomplete: b
     if not _BASELINE_PATH.exists():
         print(f"[fatal] no baseline at {_BASELINE_PATH}", file=sys.stderr)
         return 2
-    baseline = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+    # QG R1 Fix 3: guard malformed/truncated baseline.json (e.g. interrupted
+    # prior `--write-baseline`). Surface fatal-with-context not raw traceback.
+    try:
+        baseline = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        print(
+            f"[fatal] baseline.json malformed or unreadable: {e}",
+            file=sys.stderr,
+        )
+        return 2
     if baseline.get("template_sha") != current_template_sha:
         print(
             f"[warn] template_sha drift since baseline (baseline: "
@@ -520,8 +547,17 @@ def score(
             incomplete = True
         # Parse "errors: N/total" line if present (I-11)
         if len(first) >= 2 and first[1].startswith("errors:"):
-            n_str, total_str = first[1].removeprefix("errors:").strip().split("/")
-            n_err, total = int(n_str), int(total_str)
+            # QG R1 Fix 1: guard malformed payload (e.g. `errors:`, `errors: abc/5`,
+            # `errors: 1`). Surface fatal-with-context instead of raw traceback.
+            try:
+                n_str, total_str = first[1].removeprefix("errors:").strip().split("/")
+                n_err, total = int(n_str), int(total_str)
+            except (ValueError, IndexError):
+                print(
+                    f"[fatal] malformed .collect-status second line: {first[1]!r}",
+                    file=sys.stderr,
+                )
+                return 2
             if total > 0 and n_err == total:
                 if not allow_incomplete:
                     print(
@@ -580,14 +616,25 @@ def score(
         by_fixture.setdefault(fid, []).append((entry["trial"], entry, out))
 
     # Run lens_runner per fixture
+    # QG R1 Fix 2: honor manifest's trials_override header (if set) as the
+    # canonical n_trials per fixture, not the evals.json replicate_rule. Falls
+    # back to per-fixture manifest-trial count when no override was recorded
+    # (e.g. legacy manifests). Threshold is clamped against the actual N.
+    manifest_trials_override = manifest.get("trials_override")
     fixture_results: list[dict] = []
     for fid, trials_list in by_fixture.items():
         fix = fixtures_by_id[fid]
         trials_list.sort(key=lambda t: t[0])
         reviewer_outputs = [out for _, _, out in trials_list]
         rule = fix.get("replicate_rule", {"trials": 1, "threshold": 1})
-        n_trials = rule.get("trials", 1)
+        if manifest_trials_override is not None:
+            n_trials = manifest_trials_override
+        else:
+            # Count actual trial entries the manifest staged for this fixture
+            n_trials = len(trials_list) or rule.get("trials", 1)
         threshold = rule.get("threshold", 1)
+        if threshold > n_trials:
+            threshold = n_trials  # clamp
         result = _aggregate_from_outputs(
             fix, reviewer_outputs, n_trials=n_trials, threshold=threshold
         )

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -37,6 +37,26 @@ _LAST_RUN = (
     if os.environ.get("TEMPER_LAST_RUN_OVERRIDE")
     else _EVALS_DIR / "last_run.json"
 )
+
+
+def _resolve_output_path(run_id: str, *, per_iter: bool) -> Path:
+    """S4 R6: resolves output path at call time using CURRENT _EVALS_DIR.
+
+    Replaces direct `_LAST_RUN` / `_EVALS_DIR / ".calibrate-state" / ...` references
+    in score(). Eliminates the import-time vs runtime asymmetry that previously
+    required tests to monkeypatch _LAST_RUN AND _EVALS_DIR separately.
+
+    Note: `TEMPER_LAST_RUN_OVERRIDE` (Task 4 Step 3.5 addendum) still wins for the
+    SHARED path when set — preserved here for legacy test-isolation parity. The
+    per-iter path is unaffected by the override (no test currently needs it).
+    """
+    if per_iter:
+        return _EVALS_DIR / ".calibrate-state" / f"last_run-{run_id}.json"
+    # Legacy override hook preserved (Task 4 Step 3.5 addendum)
+    env_override = os.environ.get("TEMPER_LAST_RUN_OVERRIDE")
+    if env_override:
+        return Path(env_override)
+    return _EVALS_DIR / "last_run.json"
 # SP-R7-C: declared in Task 6 (not Task 8) so test_run_evals_score.py's
 # `_seed_dispatch_dir` helper can `monkeypatch.setattr(run_evals, "_BASELINE_PATH", ...)`
 # without raising AttributeError. The `_write_baseline` / `_compare_baseline` helper
@@ -596,16 +616,13 @@ def score(
         payload["force_rescore"] = True
 
     # F1 / S-FE-5 R3: per-iter outputs under .calibrate-state/ (blanket-gitignored)
+    out_path = _resolve_output_path(run_id, per_iter=per_iter)
     if per_iter:
-        per_iter_dir = _EVALS_DIR / ".calibrate-state"
-        per_iter_dir.mkdir(parents=True, exist_ok=True)
-        out_path = per_iter_dir / f"last_run-{run_id}.json"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
         print(
             f"[info] writing per-iter output to {out_path} (gitignored via .calibrate-state/)",
             file=sys.stderr,
         )
-    else:
-        out_path = _LAST_RUN
     out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
     # --write-baseline + --compare-baseline — see Task 8 (stubs raise NotImplementedError)

--- a/skills/temper/evals/test_argparse_help.py
+++ b/skills/temper/evals/test_argparse_help.py
@@ -1,0 +1,46 @@
+"""AC-10: argparse --help output golden test.
+
+Uses substring assertions on flag names rather than full byte-equality
+to survive argparse's formatting drift across Python versions / terminal widths.
+"""
+import subprocess
+import sys
+
+
+def _help_text(argv: list[str]) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "skills.temper.evals.run_evals", *argv, "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    return result.stdout + result.stderr
+
+
+def test_stage_help_lists_all_flags():
+    out = _help_text(["stage"])
+    for flag in ["--force", "--source", "--fixture", "--trials-override", "--timeout"]:
+        assert flag in out, f"missing {flag} in `stage --help`"
+    assert "run_id" in out
+
+
+def test_score_help_lists_all_flags():
+    # F-R4-1: `--per-iter` is asserted by Task 13's `test_score_help_lists_per_iter`
+    # (S-1 R5; added in the same atomic commit that declares + wires the flag).
+    # It is NOT asserted here because the flag does not exist on the score
+    # subparser until Task 13 lands.
+    out = _help_text(["score"])
+    for flag in ["--write-baseline", "--compare-baseline", "--force-rescore",
+                 "--allow-incomplete"]:
+        assert flag in out, f"missing {flag} in `score --help`"
+    assert "run_id" in out
+
+
+def test_root_help_lists_legacy_flags():
+    out = _help_text([])
+    for flag in ["--legacy-fixture", "--legacy-timeout", "--legacy-trials-override",
+                 "--mock-reviewer", "--replay"]:
+        assert flag in out, f"missing {flag} in root --help"
+
+
+def test_root_help_lists_subcommands():
+    out = _help_text([])
+    assert "stage" in out and "score" in out

--- a/skills/temper/evals/test_dispatch_paths.py
+++ b/skills/temper/evals/test_dispatch_paths.py
@@ -1,0 +1,35 @@
+"""Tests for _dispatch_paths: resolve_dispatch_dir + fixture_sha."""
+import os
+from pathlib import Path
+
+from skills.temper.evals._dispatch_paths import fixture_sha, resolve_dispatch_dir
+
+
+def test_resolve_dispatch_dir_uses_xdg_runtime(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "alice")
+    p = resolve_dispatch_dir("R-test")
+    assert p == tmp_path / "alice-crucible-dispatch-R-test"
+
+
+def test_resolve_dispatch_dir_falls_back_to_tmp(monkeypatch, tmp_path):
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setenv("USER", "alice")
+    p = resolve_dispatch_dir("R-test")
+    assert str(p).startswith("/tmp/")
+    assert "alice-crucible-dispatch-R-test" in str(p)
+
+
+def test_resolve_dispatch_dir_handles_unset_user(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.delenv("USER", raising=False)
+    p = resolve_dispatch_dir("R-test")
+    assert str(os.getuid()) in str(p)
+
+
+def test_fixture_sha_deterministic():
+    record = {"id": "x", "prompt": "p", "allowed_files": ["a"]}
+    h1 = fixture_sha(record)
+    h2 = fixture_sha({"prompt": "p", "id": "x", "allowed_files": ["a"]})  # key reorder
+    assert h1 == h2  # sort_keys=True normalizes
+    assert len(h1) == 64  # sha256 hex

--- a/skills/temper/evals/test_inquisitor_edge_cases.py
+++ b/skills/temper/evals/test_inquisitor_edge_cases.py
@@ -1,0 +1,127 @@
+"""Inquisitor Edge Cases dimension (#297).
+
+Hunts boundary-condition failures at the new public API surfaces.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from skills.temper.evals import run_evals
+from skills.temper.evals._dispatch_paths import fixture_sha, resolve_dispatch_dir
+from skills.temper.evals._runid import sanitize_summary, validate_run_id
+from skills.temper.evals.run_evals import _parse_result_file, score, stage
+
+
+def _seed(monkeypatch, tmp_path, run_id="R-edge"):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    return stage(run_id)
+
+
+# Vector 1: run-id at the exact length boundary (32 chars — the _RUN_ID_RE
+# upper bound). Off-by-one in the regex would either reject valid IDs or
+# accept oversized ones that overflow downstream filename buffers.
+def test_run_id_exactly_32_chars_is_accepted():
+    """32 = max length per _RUN_ID_RE `[A-Za-z0-9_-]{0,31}` after the leading char."""
+    # 1 leading + 31 trailing = 32 total
+    rid = "A" + ("a" * 31)
+    assert len(rid) == 32
+    validate_run_id(rid)  # must not raise
+
+
+def test_run_id_33_chars_is_rejected():
+    """33 chars must be rejected — proves the regex bound is inclusive."""
+    rid = "A" + ("a" * 32)
+    assert len(rid) == 33
+    with pytest.raises(ValueError):
+        validate_run_id(rid)
+
+
+# Vector 2: dispatch-dir resolver with USER unset AND XDG_RUNTIME_DIR unset
+# simultaneously. The implementation falls back to UID + /tmp, but if either
+# fallback raises (e.g., os.getuid() fails inside a chroot), the entire stage
+# pipeline crashes before any user-facing error.
+def test_resolve_dispatch_dir_both_envs_unset(monkeypatch):
+    """Container environment with neither XDG_RUNTIME_DIR nor USER set."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("USER", raising=False)
+    p = resolve_dispatch_dir("R-x")
+    # Must resolve to /tmp + <uid> + crucible-dispatch
+    assert str(p).startswith("/tmp/"), f"unexpected fallback path: {p}"
+    assert "crucible-dispatch-R-x" in str(p)
+
+
+# Vector 3: sanitize_summary on extreme inputs: empty string, very long string,
+# multiple sentinels in one summary, sentinel at the very start, sentinel at
+# the very end. A regression that uses .replace() with maxreplace=1 would
+# silently leave subsequent sentinels intact.
+def test_sanitize_summary_replaces_all_occurrences():
+    """Multiple literal sentinels must all be replaced — `.replace()` default
+    is replace-all but a future maxreplace=1 regression would silently leak."""
+    s = "DISPATCH_STATUS: OK then DISPATCH_STATUS: ERROR midway DISPATCH_STATUS: done"
+    out = sanitize_summary(s)
+    assert "DISPATCH_STATUS:" not in out, (
+        f"sanitize_summary leaked sentinel(s): {out!r}"
+    )
+    assert out.count("[DISPATCH_STATUS_LITERAL]") == 3
+
+
+def test_sanitize_summary_empty_string():
+    """Empty input must not crash."""
+    assert sanitize_summary("") == ""
+
+
+# Vector 4: `_parse_result_file` on a result file that is entirely empty
+# (zero bytes) — a plausible filesystem corruption / aborted write residue.
+# Must not crash; must return None (treat as ERROR).
+def test_parse_result_file_zero_byte_file(tmp_path):
+    """Zero-byte result file (e.g. aborted atomic write left a truncated
+    target) must return None, not crash."""
+    p = tmp_path / "empty.md"
+    p.write_text("")
+    assert _parse_result_file(p) is None
+
+
+def test_parse_result_file_only_sentinel_line_no_blank_no_body(tmp_path):
+    """`DISPATCH_STATUS: OK` with NO trailing newline at all — common shell
+    pipe artifact. Must not crash."""
+    p = tmp_path / "no-trailing.md"
+    p.write_text("DISPATCH_STATUS: OK")
+    out = _parse_result_file(p)
+    assert out is None  # no body present
+
+
+# Vector 5: score() on an empty fixture set. `--fixture <nonexistent>` is
+# already covered by stage()'s M-1 check, but what if evals.json itself is
+# empty? The score loop must not divide-by-zero or crash on empty manifests.
+def test_score_handles_empty_manifest(monkeypatch, tmp_path):
+    """If stage somehow produces a manifest with zero trials, score must
+    still write a valid empty last_run.json — not crash."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+
+    # Hand-craft an empty dispatch dir + manifest
+    d = resolve_dispatch_dir("R-empty")
+    d.mkdir(parents=True)
+    (d / "stage-manifest.json").write_text(json.dumps({
+        "run_id": "R-empty",
+        "stage_timestamp": "2026-01-01T00:00:00Z",
+        "dispatch_timeout": 300,
+        "reviewer_model": "opus",
+        "template_sha": "a" * 64,
+        "trials": [],
+    }))
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    rc = score("R-empty", allow_incomplete=False)
+    assert rc == 0  # no fixtures → no failures
+    out = json.loads((tmp_path / "last_run.json").read_text())
+    assert out["fixtures"] == []

--- a/skills/temper/evals/test_inquisitor_integration.py
+++ b/skills/temper/evals/test_inquisitor_integration.py
@@ -92,8 +92,11 @@ def test_baseline_write_compare_uses_symmetric_template_sha_key(monkeypatch, tmp
     written = json.loads((tmp_path / "baseline.json").read_text())
     assert "template_sha" in written, "_write_baseline does not write template_sha"
     assert written["template_sha"] == "deadbeef" * 8
-    # Compare with the SAME sha should not trigger the drift warning
-    rc = _compare_baseline(payload, "deadbeef" * 8, incomplete=False)
+    # Compare with the SAME sha should not trigger the drift warning.
+    # evals_fixture_ids covers the fixture in payload so no drift is reported.
+    rc = _compare_baseline(
+        payload, "deadbeef" * 8, incomplete=False, evals_fixture_ids={"x"}
+    )
     assert rc == 0  # no regression, sha matches
 
 

--- a/skills/temper/evals/test_inquisitor_integration.py
+++ b/skills/temper/evals/test_inquisitor_integration.py
@@ -1,0 +1,151 @@
+"""Inquisitor Integration dimension (#297).
+
+Hunts data-format / contract mismatches between stage <-> collect <-> score
+and between baseline write <-> compare.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from skills.temper.evals import run_evals
+from skills.temper.evals.run_evals import (
+    _aggregate_from_outputs,
+    _compare_baseline,
+    _parse_result_file,
+    _write_baseline,
+    score,
+    stage,
+)
+
+
+def _seed(monkeypatch, tmp_path, run_id="R-int"):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    return stage(run_id)
+
+
+# Vector 1: stage writes `trials[].result_file` strings; score reads files from
+# `dispatch_dir / entry["result_file"]`. If stage's filename convention drifts
+# (e.g., 4-digit zero-pad becomes 3-digit, or `.md` becomes `.txt`), score
+# silently sees no result files and produces all-None aggregation. Verify
+# the round-trip: every file score expects, stage actually emits.
+def test_stage_result_file_names_match_score_expectations(monkeypatch, tmp_path):
+    """Producer (stage) -> Consumer (score) filename contract round-trip."""
+    d = _seed(monkeypatch, tmp_path, "R-rtrip")
+    manifest = json.loads((d / "stage-manifest.json").read_text())
+    # Simulate collect: write each result_file as DISPATCH_STATUS: OK with body
+    for trial in manifest["trials"]:
+        (d / trial["result_file"]).write_text(
+            "DISPATCH_STATUS: OK\n\n### Code Review\nVerdict: changes-requested\n"
+        )
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-rtrip", allow_incomplete=False)
+    out = json.loads((tmp_path / "last_run.json").read_text())
+    # If filename convention mismatched, all reviewer_outputs would be None.
+    # Verify at least one fixture got real reviewer output.
+    any_real = any(
+        any(o is not None for o in fr["reviewer_outputs"])
+        for fr in out["fixtures"]
+    )
+    assert any_real, (
+        "stage result_file names do not match what score expects to read — "
+        "no fixture got a populated reviewer_output despite seeded result files"
+    )
+
+
+# Vector 2: `_aggregate_from_outputs` takes (fix, reviewer_outputs, n_trials,
+# threshold). The score() loop and the legacy _run_fixture() both call it.
+# If either caller drops a kwarg, the function raises TypeError. Verify both
+# call sites still produce equivalent results given the same fixture.
+def test_aggregate_callers_produce_consistent_results():
+    """Both call sites of _aggregate_from_outputs must agree on the contract."""
+    fix = {
+        "id": "synthetic",
+        "expectations": [],
+        "replicate_rule": {"trials": 3, "threshold": 2},
+    }
+    # Call directly with explicit kwargs
+    direct = _aggregate_from_outputs(fix, [None, None, None], n_trials=3, threshold=2)
+    assert direct["id"] == "synthetic"
+    assert direct["trials"] == 3
+    assert direct["threshold"] == 2
+    # Verify the contract is the keyword form (positional would be brittle)
+    with pytest.raises(TypeError):
+        _aggregate_from_outputs(fix, [None], 1, 1)  # all positional should fail
+
+
+# Vector 3: baseline write/compare round-trip. _write_baseline writes
+# `template_sha` field; _compare_baseline reads `template_sha`. If schema
+# drifts (e.g., key rename to `template_hash`), compare silently warns about
+# "drift" on every run. Verify the symmetric key.
+def test_baseline_write_compare_uses_symmetric_template_sha_key(monkeypatch, tmp_path):
+    """SP-1: baseline header carries template_sha; compare must read the same key."""
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    payload = {"fixtures": [{"id": "x", "verdict": "PASS"}]}
+    _write_baseline(payload, "deadbeef" * 8)
+    written = json.loads((tmp_path / "baseline.json").read_text())
+    assert "template_sha" in written, "_write_baseline does not write template_sha"
+    assert written["template_sha"] == "deadbeef" * 8
+    # Compare with the SAME sha should not trigger the drift warning
+    rc = _compare_baseline(payload, "deadbeef" * 8, incomplete=False)
+    assert rc == 0  # no regression, sha matches
+
+
+# Vector 4: the `incomplete` flag propagates from .collect-status parsing in
+# score() through to the payload header, then is consumed by _compare_baseline
+# to refuse. If the boolean polarity flips anywhere in the chain (e.g.,
+# `incomplete=False` accidentally becomes the absence of the key), compare
+# would silently accept incomplete runs and produce false PASS comparisons.
+def test_incomplete_flag_propagates_through_score_to_compare(monkeypatch, tmp_path):
+    """End-to-end: collect-status absent -> score writes incomplete: true ->
+    compare refuses with rc=2."""
+    _seed(monkeypatch, tmp_path, "R-incomp-int")
+    # No .collect-status: with allow_incomplete=True, score writes incomplete header
+    rc = score("R-incomp-int", allow_incomplete=True)
+    assert rc in (0, 1)  # write succeeded
+    out = json.loads((tmp_path / "last_run.json").read_text())
+    assert out.get("incomplete") is True
+    # Now write a baseline first (clean) then compare on incomplete payload
+    clean_payload = {"fixtures": []}
+    _write_baseline(clean_payload, "x" * 64)
+    # Re-score with compare_baseline + allow_incomplete; must refuse with rc=2
+    rc2 = score("R-incomp-int", compare_baseline=True, allow_incomplete=True)
+    assert rc2 == 2, (
+        f"compare_baseline did not refuse on incomplete run (got rc={rc2}); "
+        f"incomplete-flag propagation broken between score() and _compare_baseline"
+    )
+
+
+# Vector 5: the DISPATCH_STATUS sentinel format is the contract between the
+# collect skill (producer) and `_parse_result_file` (consumer). SKILL.md
+# documents three sentinel shapes:
+#   "DISPATCH_STATUS: OK\n\n<body>"
+#   "DISPATCH_STATUS: ERROR: <reason>\n\n"
+#   "DISPATCH_STATUS: ERROR: output-too-large\n\n"
+# Verify each documented shape is consumed correctly. A parser regression to
+# require trailing whitespace or specific casing would silently drop valid
+# inputs.
+def test_parse_handles_all_documented_sentinel_shapes(tmp_path):
+    """Producer (collect skill SKILL.md) documents these shapes; consumer
+    (`_parse_result_file`) must accept all of them and reject none."""
+    shapes = {
+        "ok_with_body": ("DISPATCH_STATUS: OK\n\n# body content here\n", "not-none"),
+        "error_timeout": ("DISPATCH_STATUS: ERROR: timeout\n\n", "none"),
+        "error_empty_body": ("DISPATCH_STATUS: ERROR: empty-body\n\n", "none"),
+        "error_too_large": ("DISPATCH_STATUS: ERROR: output-too-large\n\n", "none"),
+        "error_generic": ("DISPATCH_STATUS: ERROR: some-other\n\n", "none"),
+    }
+    for name, (content, expected) in shapes.items():
+        p = tmp_path / f"{name}.md"
+        p.write_text(content)
+        out = _parse_result_file(p)
+        if expected == "none":
+            assert out is None, f"shape {name!r} should parse to None, got {out!r}"
+        else:
+            assert out is not None, f"shape {name!r} should parse to body, got None"

--- a/skills/temper/evals/test_inquisitor_lifecycle.py
+++ b/skills/temper/evals/test_inquisitor_lifecycle.py
@@ -1,0 +1,118 @@
+"""Inquisitor State & Lifecycle dimension (#297).
+
+Hunts state-mismanagement across the stage -> collect -> score lifecycle
+and across consecutive runs with the same / overlapping run-ids.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from skills.temper.evals import run_evals
+from skills.temper.evals._dispatch_paths import resolve_dispatch_dir
+from skills.temper.evals.run_evals import score, stage
+
+
+def _seed(monkeypatch, tmp_path, run_id):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    return stage(run_id)
+
+
+# Vector 1: score-before-stage. Operator invokes `score R-typo` without first
+# staging — must produce a clear fatal (rc=2) about the missing manifest,
+# not crash with an opaque FileNotFoundError. Lifecycle violation must be
+# diagnosed.
+def test_score_without_stage_returns_fatal_not_traceback(monkeypatch, tmp_path):
+    """Score-before-stage must return rc=2, not raise an unhandled exception."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    # No stage was called for R-no-stage
+    rc = score("R-no-stage")
+    assert rc == 2  # fatal but graceful
+
+
+# Vector 2: stage->stage (re-stage without --force). The second stage MUST
+# refuse with FileExistsError (idempotency-preserving). A silent overwrite
+# would race with any in-flight `/temper-eval-collect` invocation against
+# the original stage.
+def test_restage_without_force_refuses(monkeypatch, tmp_path):
+    """Re-staging the same run-id without --force protects in-flight collects."""
+    _seed(monkeypatch, tmp_path, "R-restage")
+    with pytest.raises(FileExistsError):
+        stage("R-restage")
+
+
+# Vector 3: stage->stage(force)->score lifecycle. After a forced re-stage,
+# the OLD result files are wiped (rmtree). If score holds stale file handles
+# from a prior invocation, it would read garbage. Verify clean lifecycle:
+# force-restage produces an empty dispatch dir, score sees only new content.
+def test_force_restage_wipes_stale_result_files(monkeypatch, tmp_path):
+    """Force re-stage MUST rmtree the dispatch dir so stale result files
+    from a prior collect cannot contaminate the new score."""
+    d = _seed(monkeypatch, tmp_path, "R-wipe")
+    # Simulate a prior collect: drop result files + collect-status + a sentinel
+    manifest = json.loads((d / "stage-manifest.json").read_text())
+    first_trial = manifest["trials"][0]
+    (d / first_trial["result_file"]).write_text("DISPATCH_STATUS: OK\n\nstale body\n")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    (d / "operator-marker").write_text("would survive a soft restage")
+
+    # Force re-stage
+    d2 = stage("R-wipe", force=True)
+    assert d2 == d
+    # All non-stage files must be gone
+    assert not (d / first_trial["result_file"]).exists()
+    assert not (d / ".collect-status").exists()
+    assert not (d / "operator-marker").exists()
+    # Stage artifacts re-created
+    assert (d / "stage-manifest.json").exists()
+
+
+# Vector 4: per-iter output directory creation. score(..., per_iter=True)
+# writes to `.calibrate-state/last_run-<rid>.json`. The directory must be
+# created lazily on first call (operators don't pre-create it). If it's
+# missing AND mkdir isn't called, the write raises FileNotFoundError —
+# which would corrupt a calibrate sweep mid-iteration.
+def test_per_iter_creates_calibrate_state_dir_lazily(monkeypatch, tmp_path):
+    """First-ever --per-iter score must lazy-create `.calibrate-state/`."""
+    d = _seed(monkeypatch, tmp_path, "R-lazy")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    # Confirm the dir does NOT exist before score
+    cal_dir = tmp_path / ".calibrate-state"
+    assert not cal_dir.exists()
+    rc = score("R-lazy", per_iter=True, allow_incomplete=False)
+    assert rc in (0, 1)
+    # Now it MUST exist with the per-iter file inside
+    assert cal_dir.exists() and cal_dir.is_dir()
+    assert (cal_dir / "last_run-R-lazy.json").exists()
+
+
+# Vector 5: consecutive per-iter scores with same run-id. Calibrate's
+# idempotency check (sentinel + last_run-<i>.json with matching run_id)
+# guards against re-running. But what if the operator manually invokes
+# `score R-x --per-iter` twice without the calibrate skill's sentinel? The
+# SECOND write must succeed (no lock file blocks it) AND must overwrite
+# cleanly (no partial-write residue from the first).
+def test_per_iter_score_can_safely_re_run(monkeypatch, tmp_path):
+    """Manually re-running `score --per-iter` overwrites cleanly."""
+    d = _seed(monkeypatch, tmp_path, "R-rerun")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-rerun", per_iter=True, allow_incomplete=False)
+    per_iter_path = tmp_path / ".calibrate-state" / "last_run-R-rerun.json"
+    assert per_iter_path.exists()
+    first = json.loads(per_iter_path.read_text())
+    # Second run must succeed without error
+    score("R-rerun", per_iter=True, allow_incomplete=False)
+    second = json.loads(per_iter_path.read_text())
+    # Both must have run_id field set correctly (no partial-write corruption)
+    assert first["run_id"] == "R-rerun"
+    assert second["run_id"] == "R-rerun"

--- a/skills/temper/evals/test_inquisitor_regression.py
+++ b/skills/temper/evals/test_inquisitor_regression.py
@@ -1,0 +1,135 @@
+"""Inquisitor Regression dimension (#297).
+
+Hunts breakage of pre-#297 functionality. Existing AC-3 / legacy_modes tests
+cover --mock-reviewer end-to-end via subprocess; these tests probe the CLI
+surface contracts and the legacy code paths from different angles.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from skills.temper.evals import run_evals
+
+
+# Vector 1: pre-#297, `python -m run_evals` with NO subcommand and NO flags
+# attempted live dispatch. Post-#297, that path is dead. The CLI must NOT
+# crash with a Python traceback — it must produce a clear operator-facing
+# fatal explaining the new stage/score subcommand workflow.
+def test_legacy_main_no_flags_produces_guided_fatal_not_traceback(tmp_path):
+    """Bare `python -m run_evals` (no subcommand, no flags) must guide the
+    operator to the new workflow, not crash."""
+    env = {**os.environ, "TEMPER_LAST_RUN_OVERRIDE": str(tmp_path / "lr.json")}
+    result = subprocess.run(
+        [sys.executable, "-m", "skills.temper.evals.run_evals"],
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+    assert result.returncode != 0  # must be fatal
+    combined = result.stdout + result.stderr
+    assert "Traceback" not in combined, (
+        f"Bare invocation crashed with traceback: {combined}"
+    )
+    # Must mention the new workflow
+    assert "stage" in combined or "/temper-eval-collect" in combined, (
+        f"Fatal message does not guide operator to new workflow: {combined}"
+    )
+
+
+# Vector 2: --replay still works. This is the pre-#297 replay mode for
+# re-evaluating a captured last_run.json. The legacy code path was rewired
+# (template arg removed from _resolve_output, etc.); a regression that
+# accidentally drops --replay support would silently break re-evaluation
+# of historical runs.
+def test_legacy_replay_mode_still_works(monkeypatch, tmp_path):
+    """--replay reads outputs from a prior last_run.json and re-evaluates."""
+    # Fabricate a minimal prior-run last_run.json
+    fake_last_run = tmp_path / "fake_prior.json"
+    fake_last_run.write_text(json.dumps({
+        "run_at": "2026-01-01T00:00:00Z",
+        "fixtures": [
+            {
+                "id": "1a",  # real fixture id from evals.json
+                "verdict": "PASS",
+                "trials": 1,
+                "threshold": 1,
+                "reviewer_outputs": [
+                    "### Code Review\nVerdict: changes-requested\n\n### Issues\nFinding text\n"
+                ],
+                "expectations": [],
+            }
+        ],
+    }))
+    out = tmp_path / "last_run.json"
+    env = {**os.environ, "TEMPER_LAST_RUN_OVERRIDE": str(out)}
+    result = subprocess.run(
+        [sys.executable, "-m", "skills.temper.evals.run_evals",
+         "--replay", str(fake_last_run), "--legacy-fixture", "1a"],
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+    # Replay mode must not crash with traceback even if verdicts are N/A
+    assert "Traceback" not in (result.stdout + result.stderr), (
+        f"--replay regressed: {result.stderr}"
+    )
+    assert out.exists()
+
+
+# Vector 3: lens_runner.evaluate_expectation and aggregate_replicates contracts
+# remained intact through the refactor. _aggregate_from_outputs is the new
+# wrapper that calls them; verify with a real expectation that they still work.
+def test_lens_runner_evaluate_contract_unchanged():
+    """The lens_runner public surface used by score()/legacy must still work."""
+    from skills.temper.evals import lens_runner
+    # Use a real fixture's expectation shape (verdict_contains is common)
+    fix = {"id": "x", "expected_output": "test"}
+    expectation = {"check": "verdict_contains", "params": {"value": "approve"}}
+    reviewer_out = "### Code Review\nVerdict: approve\nNo findings.\n"
+    verdict, rationale = lens_runner.evaluate_expectation(expectation, reviewer_out, fix)
+    assert verdict in ("PASS", "FAIL", "N/A")
+    assert isinstance(rationale, str)
+
+
+# Vector 4: subprocess module was removed from run_evals.py (was used only
+# by the deleted _dispatch_live). Verify it's truly absent — keeping a stale
+# `import subprocess` would mean dead-code lint trips and would mask any
+# future re-introduction of subprocess shell-outs.
+def test_subprocess_import_removed_from_run_evals():
+    """#297 removed the only subprocess.run() call; the import should be gone."""
+    import inspect
+    src = inspect.getsource(run_evals)
+    # Allow subprocess in docstrings (post-#297 references it in deprecation note)
+    # but it must not be imported.
+    assert "\nimport subprocess" not in src, (
+        "subprocess module still imported in run_evals.py — dead code or "
+        "silent re-introduction of banned subprocess dispatch"
+    )
+
+
+# Vector 5: argparse flag rename --fixture -> --legacy-fixture for the root
+# parser (pre-existing) must NOT have broken the `stage --fixture` subparser
+# flag. A naive find/replace during the refactor could have inadvertently
+# renamed the stage subparser's --fixture too, breaking the calibrate skill's
+# documented `--fixture <id>` pass-through.
+def test_stage_fixture_flag_not_renamed_to_legacy_fixture(tmp_path, monkeypatch):
+    """The stage subparser's --fixture flag must remain --fixture (not
+    --legacy-fixture). Calibrate skill passes --fixture through verbatim."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    # `stage R-x --fixture 1a` must succeed (or fail for fixture-not-found
+    # reasons, NOT for "unrecognized arguments" reasons).
+    result = subprocess.run(
+        [sys.executable, "-m", "skills.temper.evals.run_evals",
+         "stage", "R-fixflag", "--fixture", "1a"],
+        capture_output=True, text=True, timeout=30,
+        env={**os.environ, "XDG_RUNTIME_DIR": str(tmp_path), "USER": "tester"},
+    )
+    # If --fixture was renamed, argparse error would mention "unrecognized"
+    assert "unrecognized arguments" not in result.stderr.lower(), (
+        f"stage --fixture flag broken: {result.stderr}"
+    )
+    # And it should produce a dispatch dir
+    assert (tmp_path / "tester-crucible-dispatch-R-fixflag").exists()

--- a/skills/temper/evals/test_inquisitor_wiring.py
+++ b/skills/temper/evals/test_inquisitor_wiring.py
@@ -1,0 +1,122 @@
+"""Inquisitor Wiring dimension (#297 full-feature scan).
+
+Hunts cross-component wiring bugs: new entry points / helpers that exist but
+are not actually reachable from intended callers.
+
+Per-task tests verify each helper in isolation. These tests verify the seams
+between the helper, the CLI surface, and the SKILL.md documented invocations.
+"""
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+from skills.temper.evals import run_evals
+
+
+# Vector 1: every flag the calibrate SKILL.md tells operators to pass to `score`
+# must actually exist on the score subparser. The calibrate skill shells out via
+# bash; a typo in either side would silently fail at runtime, not at import.
+def test_calibrate_skill_score_flags_exist_on_score_subparser():
+    """Calibrate skill Step 3e shell-outs: `score $RUN_ID --per-iter [--write-baseline]
+    [--compare-baseline]`. Every flag mentioned must exist on the score subparser.
+    """
+    skill = Path("skills/temper-eval-calibrate/SKILL.md").read_text()
+    # Extract the score invocation line
+    m = re.search(r"score[^\n]*--per-iter[^\n]*", skill)
+    assert m, "calibrate SKILL.md no longer shells out to `score ... --per-iter`"
+    flags_in_skill = set(re.findall(r"--[a-z][a-z-]*", m.group(0)))
+
+    # Pull score subparser's actual flags
+    parser = importlib.reload(run_evals)._parse_args.__wrapped__ if hasattr(
+        run_evals._parse_args, "__wrapped__"
+    ) else None
+    # Direct approach: invoke `score --help` machinery via argparse introspection
+    import argparse
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd")
+    # Re-derive via _parse_args by feeding `score --help` style probe is hard;
+    # instead, parse a known-good `score` invocation and check available actions.
+    # Simpler: stage manifest of available flags from source of truth.
+    src = Path("skills/temper/evals/run_evals.py").read_text()
+    # find sp_score block
+    score_block = re.search(
+        r"sp_score = sub\.add_parser.*?(?=\n[a-zA-Z#])", src, re.DOTALL
+    )
+    assert score_block, "sp_score block not found in run_evals.py"
+    declared_flags = set(re.findall(r'add_argument\("(--[a-z-]+)"', score_block.group(0)))
+
+    missing = flags_in_skill - declared_flags
+    assert not missing, (
+        f"calibrate SKILL.md references {missing} on `score` subparser but those "
+        f"flags are not declared. Declared: {sorted(declared_flags)}"
+    )
+
+
+# Vector 2: the collect skill's bash example sanitize_summary shell-out imports
+# `sanitize_summary` from `skills.temper.evals._runid`. If the helper is moved
+# or renamed, the SKILL.md example silently rots — no test catches it because
+# the skill body is a markdown doc, not code. Verify the symbol path.
+def test_collect_skill_sanitize_summary_symbol_resolves():
+    """SKILL.md Step 7 shell-out: `from skills.temper.evals._runid import sanitize_summary`.
+    A future refactor that moves the helper to a different module would silently
+    break the shell-out at runtime. Pin the symbol path here.
+    """
+    skill = Path("skills/temper-eval-collect/SKILL.md").read_text()
+    assert "from skills.temper.evals._runid import sanitize_summary" in skill, (
+        "collect SKILL.md no longer references the documented import path"
+    )
+    # Now verify the import actually works
+    from skills.temper.evals._runid import sanitize_summary  # noqa
+    assert callable(sanitize_summary)
+
+
+# Vector 3: `_resolve_output_path` exists as a documented helper (S4 R6) and
+# is supposed to be the SOLE routing function for both shared and per-iter
+# paths. Verify it is actually called from `score()` — not just defined.
+# A regression where score() reverts to direct `_LAST_RUN` writes would
+# silently break the per-iter routing.
+def test_score_uses_resolve_output_path_helper():
+    """S4 R6: score() must route via _resolve_output_path. Hard-coding the
+    output path inline would re-introduce the import-time vs runtime asymmetry
+    the helper was extracted to eliminate.
+    """
+    import inspect
+    src = inspect.getsource(run_evals.score)
+    assert "_resolve_output_path(" in src, (
+        "score() no longer routes via _resolve_output_path — per-iter writes "
+        "may be hard-coded again, breaking test isolation"
+    )
+
+
+# Vector 4: the `stage` subparser must be wired into main()'s dispatch chain.
+# `_parse_args` could declare the subparser AND main() could omit the
+# `if args.cmd == "stage"` branch — argparse would parse fine, main() would
+# silently fall through to legacy_main and fail with a confusing error.
+def test_stage_subcommand_main_dispatch_wired():
+    """Wiring: `_parse_args` declares stage; `main()` must dispatch to stage()."""
+    import inspect
+    src = inspect.getsource(run_evals.main)
+    assert 'args.cmd == "stage"' in src, "main() does not dispatch the stage subcommand"
+    assert "stage(" in src, "main() does not call stage()"
+
+
+# Vector 5: bootstrap_snapshot.py is a standalone script. Operators invoke it
+# as `python -m skills.temper.evals.bootstrap_snapshot`. If `__main__` block
+# is dropped or the module path moves, the documented invocation silently
+# breaks. Verify the entry point exists.
+def test_bootstrap_snapshot_has_main_entrypoint():
+    """bootstrap_snapshot.py must be runnable as `python -m ...` per its
+    docstring. A missing `if __name__ == "__main__":` block would make the
+    documented invocation a no-op."""
+    src = Path("skills/temper/evals/bootstrap_snapshot.py").read_text()
+    assert 'if __name__ == "__main__":' in src, (
+        "bootstrap_snapshot.py missing __main__ block — documented "
+        "`python -m skills.temper.evals.bootstrap_snapshot` invocation will silently no-op"
+    )
+    # Verify the test_legacy_modes failure-message points to the right command
+    legacy = Path("skills/temper/evals/test_legacy_modes.py").read_text()
+    assert "python -m skills.temper.evals.bootstrap_snapshot" in legacy, (
+        "test_legacy_modes failure message references a different bootstrap command"
+    )

--- a/skills/temper/evals/test_legacy_modes.py
+++ b/skills/temper/evals/test_legacy_modes.py
@@ -15,6 +15,7 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 _SNAPSHOT = _REPO_ROOT / "skills" / "temper" / "evals" / "mock_snapshot.json"
 _MOCK_DIR = _REPO_ROOT / "skills" / "temper" / "evals" / "mock-fixtures"
+_EVALS_JSON = _REPO_ROOT / "skills" / "temper" / "evals" / "evals.json"
 
 def _run_mock(tmp_path: Path) -> dict:
     """Run --mock-reviewer and return per-fixture verdicts.
@@ -67,9 +68,11 @@ def test_legacy_mock_reviewer_matches_snapshot(tmp_path):
     # truncated/empty snapshot (e.g. subprocess error swallowed), the equality
     # assertion below would pass trivially — so explicitly floor the shape first.
     # `expected` is a flat {fixture_id: verdict} dict; assert both cardinality and
-    # verdict-presence.
-    assert len(expected) >= 7, (
-        f"snapshot has <7 fixtures (expected N=7); re-bootstrap via "
+    # verdict-presence. Floor is derived from evals.json so it stays current as
+    # fixtures are added.
+    expected_n = len(json.loads(_EVALS_JSON.read_text())["evals"])
+    assert len(expected) >= expected_n, (
+        f"snapshot has <{expected_n} fixtures (expected N={expected_n}); re-bootstrap via "
         f"`python -m skills.temper.evals.bootstrap_snapshot`"
     )
     assert all(isinstance(v, str) and v for v in expected.values()), (

--- a/skills/temper/evals/test_legacy_modes.py
+++ b/skills/temper/evals/test_legacy_modes.py
@@ -1,0 +1,84 @@
+"""F2: regression coverage for legacy --mock-reviewer and --replay paths.
+
+The snapshot is generated OUT-OF-BAND via `python -m skills.temper.evals.bootstrap_snapshot`,
+reviewed and committed. The test below ONLY asserts — it never writes the snapshot.
+This prevents silent capture of local reviewer-output deltas as the canonical baseline.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+# 2P-R4-3: Both helpers use Path(__file__).resolve() to handle symlinked checkouts uniformly.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_SNAPSHOT = _REPO_ROOT / "skills" / "temper" / "evals" / "mock_snapshot.json"
+_MOCK_DIR = _REPO_ROOT / "skills" / "temper" / "evals" / "mock-fixtures"
+
+def _run_mock(tmp_path: Path) -> dict:
+    """Run --mock-reviewer and return per-fixture verdicts.
+
+    2P-FE-2 R3: writes go to tmp_path, never to the repo-tracked last_run.json.
+    """
+    last_run_out = tmp_path / "last_run.json"
+    env = {**os.environ, "TEMPER_LAST_RUN_OVERRIDE": str(last_run_out)}
+    subprocess.run(
+        # DEVIATION FROM PLAN: use sys.executable instead of literal "python".
+        # The host CI/runtime does not symlink `python` → `python3` (Debian/Ubuntu
+        # default without `python-is-python3`). sys.executable is the portable
+        # form and matches the convention used inside bootstrap_snapshot.py.
+        [sys.executable, "-m", "skills.temper.evals.run_evals",
+         "--mock-reviewer", str(_MOCK_DIR)],
+        check=True, capture_output=True, text=True, timeout=120,
+        cwd=str(_REPO_ROOT), env=env,
+    )
+    out = json.loads(last_run_out.read_text())
+    return {f["id"]: f["verdict"] for f in out["fixtures"]}
+
+def test_legacy_mock_reviewer_matches_snapshot(tmp_path):
+    """Assert ONLY — never bootstrap. Missing snapshot is a hard failure."""
+    if not _SNAPSHOT.exists():
+        pytest.fail(
+            f"Snapshot missing at {_SNAPSHOT}. "
+            f"Run bootstrap script locally: "
+            f"`python -m skills.temper.evals.bootstrap_snapshot`. "
+            f"Review the generated mock_snapshot.json, then `git add` and commit "
+            f"BOTH bootstrap_snapshot.py and mock_snapshot.json before pushing."
+        )
+    snapshot = json.loads(_SNAPSHOT.read_text())
+    # S-R7-2: snapshot is a structured envelope {"bootstrap_python": "X.Y", "verdicts": {...}}.
+    # Pin the snapshot to the bootstrapping Python's MAJOR.MINOR so cross-env drift
+    # surfaces loudly. If lens_runner output is empirically version-stable across
+    # 3.10/3.11/3.12 (per AC-8), this check can be softened to a warning via a
+    # follow-up issue once stability is empirically established.
+    # TODO(S-R7-2): track cross-version stability; relax to warning once confirmed.
+    expected_py = snapshot.get("bootstrap_python")
+    runtime_py = f"{sys.version_info.major}.{sys.version_info.minor}"
+    assert expected_py == runtime_py, (
+        f"snapshot was bootstrapped under Python {expected_py!r} but tests are running "
+        f"under {runtime_py!r}. Either (a) re-bootstrap under Python {runtime_py} via "
+        f"`python -m skills.temper.evals.bootstrap_snapshot`, or (b) if you have "
+        f"empirically confirmed cross-version stability of lens_runner output, "
+        f"update the snapshot's `bootstrap_python` field manually and document why."
+    )
+    expected = snapshot["verdicts"]
+    # S-R4-2: sanity-floor assertions. If a prior bootstrap silently produced a
+    # truncated/empty snapshot (e.g. subprocess error swallowed), the equality
+    # assertion below would pass trivially — so explicitly floor the shape first.
+    # `expected` is a flat {fixture_id: verdict} dict; assert both cardinality and
+    # verdict-presence.
+    assert len(expected) >= 7, (
+        f"snapshot has <7 fixtures (expected N=7); re-bootstrap via "
+        f"`python -m skills.temper.evals.bootstrap_snapshot`"
+    )
+    assert all(isinstance(v, str) and v for v in expected.values()), (
+        "snapshot fixtures missing verdict strings (expected PASS/FAIL/N/A)"
+    )
+    actual = _run_mock(tmp_path)
+    assert actual == expected, (
+        f"legacy --mock-reviewer verdicts diverged from snapshot.\n"
+        f"expected: {expected}\nactual:   {actual}\n"
+        f"If this divergence is intentional, re-run "
+        f"`python -m skills.temper.evals.bootstrap_snapshot` and review the diff."
+    )

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from skills.temper.evals import run_evals
 from skills.temper.evals.run_evals import score, stage
 
@@ -85,15 +83,71 @@ def test_score_no_stage_manifest_returns_fatal(monkeypatch, tmp_path):
     assert rc == 2
 
 
-def test_score_baseline_stubs_raise_not_implemented(monkeypatch, tmp_path):
-    """S-R4-1: --write-baseline / --compare-baseline raise NotImplementedError
-    cleanly between Task 6 and Task 8 commits."""
-    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-stub")
+def test_write_baseline_produces_matching_baseline_json(monkeypatch, tmp_path):
+    """Task 8 AC-10b: --write-baseline emits baseline.json mirroring last_run
+    verdicts + a template_sha header (SP-1)."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-base")
     (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
-    with pytest.raises(NotImplementedError, match="Task 8"):
-        score("R-stub", write_baseline=True)
-    with pytest.raises(NotImplementedError, match="Task 8"):
-        score("R-stub", compare_baseline=True)
+    score("R-base", write_baseline=True)
+    # F-1: read via module attributes (monkeypatched to tmp_path) — NOT via
+    # hardcoded skills/temper/evals/ paths.
+    baseline = json.loads(run_evals._BASELINE_PATH.read_text())
+    last_run = json.loads(run_evals._LAST_RUN.read_text())
+    # Header carries template_sha (SP-1)
+    assert "template_sha" in baseline
+    # Verdicts match
+    assert [f["verdict"] for f in baseline["fixtures"]] == [
+        f["verdict"] for f in last_run["fixtures"]
+    ]
+
+
+def test_compare_baseline_exits_nonzero_on_regression(monkeypatch, tmp_path):
+    """Task 8 AC-10c: --compare-baseline returns non-zero when current verdicts
+    regress relative to baseline."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-cmp")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-cmp", write_baseline=True)
+    # F-1: mutate via module-attribute path (monkeypatched to tmp_path)
+    baseline = json.loads(run_evals._BASELINE_PATH.read_text())
+    if baseline["fixtures"]:
+        baseline["fixtures"][0]["verdict"] = "PASS"  # claim baseline was PASS
+    run_evals._BASELINE_PATH.write_text(json.dumps(baseline))
+    # New run with all-N/A (no results) — compare should detect regression
+    rc = score("R-cmp", compare_baseline=True)
+    # rc==1 iff regression; rc==2 if incomplete-blocked; either signals nonzero
+    assert rc != 0
+
+
+def test_compare_baseline_refuses_incomplete(monkeypatch, tmp_path):
+    """AC-13 + Override Flags: --compare-baseline refuses to compare incomplete."""
+    _seed_dispatch_dir(monkeypatch, tmp_path, "R-incomplete")
+    # Skip .collect-status
+    score("R-incomplete", allow_incomplete=True)  # writes incomplete: true
+    rc = score("R-incomplete", compare_baseline=True, allow_incomplete=True)
+    assert rc == 2  # explicit refusal exit
+
+
+def test_compare_baseline_warns_on_template_drift(monkeypatch, tmp_path, capsys):
+    """SP2 R8: when current template_sha differs from baseline.template_sha,
+    --compare-baseline emits a `[warn]` line to stderr (apples-to-oranges narration).
+
+    Asserts the warn-not-refuse asymmetry documented in Task 8's M6 R6 note:
+    template_sha drift is informational; the comparison still proceeds.
+    """
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-drift")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-drift", write_baseline=True)
+    # Mutate baseline.template_sha to a different value to simulate drift
+    baseline = json.loads(run_evals._BASELINE_PATH.read_text())
+    baseline["template_sha"] = "0" * 64  # bogus sha, certain to differ from current
+    run_evals._BASELINE_PATH.write_text(json.dumps(baseline))
+    capsys.readouterr()  # clear prior output
+    score("R-drift", compare_baseline=True)
+    captured = capsys.readouterr()
+    assert "[warn]" in captured.err
+    assert "template_sha drift" in captured.err, (
+        "SP2 R8: --compare-baseline must emit a template_sha drift warning"
+    )
 
 
 def test_aggregate_from_outputs_matches_run_fixture_legacy(monkeypatch):

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -244,3 +244,25 @@ def test_parse_result_file_whitespace_only_body_returns_none(tmp_path):
     p.write_text("DISPATCH_STATUS: OK\n\n   \n\t\n")
     out = _parse_result_file(p)
     assert out is None
+
+
+def test_ac3_smoke_coverage_delegated_to_legacy_modes():
+    """AC-3: `--mock-reviewer` end-to-end smoke.
+
+    Per #297 plan Task 10, the AC-3 smoke is delegated to
+    `test_legacy_modes.py::test_legacy_mock_reviewer_matches_snapshot`,
+    which is strictly stronger than the original tautological "claude not in
+    stderr" smoke: it asserts per-fixture verdict equality against the
+    committed pre-#297 snapshot. This marker test enforces that the
+    delegation target still exists.
+    """
+    from pathlib import Path
+    legacy_modes = Path(__file__).parent / "test_legacy_modes.py"
+    assert legacy_modes.exists(), (
+        "AC-3 delegation target missing: test_legacy_modes.py was deleted "
+        "or renamed. Either restore it or update AC-3 coverage here."
+    )
+    contents = legacy_modes.read_text()
+    assert "def test_legacy_mock_reviewer_matches_snapshot" in contents, (
+        "AC-3 delegation target test function was renamed; update marker test."
+    )

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -1,0 +1,160 @@
+"""Tests for score() subcommand (Task 6 of #297).
+
+SP3 / F-1: All tests in this file MUST use module-attribute access
+(`run_evals._LAST_RUN`, `run_evals._BASELINE_PATH`) — never hardcode
+`skills/temper/evals/...` paths. The shared `_seed_dispatch_dir` helper
+monkeypatches _LAST_RUN, _BASELINE_PATH, and _EVALS_DIR to tmp_path,
+so any test that wants to read or assert against these files must do so
+through the module attribute (which the helper has redirected) — not via
+`Path("skills/temper/evals/baseline.json")` which would bypass the redirect.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from skills.temper.evals import run_evals
+from skills.temper.evals.run_evals import score, stage
+
+
+def _seed_dispatch_dir(monkeypatch, tmp_path, run_id="R-score"):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    # SP3 / F-1: redirect last_run.json, baseline.json, AND _EVALS_DIR to tmp_path
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    dispatch_dir = stage(run_id)
+    return dispatch_dir
+
+
+def test_score_with_no_results_returns_n_a(monkeypatch, tmp_path):
+    d = _seed_dispatch_dir(monkeypatch, tmp_path)
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    rc = score("R-score", allow_incomplete=False)
+    assert rc in (0, 1)
+    out = json.loads(run_evals._LAST_RUN.read_text())
+    assert "fixtures" in out
+    for fr in out["fixtures"]:
+        assert all(o is None for o in fr["reviewer_outputs"])
+
+
+def test_score_refuses_when_collect_status_absent(monkeypatch, tmp_path):
+    """2P-2 R5: score() returns rc (no sys.exit) — assert return-code."""
+    _seed_dispatch_dir(monkeypatch, tmp_path)
+    rc = score("R-score")
+    assert rc == 2
+
+
+def test_score_allow_incomplete_writes_incomplete_header(monkeypatch, tmp_path):
+    _seed_dispatch_dir(monkeypatch, tmp_path)
+    score("R-score", allow_incomplete=True)
+    out = json.loads(run_evals._LAST_RUN.read_text())
+    assert out.get("incomplete") is True
+    assert "incomplete-cause" not in out  # cause undetermined per S-2
+
+
+def test_score_all_error_sets_incomplete_cause(monkeypatch, tmp_path):
+    """M-4 R5 / AC-14: when all dispatches errored, last_run.json header carries
+    `incomplete-cause: all-error` AND score refuses to PASS.
+    """
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-allerr")
+    manifest = json.loads((d / "stage-manifest.json").read_text())
+    total = len(manifest["trials"])
+    (d / ".collect-status").write_text(f"complete\nerrors: {total}/{total}\n")
+    rc = score("R-allerr", allow_incomplete=False)
+    assert rc == 2
+    score("R-allerr", allow_incomplete=True)
+    out = json.loads(run_evals._LAST_RUN.read_text())
+    assert out.get("incomplete") is True
+    assert out.get("incomplete-cause") == "all-error", (
+        f"AC-14: expected incomplete-cause: all-error, got {out.get('incomplete-cause')!r}"
+    )
+
+
+def test_score_no_stage_manifest_returns_fatal(monkeypatch, tmp_path):
+    """No stage-manifest.json at dispatch dir → rc=2."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    rc = score("R-nonexistent")
+    assert rc == 2
+
+
+def test_score_baseline_stubs_raise_not_implemented(monkeypatch, tmp_path):
+    """S-R4-1: --write-baseline / --compare-baseline raise NotImplementedError
+    cleanly between Task 6 and Task 8 commits."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-stub")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    with pytest.raises(NotImplementedError, match="Task 8"):
+        score("R-stub", write_baseline=True)
+    with pytest.raises(NotImplementedError, match="Task 8"):
+        score("R-stub", compare_baseline=True)
+
+
+def test_aggregate_from_outputs_matches_run_fixture_legacy(monkeypatch):
+    """SP2 / F-2: _aggregate_from_outputs(fix, outs) == _run_fixture(fix, replay_outputs=outs).
+
+    F-2: To guard against silent regression where some future refactor causes
+    replay_outputs=[None,...] to trigger live dispatch, we monkeypatch
+    subprocess.run to RAISE — any subprocess call during this test fails loud.
+    """
+    import subprocess
+
+    from skills.temper.evals.run_evals import _aggregate_from_outputs, _run_fixture
+
+    def _no_subprocess(*a, **kw):
+        raise AssertionError(
+            "F-2 violation: _run_fixture(replay_outputs=[None]*n) attempted a subprocess call; "
+            "the replay branch must not invoke live dispatch."
+        )
+    monkeypatch.setattr(subprocess, "run", _no_subprocess)
+
+    evals = json.loads(Path("skills/temper/evals/evals.json").read_text())
+    fix = evals["evals"][0]
+    rule = fix.get("replicate_rule", {"trials": 1, "threshold": 1})
+    n_trials = rule.get("trials", 1)
+    threshold = rule.get("threshold", 1)
+    outs = [None] * n_trials
+    legacy_result = _run_fixture(
+        fix,
+        template=None,
+        mock_dir=None,
+        replay_outputs=outs,
+        trials_override=None,
+        timeout=0,
+    )
+    extracted_result = _aggregate_from_outputs(
+        fix, outs, n_trials=n_trials, threshold=threshold
+    )
+    assert legacy_result == extracted_result
+
+
+def test_aggregate_from_outputs_has_no_implicit_closure_leak():
+    """S2 R8/R9: closure-dep enumeration is read from /tmp/_aggregate_closure_deps.txt
+    (populated by Task 6 Step 0's inspection). The helper's kwarg signature
+    must match exactly — catches operator forgetting to mirror Step 0 findings.
+    """
+    import inspect
+
+    from skills.temper.evals.run_evals import _aggregate_from_outputs
+
+    closure_deps_file = Path("/tmp/_aggregate_closure_deps.txt")
+    assert closure_deps_file.exists(), (
+        "S2 R9: closure-deps file missing — run Task 6 Step 0 inspection first "
+        "and write findings to /tmp/_aggregate_closure_deps.txt."
+    )
+    expected = set(closure_deps_file.read_text().split())
+    sig = inspect.signature(_aggregate_from_outputs)
+    params = set(sig.parameters)
+    assert "fix" in params
+    assert "reviewer_outputs" in params
+    kwargs = params - {"fix", "reviewer_outputs"}
+    assert kwargs == expected, (
+        f"S2 R9: closure-dep mismatch: signature has {kwargs}, expected {expected}. "
+        f"Update _aggregate_from_outputs signature OR re-run Step 0 inspection."
+    )

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -168,20 +168,22 @@ def test_dispatch_live_symbol_remains_deleted():
 
 
 def test_aggregate_from_outputs_has_no_implicit_closure_leak():
-    """S2 R8/R9: closure-dep enumeration is read from /tmp/_aggregate_closure_deps.txt
-    (populated by Task 6 Step 0's inspection). The helper's kwarg signature
-    must match exactly — catches operator forgetting to mirror Step 0 findings.
+    """S2 R8/R9: enumerate the kwargs `_aggregate_from_outputs` must carry
+    explicitly so that closure-leak regressions surface as a signature mismatch
+    rather than a NameError at first call.
+
+    The canonical closure-dep set was captured by Task 6 Step 0 inspection and is
+    inlined here so the test is reproducible on any fresh clone (the prior
+    /tmp/_aggregate_closure_deps.txt artifact did not survive `/tmp` cleanup
+    or CI).
     """
     import inspect
 
     from skills.temper.evals.run_evals import _aggregate_from_outputs
 
-    closure_deps_file = Path("/tmp/_aggregate_closure_deps.txt")
-    assert closure_deps_file.exists(), (
-        "S2 R9: closure-deps file missing — run Task 6 Step 0 inspection first "
-        "and write findings to /tmp/_aggregate_closure_deps.txt."
-    )
-    expected = set(closure_deps_file.read_text().split())
+    # Canonical closure-dep set (Task 6 Step 0 inspection output, inlined for
+    # reproducibility — see _aggregate_from_outputs docstring).
+    expected = {"n_trials", "threshold"}
     sig = inspect.signature(_aggregate_from_outputs)
     params = set(sig.parameters)
     assert "fix" in params
@@ -189,7 +191,7 @@ def test_aggregate_from_outputs_has_no_implicit_closure_leak():
     kwargs = params - {"fix", "reviewer_outputs"}
     assert kwargs == expected, (
         f"S2 R9: closure-dep mismatch: signature has {kwargs}, expected {expected}. "
-        f"Update _aggregate_from_outputs signature OR re-run Step 0 inspection."
+        f"Update _aggregate_from_outputs signature OR update the expected set here."
     )
 
 

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -1,12 +1,15 @@
 """Tests for score() subcommand (Task 6 of #297).
 
-SP3 / F-1: All tests in this file MUST use module-attribute access
-(`run_evals._LAST_RUN`, `run_evals._BASELINE_PATH`) — never hardcode
-`skills/temper/evals/...` paths. The shared `_seed_dispatch_dir` helper
-monkeypatches _LAST_RUN, _BASELINE_PATH, and _EVALS_DIR to tmp_path,
-so any test that wants to read or assert against these files must do so
-through the module attribute (which the helper has redirected) — not via
-`Path("skills/temper/evals/baseline.json")` which would bypass the redirect.
+SP3 / F-1: All tests in this file MUST redirect output paths via monkeypatch —
+never hardcode `skills/temper/evals/...` paths. The shared `_seed_dispatch_dir`
+helper monkeypatches _LAST_RUN, _BASELINE_PATH, and _EVALS_DIR to tmp_path.
+
+Post-Task-13.5: `_resolve_output_path()` reads `_EVALS_DIR` at call time, so
+monkeypatching `_EVALS_DIR` alone is sufficient for both the shared and per-iter
+output paths. `_LAST_RUN` is still monkeypatched by `_seed_dispatch_dir` only to
+exercise the legacy `TEMPER_LAST_RUN_OVERRIDE` env-var path. Tests that read the
+shared output file should use `tmp_path / "last_run.json"` directly — not
+`run_evals._LAST_RUN` — since that attribute is not the routing source post-13.5.
 """
 from __future__ import annotations
 
@@ -276,35 +279,25 @@ def test_ac3_smoke_coverage_delegated_to_legacy_modes():
 def test_score_per_iter_flag_writes_separate_file(monkeypatch, tmp_path):
     """F1: --per-iter routes output to last_run-<run_id>.json; shared file untouched.
 
-    M-4: this test depends on both _LAST_RUN (import-time constant) AND _EVALS_DIR
-    (used at runtime inside score()) being monkeypatched. The brittle coupling is
-    documented above the test block. Do not refactor one without the other.
+    Post-Task-13.5: `_resolve_output_path()` reads `_EVALS_DIR` at call time, so
+    monkeypatching `_EVALS_DIR` alone is sufficient for BOTH the shared and per-iter
+    output paths. The `_LAST_RUN` monkeypatch in `_seed_dispatch_dir` is preserved
+    only to exercise the legacy `TEMPER_LAST_RUN_OVERRIDE` env-var path.
 
-    SP3 R8 bisect-window note: Task 13.5 (next commit) refactors the per-iter path
-    resolution into `_resolve_output_path()`, after which monkeypatching `_EVALS_DIR`
-    alone is sufficient. THIS docstring's brittle-coupling note is correct for THIS
-    commit's state and will be updated in Task 13.5. If you are reading this after
-    Task 13.5 has landed and the docstring still says "Do not refactor one without
-    the other," that is a stale-docstring bug — fix it.
-
-    M-R4-1: note the asymmetry — `_EVALS_DIR` and `_EVALS_JSON` are both bound
-    at import time, but only `_EVALS_DIR` appears in a runtime path expression
-    inside `score()` (the per-iter path), so monkeypatching `_EVALS_DIR` redirects
-    that expression. `_EVALS_JSON` is bound at import time AND used by name at
-    runtime — monkeypatching `_EVALS_DIR` does NOT retroactively redirect
-    `_EVALS_JSON`. If a future test needs to redirect fixture data, it must
-    monkeypatch `_EVALS_JSON` separately.
+    M-R4-1: `_EVALS_JSON` is bound at import time AND used by name at runtime —
+    monkeypatching `_EVALS_DIR` does NOT retroactively redirect `_EVALS_JSON`. If a
+    future test needs to redirect fixture data, it must monkeypatch `_EVALS_JSON`
+    separately.
 
     M-5 R5: `_seed_dispatch_dir` already monkeypatches `_EVALS_DIR` to `tmp_path`,
-    so the redundant `monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)`
-    that previously appeared here has been removed.
+    so no additional `_EVALS_DIR` monkeypatch is needed here.
     """
     import time
     d = _seed_dispatch_dir(monkeypatch, tmp_path, "Rcalprefix-1")
     (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
 
     # Pre-populate the shared last_run.json with sentinel content, capture mtime
-    shared = run_evals._LAST_RUN  # SP3: monkeypatched to tmp_path
+    shared = tmp_path / "last_run.json"  # _seed_dispatch_dir sets _EVALS_DIR → tmp_path
     shared.write_text('{"sentinel": "untouched"}')
     mtime_before = shared.stat().st_mtime
     time.sleep(0.01)  # ensure any write would change mtime
@@ -325,12 +318,15 @@ def test_score_without_per_iter_writes_shared(monkeypatch, tmp_path):
     `--per-iter` flag is the routing trigger, NOT run-id shape. Under the
     pre-F1 regex heuristic (`-\\d+$`), this run-id would have been MIS-ROUTED
     to a per-iter path; under the F1 explicit flag, it correctly writes shared.
+
+    Post-Task-13.5: `_resolve_output_path()` reads `_EVALS_DIR` at call time, so
+    monkeypatching `_EVALS_DIR` alone is sufficient. The redundant `_EVALS_DIR` and
+    `_LAST_RUN` monkeypatches that previously appeared here have been removed —
+    `_seed_dispatch_dir` already sets `_EVALS_DIR` to `tmp_path`.
     """
     d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-2026-04-15")  # run-id ends in -<digits>!
     (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
-    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
     shared = tmp_path / "last_run.json"
-    monkeypatch.setattr(run_evals, "_LAST_RUN", shared)
 
     score("R-2026-04-15", per_iter=False, allow_incomplete=False)
 
@@ -352,7 +348,7 @@ def test_per_iter_flag_not_silently_dropped(monkeypatch, tmp_path):
     from skills.temper.evals.run_evals import main
     d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-flag-drop")
     (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
-    shared = run_evals._LAST_RUN  # monkeypatched to tmp_path by _seed_dispatch_dir
+    shared = tmp_path / "last_run.json"  # _seed_dispatch_dir sets _EVALS_DIR → tmp_path
     shared.write_text('{"sentinel": "untouched"}')
     mtime_before = shared.stat().st_mtime
     time.sleep(0.01)
@@ -381,3 +377,22 @@ def test_score_help_lists_per_iter():
     )
     out = result.stdout + result.stderr
     assert "--per-iter" in out, "Task 13 must add --per-iter to score subparser"
+
+
+# ---------------------------------------------------------------------------
+# Task 13.5: _resolve_output_path() helper (S4 R6)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_output_path_uses_current_evals_dir(monkeypatch, tmp_path):
+    """S4 R6: _resolve_output_path reads _EVALS_DIR at CALL TIME, not import time.
+
+    Eliminates the asymmetry where tests previously had to monkeypatch _LAST_RUN
+    AND _EVALS_DIR separately. After this refactor, monkeypatching _EVALS_DIR
+    alone is sufficient for BOTH the shared and per-iter output paths.
+    """
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    p_shared = run_evals._resolve_output_path("R-x", per_iter=False)
+    p_iter = run_evals._resolve_output_path("R-x", per_iter=True)
+    assert p_shared == tmp_path / "last_run.json"
+    assert p_iter == tmp_path / ".calibrate-state" / "last_run-R-x.json"

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -440,6 +440,65 @@ def test_compare_baseline_handles_corrupt_baseline_json(monkeypatch, tmp_path, c
     assert "baseline.json" in captured.err
 
 
+def test_score_write_is_atomic(monkeypatch, tmp_path):
+    """QG R2 Fix 1: atomic write — no `.tmp` artifact survives, no truncated file."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-atomic")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    rc = score("R-atomic", allow_incomplete=False)
+    assert rc in (0, 1)
+    # No tmp residue
+    assert not any(p.name.endswith(".tmp") for p in tmp_path.rglob("*"))
+    # File is valid JSON (not truncated)
+    out = tmp_path / "last_run.json"
+    json.loads(out.read_text())  # raises if malformed
+
+
+def test_compare_baseline_warns_on_added_fixture(monkeypatch, tmp_path, capsys):
+    """QG R2 Fix 3: fixtures added since baseline emit a [warn] but don't block."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-added")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-added", write_baseline=True)
+    # Mutate baseline: drop all-but-first fixture so the rest appear "added"
+    baseline = json.loads(run_evals._BASELINE_PATH.read_text())
+    assert len(baseline["fixtures"]) >= 2, "need >=2 fixtures to simulate addition"
+    baseline["fixtures"] = baseline["fixtures"][:1]
+    run_evals._BASELINE_PATH.write_text(json.dumps(baseline))
+    capsys.readouterr()
+    rc = score("R-added", compare_baseline=True, allow_incomplete=False)
+    captured = capsys.readouterr()
+    # additions don't block: rc must not be the "removed fixtures" refusal (rc=2)
+    assert rc != 2, f"additions should not block compare; got rc={rc}, stderr={captured.err!r}"
+    assert "added since baseline" in captured.err
+
+
+def test_compare_baseline_refuses_removed_fixture(monkeypatch, tmp_path, capsys):
+    """QG R2 Fix 3: fixtures removed from evals.json post-baseline block compare
+    with rc=2 unless --allow-fixture-drift is passed (prevents silent
+    regression-laundering by fixture deletion)."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-removed")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-removed", write_baseline=True)
+    # Mutate baseline to ADD a fake fixture id that doesn't exist in current run
+    # → simulates fixture being removed from evals.json since baseline was taken
+    baseline = json.loads(run_evals._BASELINE_PATH.read_text())
+    baseline["fixtures"].append({"id": "ghost-fixture-id", "verdict": "PASS"})
+    run_evals._BASELINE_PATH.write_text(json.dumps(baseline))
+    # Without flag: refused
+    capsys.readouterr()
+    rc = score("R-removed", compare_baseline=True, allow_incomplete=False)
+    captured = capsys.readouterr()
+    assert rc == 2, f"removed fixtures should refuse without flag; got rc={rc}"
+    assert "removed from baseline" in captured.err
+    # With flag: proceeds (rc=0 since remaining fixtures show no regression)
+    rc2 = score(
+        "R-removed",
+        compare_baseline=True,
+        allow_incomplete=False,
+        allow_fixture_drift=True,
+    )
+    assert rc2 == 0, f"--allow-fixture-drift should allow comparison; got rc={rc2}"
+
+
 def test_resolve_output_path_uses_current_evals_dir(monkeypatch, tmp_path):
     """S4 R6: _resolve_output_path reads _EVALS_DIR at CALL TIME, not import time.
 

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -266,3 +266,118 @@ def test_ac3_smoke_coverage_delegated_to_legacy_modes():
     assert "def test_legacy_mock_reviewer_matches_snapshot" in contents, (
         "AC-3 delegation target test function was renamed; update marker test."
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 13: wire --per-iter flag (F1, F-R4-1)
+# ---------------------------------------------------------------------------
+
+
+def test_score_per_iter_flag_writes_separate_file(monkeypatch, tmp_path):
+    """F1: --per-iter routes output to last_run-<run_id>.json; shared file untouched.
+
+    M-4: this test depends on both _LAST_RUN (import-time constant) AND _EVALS_DIR
+    (used at runtime inside score()) being monkeypatched. The brittle coupling is
+    documented above the test block. Do not refactor one without the other.
+
+    SP3 R8 bisect-window note: Task 13.5 (next commit) refactors the per-iter path
+    resolution into `_resolve_output_path()`, after which monkeypatching `_EVALS_DIR`
+    alone is sufficient. THIS docstring's brittle-coupling note is correct for THIS
+    commit's state and will be updated in Task 13.5. If you are reading this after
+    Task 13.5 has landed and the docstring still says "Do not refactor one without
+    the other," that is a stale-docstring bug — fix it.
+
+    M-R4-1: note the asymmetry — `_EVALS_DIR` and `_EVALS_JSON` are both bound
+    at import time, but only `_EVALS_DIR` appears in a runtime path expression
+    inside `score()` (the per-iter path), so monkeypatching `_EVALS_DIR` redirects
+    that expression. `_EVALS_JSON` is bound at import time AND used by name at
+    runtime — monkeypatching `_EVALS_DIR` does NOT retroactively redirect
+    `_EVALS_JSON`. If a future test needs to redirect fixture data, it must
+    monkeypatch `_EVALS_JSON` separately.
+
+    M-5 R5: `_seed_dispatch_dir` already monkeypatches `_EVALS_DIR` to `tmp_path`,
+    so the redundant `monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)`
+    that previously appeared here has been removed.
+    """
+    import time
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "Rcalprefix-1")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+
+    # Pre-populate the shared last_run.json with sentinel content, capture mtime
+    shared = run_evals._LAST_RUN  # SP3: monkeypatched to tmp_path
+    shared.write_text('{"sentinel": "untouched"}')
+    mtime_before = shared.stat().st_mtime
+    time.sleep(0.01)  # ensure any write would change mtime
+
+    score("Rcalprefix-1", per_iter=True, allow_incomplete=False)
+
+    # S-FE-5 R3: per-iter file lives under .calibrate-state/
+    per_iter_path = tmp_path / ".calibrate-state" / "last_run-Rcalprefix-1.json"
+    assert per_iter_path.exists()
+    # SP5: shared last_run.json MUST NOT be overwritten
+    assert shared.stat().st_mtime == mtime_before
+    assert json.loads(shared.read_text()) == {"sentinel": "untouched"}
+
+def test_score_without_per_iter_writes_shared(monkeypatch, tmp_path):
+    """F1 inverse: no --per-iter ⇒ shared last_run.json is written, no per-iter file.
+
+    M-FE-4 R3: run-id ends in `-15` (digits) — this proves the new explicit
+    `--per-iter` flag is the routing trigger, NOT run-id shape. Under the
+    pre-F1 regex heuristic (`-\\d+$`), this run-id would have been MIS-ROUTED
+    to a per-iter path; under the F1 explicit flag, it correctly writes shared.
+    """
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-2026-04-15")  # run-id ends in -<digits>!
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    shared = tmp_path / "last_run.json"
+    monkeypatch.setattr(run_evals, "_LAST_RUN", shared)
+
+    score("R-2026-04-15", per_iter=False, allow_incomplete=False)
+
+    assert shared.exists()  # shared written
+    # No per-iter file created — proves regex-heuristic would have wrongly routed this
+    assert not (tmp_path / ".calibrate-state" / "last_run-R-2026-04-15.json").exists()
+
+def test_per_iter_flag_not_silently_dropped(monkeypatch, tmp_path):
+    """F-R4-1: argparse declaration + main() wiring land atomically in Task 13 (S-1 R5).
+
+    Guards against a regression where `--per-iter` argparse declaration and main()
+    wiring split across two commits — between them, `score R-x --per-iter` would
+    parse the flag and silently drop it, clobbering shared last_run.json.
+
+    This test exercises the CLI path (via main()) to prove the flag is honored:
+    the per-iter file is written AND the shared last_run.json is left untouched.
+    """
+    import time
+    from skills.temper.evals.run_evals import main
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-flag-drop")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    shared = run_evals._LAST_RUN  # monkeypatched to tmp_path by _seed_dispatch_dir
+    shared.write_text('{"sentinel": "untouched"}')
+    mtime_before = shared.stat().st_mtime
+    time.sleep(0.01)
+
+    rc = main(["score", "R-flag-drop", "--per-iter"])
+    assert rc in (0, 1)
+
+    # Per-iter path written
+    per_iter_path = tmp_path / ".calibrate-state" / "last_run-R-flag-drop.json"
+    assert per_iter_path.exists(), \
+        "--per-iter was parsed but silently dropped (F-R4-1 regression)"
+    # Shared file untouched
+    assert shared.stat().st_mtime == mtime_before
+    assert json.loads(shared.read_text()) == {"sentinel": "untouched"}
+
+def test_score_help_lists_per_iter():
+    """F-R4-1: argparse declaration for --per-iter lives in Task 13 (S-1 R5), not Task 4.
+
+    Asserted here (rather than in Task 4's argparse-help golden test) because
+    the flag does not exist on the score subparser until this task lands.
+    """
+    import subprocess, sys
+    result = subprocess.run(
+        [sys.executable, "-m", "skills.temper.evals.run_evals", "score", "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    out = result.stdout + result.stderr
+    assert "--per-iter" in out, "Task 13 must add --per-iter to score subparser"

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -454,11 +454,16 @@ def test_score_write_is_atomic(monkeypatch, tmp_path):
 
 
 def test_compare_baseline_warns_on_added_fixture(monkeypatch, tmp_path, capsys):
-    """QG R2 Fix 3: fixtures added since baseline emit a [warn] but don't block."""
+    """QG R2 Fix 3 / QG R3 Fix 1: fixtures added to evals.json since baseline emit
+    a [warn] but don't block. Drift is now measured against the live evals.json keyset,
+    not the manifest payload — so a fixture present in evals.json but not in baseline
+    correctly appears as "added"."""
     d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-added")
     (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
     score("R-added", write_baseline=True)
-    # Mutate baseline: drop all-but-first fixture so the rest appear "added"
+    # Mutate baseline: drop all-but-first fixture so the remaining evals.json fixtures
+    # appear "added to evals.json since baseline". The manifest scope is unchanged —
+    # only the baseline is trimmed, so the drift is detected via the evals.json comparison.
     baseline = json.loads(run_evals._BASELINE_PATH.read_text())
     assert len(baseline["fixtures"]) >= 2, "need >=2 fixtures to simulate addition"
     baseline["fixtures"] = baseline["fixtures"][:1]
@@ -468,18 +473,21 @@ def test_compare_baseline_warns_on_added_fixture(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     # additions don't block: rc must not be the "removed fixtures" refusal (rc=2)
     assert rc != 2, f"additions should not block compare; got rc={rc}, stderr={captured.err!r}"
-    assert "added since baseline" in captured.err
+    assert "added to evals.json since baseline" in captured.err
 
 
 def test_compare_baseline_refuses_removed_fixture(monkeypatch, tmp_path, capsys):
-    """QG R2 Fix 3: fixtures removed from evals.json post-baseline block compare
-    with rc=2 unless --allow-fixture-drift is passed (prevents silent
-    regression-laundering by fixture deletion)."""
+    """QG R2 Fix 3 / QG R3 Fix 1: fixtures removed from evals.json post-baseline block
+    compare with rc=2 unless --allow-fixture-drift is passed (prevents silent
+    regression-laundering by fixture deletion). Drift is now measured against the live
+    evals.json keyset — adding a ghost to baseline simulates a fixture deleted from
+    evals.json."""
     d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-removed")
     (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
     score("R-removed", write_baseline=True)
-    # Mutate baseline to ADD a fake fixture id that doesn't exist in current run
-    # → simulates fixture being removed from evals.json since baseline was taken
+    # Mutate baseline to ADD a fake fixture id that doesn't exist in evals.json
+    # → simulates fixture being removed from evals.json since baseline was taken.
+    # The live evals.json does not contain "ghost-fixture-id", so drift is detected.
     baseline = json.loads(run_evals._BASELINE_PATH.read_text())
     baseline["fixtures"].append({"id": "ghost-fixture-id", "verdict": "PASS"})
     run_evals._BASELINE_PATH.write_text(json.dumps(baseline))
@@ -488,7 +496,7 @@ def test_compare_baseline_refuses_removed_fixture(monkeypatch, tmp_path, capsys)
     rc = score("R-removed", compare_baseline=True, allow_incomplete=False)
     captured = capsys.readouterr()
     assert rc == 2, f"removed fixtures should refuse without flag; got rc={rc}"
-    assert "removed from baseline" in captured.err
+    assert "removed from evals.json" in captured.err
     # With flag: proceeds (rc=0 since remaining fixtures show no regression)
     rc2 = score(
         "R-removed",
@@ -497,6 +505,43 @@ def test_compare_baseline_refuses_removed_fixture(monkeypatch, tmp_path, capsys)
         allow_fixture_drift=True,
     )
     assert rc2 == 0, f"--allow-fixture-drift should allow comparison; got rc={rc2}"
+
+
+def test_compare_baseline_allows_scoped_stage(monkeypatch, tmp_path, capsys):
+    """QG R3 regression: stage --fixture <subset> + score --compare-baseline must NOT
+    falsely report fixture drift; the manifest scope < evals.json scope is legitimate.
+
+    Setup: write baseline against a full run, then score a subset manifest.
+    The subset manifest has fewer fixtures than evals.json but that is NOT a deletion —
+    evals.json still contains all fixtures. Assert: no fixture-drift warning, no rc=2,
+    normal comparison on the subset.
+    """
+    # Seed a full dispatch dir and write baseline
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-scoped-full")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-scoped-full", write_baseline=True)
+
+    # Now stage a SCOPED run (only the first fixture id from the real evals.json)
+    evals_data = json.loads(run_evals._EVALS_JSON.read_text())
+    all_fixture_ids = [f["id"] for f in evals_data.get("evals", [])]
+    assert len(all_fixture_ids) >= 2, "need >=2 fixtures to test scoping"
+    subset_id = all_fixture_ids[0]
+
+    d2 = stage("R-scoped-sub", fixture=subset_id)
+    (d2 / ".collect-status").write_text("complete\nerrors: 0/0\n")
+
+    capsys.readouterr()
+    rc = score("R-scoped-sub", compare_baseline=True, allow_incomplete=False)
+    captured = capsys.readouterr()
+
+    # The subset manifest has fewer fixtures than evals.json, but evals.json still
+    # has all fixtures → no fixture-drift warning, no rc=2
+    assert "removed from evals.json" not in captured.err, (
+        f"R3 regression: false fixture-drift for scoped stage. stderr={captured.err!r}"
+    )
+    assert rc != 2, (
+        f"R3 regression: scoped stage score rc=2 (should be 0 or 1). stderr={captured.err!r}"
+    )
 
 
 def test_resolve_output_path_uses_current_evals_dir(monkeypatch, tmp_path):

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -150,42 +150,18 @@ def test_compare_baseline_warns_on_template_drift(monkeypatch, tmp_path, capsys)
     )
 
 
-def test_aggregate_from_outputs_matches_run_fixture_legacy(monkeypatch):
-    """SP2 / F-2: _aggregate_from_outputs(fix, outs) == _run_fixture(fix, replay_outputs=outs).
+def test_dispatch_live_symbol_remains_deleted():
+    """S-FE-2 R3: post-#297, `_dispatch_live` must not exist as a module attribute.
 
-    F-2: To guard against silent regression where some future refactor causes
-    replay_outputs=[None,...] to trigger live dispatch, we monkeypatch
-    subprocess.run to RAISE — any subprocess call during this test fails loud.
+    Guards against accidental re-introduction (e.g. a future revert that doesn't
+    cleanly remove the function, or a copy-paste from git history that re-adds it).
+    If you genuinely need a subprocess-based dispatcher again, file a new issue
+    and re-design the legacy boundary — do NOT silently re-add `_dispatch_live`.
     """
-    import subprocess
-
-    from skills.temper.evals.run_evals import _aggregate_from_outputs, _run_fixture
-
-    def _no_subprocess(*a, **kw):
-        raise AssertionError(
-            "F-2 violation: _run_fixture(replay_outputs=[None]*n) attempted a subprocess call; "
-            "the replay branch must not invoke live dispatch."
-        )
-    monkeypatch.setattr(subprocess, "run", _no_subprocess)
-
-    evals = json.loads(Path("skills/temper/evals/evals.json").read_text())
-    fix = evals["evals"][0]
-    rule = fix.get("replicate_rule", {"trials": 1, "threshold": 1})
-    n_trials = rule.get("trials", 1)
-    threshold = rule.get("threshold", 1)
-    outs = [None] * n_trials
-    legacy_result = _run_fixture(
-        fix,
-        template=None,
-        mock_dir=None,
-        replay_outputs=outs,
-        trials_override=None,
-        timeout=0,
-    )
-    extracted_result = _aggregate_from_outputs(
-        fix, outs, n_trials=n_trials, threshold=threshold
-    )
-    assert legacy_result == extracted_result
+    import pytest
+    from skills.temper.evals import run_evals
+    with pytest.raises(AttributeError):
+        run_evals._dispatch_live  # noqa: B018  (intentional attribute probe)
 
 
 def test_aggregate_from_outputs_has_no_implicit_closure_leak():

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -158,3 +158,59 @@ def test_aggregate_from_outputs_has_no_implicit_closure_leak():
         f"S2 R9: closure-dep mismatch: signature has {kwargs}, expected {expected}. "
         f"Update _aggregate_from_outputs signature OR re-run Step 0 inspection."
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 7: structural DISPATCH_STATUS sentinel parser (S-1, I-T6)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_result_file_ok(tmp_path):
+    """M-2: use tmp_path, not hardcoded /tmp/, to avoid parallel-test collisions."""
+    from skills.temper.evals.run_evals import _parse_result_file
+    p = tmp_path / "test-result-ok.md"
+    p.write_text("DISPATCH_STATUS: OK\n\n### Code Review\nVerdict: Clean\n")
+    out = _parse_result_file(p)
+    assert out is not None
+    assert "Code Review" in out
+    assert "DISPATCH_STATUS" not in out  # stripped from body
+
+
+def test_parse_result_file_error_returns_none(tmp_path):
+    from skills.temper.evals.run_evals import _parse_result_file
+    p = tmp_path / "test-result-err.md"
+    p.write_text("DISPATCH_STATUS: ERROR: timeout\n\n")
+    out = _parse_result_file(p)
+    assert out is None
+
+
+def test_parse_result_file_collision_safety(tmp_path):
+    """I-T6: reviewer body containing literal 'DISPATCH_STATUS:' must not flip parse."""
+    from skills.temper.evals.run_evals import _parse_result_file
+    p = tmp_path / "test-result-collision.md"
+    p.write_text(
+        "DISPATCH_STATUS: OK\n\n"
+        "### Code Review\nThe code mentions DISPATCH_STATUS: ERROR but that's a quote.\n"
+    )
+    out = _parse_result_file(p)
+    assert out is not None
+    assert "DISPATCH_STATUS: ERROR" in out  # body preserved
+
+
+def test_parse_result_file_empty_body_returns_none(tmp_path):
+    """S1: `OK\\n\\n` with empty body returns None, not empty string."""
+    from skills.temper.evals.run_evals import _parse_result_file
+    p = tmp_path / "test-result-empty.md"
+    p.write_text("DISPATCH_STATUS: OK\n\n")
+    out = _parse_result_file(p)
+    assert out is None
+
+
+def test_parse_result_file_whitespace_only_body_returns_none(tmp_path):
+    """S1 R10: `OK` with whitespace-only body returns None — strip-check
+    semantics align with SKILL.md Step 7's empty-body promotion gate."""
+    from skills.temper.evals.run_evals import _parse_result_file
+    p = tmp_path / "test-result-ws.md"
+    p.write_text("DISPATCH_STATUS: OK\n\n   \n\t\n")
+    out = _parse_result_file(p)
+    assert out is None

--- a/skills/temper/evals/test_run_evals_score.py
+++ b/skills/temper/evals/test_run_evals_score.py
@@ -386,6 +386,60 @@ def test_score_help_lists_per_iter():
 # ---------------------------------------------------------------------------
 
 
+def test_score_handles_malformed_errors_line(monkeypatch, tmp_path, capsys):
+    """QG R1 Fix 1: malformed `.collect-status` errors-line surfaces fatal+rc=2,
+    not raw ValueError/IndexError traceback."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-malformed")
+    (d / ".collect-status").write_text("complete\nerrors: garbage\n")
+    rc = score("R-malformed", allow_incomplete=False)
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "malformed" in captured.err
+    assert ".collect-status" in captured.err
+
+
+def test_score_honors_manifest_trials_override(monkeypatch, tmp_path):
+    """QG R1 Fix 2: when stage runs with --trials-override 5, score must report
+    `5` as the denominator (not the evals.json replicate_rule trials count)."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    d = stage("R-toverride", trials_override=5)
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("R-toverride", allow_incomplete=False)
+    out = json.loads((tmp_path / "last_run.json").read_text())
+    # Every fixture must report n_trials=5 (denominator) and matching rationale
+    assert out["fixtures"], "no fixtures in output"
+    for fr in out["fixtures"]:
+        assert fr["trials"] == 5, (
+            f"fixture {fr['id']!r} reports trials={fr['trials']}, expected 5 "
+            f"(manifest trials_override should be canonical)"
+        )
+        for er in fr["expectations"]:
+            assert "/5 trials" in er["aggregated_rationale"], (
+                f"expectation rationale {er['aggregated_rationale']!r} "
+                f"does not honor manifest trials_override=5"
+            )
+
+
+def test_compare_baseline_handles_corrupt_baseline_json(monkeypatch, tmp_path, capsys):
+    """QG R1 Fix 3: corrupt/truncated baseline.json surfaces fatal+rc=2,
+    not raw JSONDecodeError traceback."""
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "R-corrupt")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    # Write a valid run first
+    score("R-corrupt", allow_incomplete=False)
+    # Now write a truncated baseline (simulates interrupted --write-baseline)
+    run_evals._BASELINE_PATH.write_text('{"fixtures": [{"id":')
+    rc = score("R-corrupt", compare_baseline=True, allow_incomplete=False)
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "malformed" in captured.err
+    assert "baseline.json" in captured.err
+
+
 def test_resolve_output_path_uses_current_evals_dir(monkeypatch, tmp_path):
     """S4 R6: _resolve_output_path reads _EVALS_DIR at CALL TIME, not import time.
 

--- a/skills/temper/evals/test_run_evals_stage.py
+++ b/skills/temper/evals/test_run_evals_stage.py
@@ -167,6 +167,25 @@ def test_rendered_prompt_validator_accepts_clean():
     _validate_rendered_prompt(clean)  # should not raise
 
 
+def test_stage_rejects_zero_trials_override(monkeypatch, tmp_path):
+    """QG R1 Fix 4: --trials-override 0 must rc=2, not silent-empty-manifest
+    (which would PASS vacuously)."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    from skills.temper.evals.run_evals import main
+    rc = main(["stage", "R-zero-t", "--trials-override", "0"])
+    assert rc == 2
+
+
+def test_stage_rejects_zero_timeout(monkeypatch, tmp_path):
+    """QG R1 Fix 4: --timeout 0 must rc=2 (defense against unusable manifest)."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    from skills.temper.evals.run_evals import main
+    rc = main(["stage", "R-zero-to", "--timeout", "0"])
+    assert rc == 2
+
+
 def test_stage_rejects_template_with_unsubstituted_placeholder(monkeypatch, tmp_path):
     """I-T9 integration: stage() must fail-fast if the template after substitution
     still contains `{` — even though fixture body legitimately contains `{`.

--- a/skills/temper/evals/test_run_evals_stage.py
+++ b/skills/temper/evals/test_run_evals_stage.py
@@ -56,3 +56,89 @@ def test_stage_rejects_bad_run_id(monkeypatch, tmp_path):
     monkeypatch.setenv("USER", "tester")
     with pytest.raises(ValueError):
         stage("../etc")
+
+
+# ---------------------------------------------------------------------------
+# Task 4: stage CLI flag tests
+# ---------------------------------------------------------------------------
+
+
+def test_stage_cli_source_filter(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    from skills.temper.evals.run_evals import main
+    rc = main(["stage", "R-syn", "--source", "synthetic"])
+    assert rc == 0
+    assert (tmp_path / "tester-crucible-dispatch-R-syn").exists()
+
+
+def test_stage_cli_force(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    from skills.temper.evals.run_evals import main
+    main(["stage", "R-force"])
+    rc = main(["stage", "R-force", "--force"])
+    assert rc == 0
+
+
+def test_stage_cli_timeout_recorded(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    from skills.temper.evals.run_evals import main
+    main(["stage", "R-to", "--timeout", "600"])
+    manifest = json.loads(
+        (tmp_path / "tester-crucible-dispatch-R-to" / "stage-manifest.json").read_text()
+    )
+    assert manifest["dispatch_timeout"] == 600
+
+
+def test_stage_timeout_not_demoted_to_legacy(monkeypatch, tmp_path):
+    """S3: `--timeout 600` on stage subcommand must NOT silently fall through to legacy_timeout."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    from skills.temper.evals.run_evals import _parse_args
+    args = _parse_args(["stage", "R-x", "--timeout", "600"])
+    assert args.cmd == "stage"
+    assert args.timeout == 600
+    assert getattr(args, "legacy_timeout", 120) == 120
+
+
+def test_legacy_main_runs_without_attribute_error(tmp_path, monkeypatch):
+    """S-2: after flag rename, _legacy_main must reference renamed attrs, not old ones."""
+    import os
+    import shutil
+    import subprocess
+    from pathlib import Path
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+    src_fixtures = repo_root / "skills" / "temper" / "evals" / "mock-fixtures"
+    if not src_fixtures.exists():
+        pytest.skip("mock-fixtures not yet present — Task 8.5 lands later in this plan")
+    dst_fixtures = tmp_path / "mock-fixtures"
+    shutil.copytree(src_fixtures, dst_fixtures)
+    last_run_out = tmp_path / "last_run.json"
+    env = {**os.environ, "TEMPER_LAST_RUN_OVERRIDE": str(last_run_out)}
+    repo_tracked = repo_root / "skills" / "temper" / "evals" / "last_run.json"
+    repo_tracked_mtime_pre = repo_tracked.stat().st_mtime if repo_tracked.exists() else None
+    result = subprocess.run(
+        ["python", "-m", "skills.temper.evals.run_evals",
+         "--mock-reviewer", str(dst_fixtures)],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(repo_root), env=env,
+    )
+    assert last_run_out.exists(), (
+        f"TEMPER_LAST_RUN_OVERRIDE ignored — output missing at {last_run_out}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    if repo_tracked_mtime_pre is None:
+        assert not repo_tracked.exists(), (
+            f"TEMPER_LAST_RUN_OVERRIDE bypassed — subprocess wrote to repo-tracked "
+            f"path: {repo_tracked}"
+        )
+    else:
+        assert repo_tracked.stat().st_mtime == repo_tracked_mtime_pre, (
+            f"TEMPER_LAST_RUN_OVERRIDE bypassed — repo-tracked path was modified: "
+            f"{repo_tracked}"
+        )
+    assert "AttributeError" not in result.stderr, (
+        f"_legacy_main attribute rename incomplete: {result.stderr}"
+    )

--- a/skills/temper/evals/test_run_evals_stage.py
+++ b/skills/temper/evals/test_run_evals_stage.py
@@ -1,0 +1,58 @@
+"""Tests for stage() subcommand (Task 3 of #297)."""
+
+import json
+
+import pytest
+
+from skills.temper.evals.run_evals import stage
+
+
+def test_stage_produces_dispatch_files(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+
+    dispatch_dir = stage("R-test")
+
+    # Manifest exists and well-formed
+    manifest = json.loads((dispatch_dir / "stage-manifest.json").read_text())
+    assert manifest["run_id"] == "R-test"
+    assert manifest["reviewer_model"] == "opus"
+    assert "template_sha" in manifest
+    assert manifest["dispatch_timeout"] == 300
+
+    # N fixtures × M trials dispatch files exist (count from evals.json)
+    evals = json.loads(open("skills/temper/evals/evals.json").read())
+    expected_count = sum(
+        f.get("replicate_rule", {}).get("trials", 1) for f in evals["evals"]
+    )
+    actual = list(dispatch_dir.glob("*-reviewer.md"))
+    assert len(actual) == expected_count == len(manifest["trials"])
+
+    # Each trial entry well-formed
+    for entry in manifest["trials"]:
+        assert entry["seq"] >= 1
+        assert "fixture_id" in entry
+        assert "fixture_sha" in entry
+        assert (dispatch_dir / entry["dispatch_file"]).exists()
+
+
+def test_stage_refuses_existing_dir_without_force(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    stage("R-test")
+    with pytest.raises(FileExistsError):
+        stage("R-test")
+
+
+def test_stage_force_overwrites(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    stage("R-test")
+    stage("R-test", force=True)  # no raise
+
+
+def test_stage_rejects_bad_run_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    with pytest.raises(ValueError):
+        stage("../etc")

--- a/skills/temper/evals/test_run_evals_stage.py
+++ b/skills/temper/evals/test_run_evals_stage.py
@@ -119,8 +119,13 @@ def test_legacy_main_runs_without_attribute_error(tmp_path, monkeypatch):
     env = {**os.environ, "TEMPER_LAST_RUN_OVERRIDE": str(last_run_out)}
     repo_tracked = repo_root / "skills" / "temper" / "evals" / "last_run.json"
     repo_tracked_mtime_pre = repo_tracked.stat().st_mtime if repo_tracked.exists() else None
+    import sys
     result = subprocess.run(
-        ["python", "-m", "skills.temper.evals.run_evals",
+        # Task 8.5 deviation: use sys.executable so the test runs under
+        # environments where `python` is not on PATH (e.g. Debian/Ubuntu
+        # without `python-is-python3`). Necessary now that mock-fixtures
+        # exists and this test un-skips.
+        [sys.executable, "-m", "skills.temper.evals.run_evals",
          "--mock-reviewer", str(dst_fixtures)],
         capture_output=True, text=True, timeout=120,
         cwd=str(repo_root), env=env,

--- a/skills/temper/evals/test_run_evals_stage.py
+++ b/skills/temper/evals/test_run_evals_stage.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from skills.temper.evals.run_evals import stage
+from skills.temper.evals.run_evals import _validate_rendered_prompt, stage
 
 
 def test_stage_produces_dispatch_files(monkeypatch, tmp_path):
@@ -142,3 +142,37 @@ def test_legacy_main_runs_without_attribute_error(tmp_path, monkeypatch):
     assert "AttributeError" not in result.stderr, (
         f"_legacy_main attribute rename incomplete: {result.stderr}"
     )
+
+
+def test_rendered_prompt_validator_rejects_small():
+    with pytest.raises(ValueError, match="length"):
+        _validate_rendered_prompt("tiny")
+
+
+def test_rendered_prompt_validator_rejects_unsubstituted_placeholder():
+    # >200 bytes so length-floor passes, but contains a placeholder marker
+    body = "x" * 300 + " {DESCRIPTION} " + "y" * 100
+    with pytest.raises(ValueError, match="placeholder"):
+        _validate_rendered_prompt(body)
+
+
+def test_rendered_prompt_validator_accepts_clean():
+    clean = "a" * 500
+    assert "{" not in clean
+    _validate_rendered_prompt(clean)  # should not raise
+
+
+def test_stage_rejects_template_with_unsubstituted_placeholder(monkeypatch, tmp_path):
+    """I-T9 integration: stage() must fail-fast if the template after substitution
+    still contains `{` — even though fixture body legitimately contains `{`.
+    Validates that validation scope is template-only (not full rendered prompt)."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    bad_template_path = tmp_path / "bad-template.md"
+    bad_template_path.write_text(
+        "# Reviewer\n" + "x" * 250 + " {UNSUBSTITUTED_VAR} more text\n"
+    )
+    from skills.temper.evals import run_evals
+    monkeypatch.setattr(run_evals, "_REVIEWER_PROMPT", bad_template_path)
+    with pytest.raises(ValueError, match="placeholder"):
+        run_evals.stage("R-bad")

--- a/skills/temper/evals/test_run_evals_stage.py
+++ b/skills/temper/evals/test_run_evals_stage.py
@@ -1,6 +1,7 @@
 """Tests for stage() subcommand (Task 3 of #297)."""
 
 import json
+import sys
 
 import pytest
 
@@ -119,7 +120,6 @@ def test_legacy_main_runs_without_attribute_error(tmp_path, monkeypatch):
     env = {**os.environ, "TEMPER_LAST_RUN_OVERRIDE": str(last_run_out)}
     repo_tracked = repo_root / "skills" / "temper" / "evals" / "last_run.json"
     repo_tracked_mtime_pre = repo_tracked.stat().st_mtime if repo_tracked.exists() else None
-    import sys
     result = subprocess.run(
         # Task 8.5 deviation: use sys.executable so the test runs under
         # environments where `python` is not on PATH (e.g. Debian/Ubuntu

--- a/skills/temper/evals/test_runid.py
+++ b/skills/temper/evals/test_runid.py
@@ -1,0 +1,55 @@
+import pytest
+from skills.temper.evals._runid import validate_run_id, validate_prefix
+
+
+def test_validate_run_id_accepts_alphanumeric():
+    validate_run_id("R-test")
+    validate_run_id("ABC_123-xyz")
+
+
+def test_validate_run_id_rejects_too_long():
+    with pytest.raises(ValueError, match="run-id"):
+        validate_run_id("a" * 33)
+
+
+def test_validate_run_id_rejects_traversal():
+    with pytest.raises(ValueError):
+        validate_run_id("../etc")
+    with pytest.raises(ValueError):
+        validate_run_id("a/b")
+
+
+def test_validate_run_id_rejects_empty():
+    with pytest.raises(ValueError):
+        validate_run_id("")
+
+
+def test_validate_run_id_rejects_leading_dash():
+    """2P-4: a leading `-` makes the run-id look like a CLI flag downstream
+    (e.g. `python -m ... stage -foo` would be parsed as a flag, not a run_id).
+    Reject at validation time."""
+    with pytest.raises(ValueError):
+        validate_run_id("-foo")
+    with pytest.raises(ValueError):
+        validate_run_id("-")
+
+
+def test_validate_prefix_caps_at_29():
+    validate_prefix("a" * 29)
+    with pytest.raises(ValueError):
+        validate_prefix("a" * 30)
+
+
+def test_validate_prefix_rejects_leading_dash():
+    """2P-4: same hazard for calibrate prefix."""
+    with pytest.raises(ValueError):
+        validate_prefix("-prefix")
+
+
+def test_sanitize_summary_replaces_literal():
+    """S-R4-5: literal DISPATCH_STATUS: substring is neutralized."""
+    from skills.temper.evals._runid import sanitize_summary
+    assert sanitize_summary("DISPATCH_STATUS: ERROR: foo") == "[DISPATCH_STATUS_LITERAL] ERROR: foo"
+    assert sanitize_summary("clean text") == "clean text"
+    # Case-sensitive — lowercase variants are not the sentinel and are preserved
+    assert sanitize_summary("dispatch_status: ok") == "dispatch_status: ok"


### PR DESCRIPTION
## Summary

Re-architects temper eval harness to remove banned `claude -p` subprocess. Replaces with hybrid stage/collect/score transport + two sibling skills (`/temper-eval-collect`, `/temper-eval-calibrate`). Unblocks #290 Phase 3.

- **23 commits** spanning Phase 3 implementation (T0-T15) + Phase 4 gate fixes (temper R1 + QG R1/R2/R3)
- **137 pytest passing** (was 92 + 1 skip pre-#297; net +45 tests including 28 inquisitor adversarials)
- **Zero `claude -p` references remain** — enforced by symbol-deletion-guard test + AC-1 grep gate
- **AC matrix:** all 14 ACs PASS; 2 manual gates (AC-5 collect e2e + AC-12b calibrate idempotency) documented for operator pre-merge

## What landed

### Production code (skills/temper/evals/run_evals.py)
- New subcommands: `stage` (writes dispatch manifest + reviewer prompts to runtime dir), `score` (aggregates results, writes `last_run.json` or per-iter file, supports `--write-baseline`/`--compare-baseline`)
- Atomic JSON writes via `_atomic_write_text` helper (tmp + `os.replace`)
- Path resolution via `_resolve_output_path()` (eliminates import-time vs runtime asymmetry)
- Robust input validation (run-id regex, trials/timeout floors, malformed `.collect-status` handling)
- Fixture-set drift detection scoped to `evals.json` (not manifest)
- `_dispatch_live` deleted; `_resolve_output` returns `None` for missing replay/mock
- 3 utility modules: `_runid.py`, `_dispatch_paths.py`, `bootstrap_snapshot.py`

### New skills
- `skills/temper-eval-collect/SKILL.md` — drives per-fixture-trial subagent dispatch via Claude Code Task tool
- `skills/temper-eval-calibrate/SKILL.md` — k-loop wrapper for stage → collect → score iterations

### Test coverage
- 10 hand-authored mock-fixture reviewer outputs (`skills/temper/evals/mock-fixtures/`)
- `mock_snapshot.json` regression baseline + `bootstrap_snapshot.py` verify-mode tool
- 28 inquisitor adversarial tests across 5 dimensions
- 8 QG-cycle regression tests (malformed errors line, manifest trials, corrupt baseline, atomic write, fixture drift, scoped stage, etc.)

### Manual pre-merge gates (operator runs once)
- **AC-5:** `/temper-eval-collect R-ac4` — verify reviewer-output files appear in dispatch dir
- **AC-12b:** `/temper-eval-calibrate ac12b-test --k 2 --source synthetic` twice — verify idempotency (zero new dispatches on re-invocation)

## Phase 4 ceremony summary

| Step | Outcome |
|------|---------|
| Acceptance tests | 100 → 137 passed across the run |
| crucible:temper | CLEAN R2 (1 fix commit) |
| crucible:inquisitor | ALL_PASS, 5 dims, 28 tests, 0 prod fixes |
| Security signal scan | 0 prod-code signals → siege SKIPPED silently |
| crucible:quality-gate (code) | PASS R4 (trajectory 6→3→1→0 Significant; 3 fix commits) |

## Follow-ups (non-blocking)

- `--legacy-timeout` argparse flag is now a no-op (kept for test compat); cleanup ticket candidate
- `_compare_baseline` accepts unused `allow_fixture_drift` kwarg (drift logic moved to caller); minor cleanup
- 4 other Minor QG R4 housekeeping items (dead code, off-by-one length floor, wasted IO)
- See gate verdict marker `gate-verdict-297-code-2026-05-24.md` for full list

## Test plan

- [x] `PYTHONPATH=. pytest skills/temper/evals/` → 137 passed
- [x] `git grep "claude -p" skills/temper/` → 0 hits
- [x] `python -m skills.temper.evals.bootstrap_snapshot` → verify-mode OK
- [ ] Operator runs AC-5 manual gate pre-merge
- [ ] Operator runs AC-12b manual gate pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)