### PR TITLE
fix(temper): mandate File:line on Tenancy + Rollback findings (#299)

### DIFF
--- a/skills/temper/temper-reviewer.md
+++ b/skills/temper/temper-reviewer.md
@@ -171,7 +171,7 @@ git diff {BASE_SHA}..{HEAD_SHA}
 >
 > **Severity:** exploitable cross-tenant reach = Critical. Defensible-but-undocumented single-layer enforcement = Important. Admin/BYPASSRLS handles in tenancy-acceptance tests = Important (the test is plumbing-only, not policy coverage). Bands are floors, not ceilings — promote per actual impact.
 >
-> **Finding format:** emit `Category: Tenancy` on its own line immediately after the `Severity:` line.
+> **Finding format:** emit `Category: Tenancy` on its own line immediately after the `Severity:` line. **Every Tenancy finding MUST also include a `File:` line in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (numeric line refs from the diff's `@@` hunks — function/class names, table names, or symbolic locators are INVALID). Findings without a numeric `File:` line are invalid and MUST be dropped before emit.** This mirrors the Lens File:line discipline (see Targeted Lenses preamble) and applies identically to Category findings.
 >
 > **Applies when:** the diff touches a tenancy surface as defined above **in code, not in documentation or prose**. If the diff only edits markdown / docstrings / prompt templates that mention tenancy concepts as text (without changing code that enforces tenancy), this discipline emits nothing. If no tenancy surface is present at all, this discipline emits nothing.
 
@@ -184,7 +184,7 @@ git diff {BASE_SHA}..{HEAD_SHA}
 >
 > **Severity:** re-`up()` failure on a migration already deployed to a production / non-rollback-able environment = Critical. CASCADE causing data loss beyond the migration's stated scope = Critical. Orphan FK columns or broken re-up in non-production paths = Important. CASCADE side-effects beyond stated scope (non-data-loss) = Important. Forward-only without documented intent = Minor. Bands are floors, not ceilings — promote per actual impact.
 >
-> **Finding format:** emit `Category: Rollback` on its own line immediately after the `Severity:` line.
+> **Finding format:** emit `Category: Rollback` on its own line immediately after the `Severity:` line. **Every Rollback finding MUST also include a `File:` line in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (numeric line refs from the diff's `@@` hunks — migration filenames without a line number, function names, or symbolic locators are INVALID). Findings without a numeric `File:` line are invalid and MUST be dropped before emit.** This mirrors the Lens File:line discipline (see Targeted Lenses preamble) and applies identically to Category findings.
 >
 > **Applies when:** the diff includes migration files. Otherwise emits nothing.
 


### PR DESCRIPTION
## Summary

- Closes #299
- Tenancy + Rollback Category findings were exempt from the lens-wide File:line mandate (line 64); their Finding-format notes only required the `Category:` line.
- Add the File:line discipline mirror to both sections, modeled on the Targeted Lenses preamble.
- R-ac4 fixtures 6 + 7 re-validated post-fix: both PASS (2/5 → 3/5 and 2/5 → 4/5).

## Why this slipped

The Targeted Lenses preamble's "Every finding emitted from any lens MUST include a `File:` line" only binds findings under the `### Targeted Lenses` heading. Tenancy and Rollback are sibling sections at the same depth, so reviewers reasonably treated their `Category:` -only Finding-format note as the complete recipe.

## Test plan

- [x] R-299-verify (fixture 6, 5 trials): all 3+ trials cite File:line → PASS
- [x] R-299-verify7 (fixture 7, 5 trials): all 3+ trials cite File:line → PASS
- [ ] Operator may want to re-run full R-ac4 (46 trials) before merging to confirm no regression on 1a/1b/2/2-reattrib/3/4/5

## Caveat

Fixture `6-tenancy-forged-callback` lands at exactly the 3/5 threshold floor post-fix. Could re-FAIL on a single noisy trial. Two follow-up options:
1. Tighten the Tenancy section further (e.g. add an example of a finding WITH the File:line)
2. Raise `6-tenancy-forged-callback`'s trial count from 5 → 7 to widen the noise band

Neither is blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)