### PR TITLE
feat(291): temper lens-health telemetry + sunset criteria

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ mcp-servers/**/__pycache__/
 /skills/temper/evals/.calibrate-state/
 /skills/temper/evals/baseline.json
 /skills/temper/evals/.opus-ceiling.json
+# #291 lens-health telemetry rolling history log (CI starts from empty/absent)
+/skills/temper/evals/history.jsonl

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -1729,8 +1729,8 @@ def report(
     """#291 Task 4: print a per-lens real-PR pass-rate trend + advisory SUNSET?.
 
     Read-only; ALWAYS returns 0. Loads history.jsonl, filters to QUALIFYING runs
-    (records carrying real-PR data — source == "all"; source == "synthetic"
-    records are skipped so they never consume a window slot), takes the last
+    (records carrying real-PR data — source in {"all", "real-pr"}; source ==
+    "synthetic" records are skipped so they never consume a window slot), takes the last
     `window` qualifying records, and renders a fixed-width table to stdout: one
     row per lens (Surgical/DRY/SRP/OCP, from _LENS_COLUMN_VALUES minus "none"),
     one column per qualifying windowed run, a `mean` column (over non-null runs),
@@ -1742,6 +1742,14 @@ def report(
     qualifying-run count, not the raw record count. Prints `no history yet` and
     returns 0 when the file is absent/empty or has no qualifying runs.
     """
+    # Clamp non-positive window to 1: window==0 makes qualifying[-0:] select the
+    # WHOLE list and `len(present) >= 0` is always True, firing a false SUNSET on
+    # lenses with zero real-PR data; window<0 left-trims. Report is advisory and
+    # always returns 0, so clamp (not hard-error) and warn.
+    if window < 1:
+        print(f"[warn] non-positive window {window} clamped to 1", file=sys.stderr)
+        window = 1
+
     if history_path is None:
         history_path = _resolve_history_path()
 
@@ -1758,9 +1766,10 @@ def report(
         except json.JSONDecodeError:
             continue
 
-    # Filter to qualifying runs: carry real-PR data. source == "all" qualifies;
-    # source == "synthetic" never consumes a window slot.
-    qualifying = [r for r in records if r.get("source") == "all"]
+    # Filter to qualifying runs: carry real-PR data. source == "all" and
+    # source == "real-pr" qualify (a real-pr-scoped score run carries per-lens
+    # real-PR rates); source == "synthetic" never consumes a window slot.
+    qualifying = [r for r in records if r.get("source") in ("all", "real-pr")]
     if not qualifying:
         print("no history yet")
         return 0

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -75,11 +75,31 @@ def _resolve_output_path(run_id: str, *, per_iter: bool) -> Path:
     if env_override:
         return Path(env_override)
     return _EVALS_DIR / "last_run.json"
+
+
+def _resolve_history_path() -> Path:
+    """#291: resolve the lens-health history log path at CALL TIME.
+
+    Mirrors `_resolve_output_path`'s call-time `_EVALS_DIR` resolution rather
+    than binding a module-level `_HISTORY_PATH` at import. The score-test
+    harness (`test_run_evals_score.py::_seed_dispatch_dir`) monkeypatches
+    `_EVALS_DIR` to `tmp_path`; resolving here means that single monkeypatch
+    keeps history writes inside the test sandbox. An import-time constant would
+    bind to the REAL `_EVALS_DIR` and existing score tests would silently
+    append to the real `skills/temper/evals/history.jsonl`.
+    """
+    return _EVALS_DIR / "history.jsonl"
 # SP-R7-C: declared in Task 6 (not Task 8) so test_run_evals_score.py's
 # `_seed_dispatch_dir` helper can `monkeypatch.setattr(run_evals, "_BASELINE_PATH", ...)`
 # without raising AttributeError. The `_write_baseline` / `_compare_baseline` helper
 # functions that USE this constant are still added in Task 8 (stubs added below in Task 6).
 _BASELINE_PATH = _EVALS_DIR / "baseline.json"
+
+# #291: rolling lens-health history log cap (most-recent K records kept).
+# The history.jsonl path itself is resolved at call time via
+# `_resolve_history_path()` (NOT a module-level constant) so the `_EVALS_DIR`
+# test monkeypatch covers it — see that helper's docstring.
+_HISTORY_CAP = 50
 
 # Task 2 (#290 S1): empirical-tolerance calibration artifact path. The header
 # schema is enforced by `test_calibration_json_schema`. Mutations land via

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -1360,6 +1360,69 @@ def _per_fixture_pass_rates(fixtures: list[dict]) -> dict[str, float]:
     return rates
 
 
+def _append_history(
+    run_id: str,
+    run_at: str,
+    grouped: dict[str, Any],
+    source: str,
+    *,
+    path: Path | None = None,
+    cap: int = _HISTORY_CAP,
+) -> None:
+    """#291 Task 2: append one per-run lens-health record to history.jsonl.
+
+    Builds a single record from the already-computed `grouped` summary:
+      - run_id, run_at (ISO-8601, copied from the run payload), source
+        (score()'s --source scope: "all" | "synthetic" | "real-pr")
+      - per_lens: copied from grouped["per_trial_rates"]
+        (shape {lens: {synthetic, real-pr}})
+      - by_source: {source: {pass, total}} rolled up from
+        grouped["by_source"] using _render_grouped_summary's PASS-over-total
+        convention — pass = count of PASS verdicts, total = len(entries), so
+        N/A-verdict fixtures count in `total` and never in `pass`.
+
+    Reads existing lines (tolerating an absent file on first run and skipping
+    malformed lines rather than crashing — CI starts from an empty/absent
+    history because the file is gitignored), appends the new record, keeps only
+    the last `cap` records, and rewrites atomically via `_atomic_write_text`.
+
+    When `path is None`, resolves it via `_resolve_history_path()` at call time
+    so the `_EVALS_DIR` test monkeypatch covers isolation; `path` stays an
+    injectable override for direct unit tests.
+    """
+    if path is None:
+        path = _resolve_history_path()
+
+    by_source_counts: dict[str, dict[str, int]] = {}
+    for src_key, entries in (grouped.get("by_source") or {}).items():
+        n_pass = sum(1 for e in entries if e.get("verdict") == "PASS")
+        by_source_counts[src_key] = {"pass": n_pass, "total": len(entries)}
+
+    record = {
+        "run_id": run_id,
+        "run_at": run_at,
+        "source": source,
+        "per_lens": grouped.get("per_trial_rates", {}),
+        "by_source": by_source_counts,
+    }
+
+    existing: list[str] = []
+    if path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                json.loads(line)
+            except json.JSONDecodeError:
+                # Skip malformed prior lines rather than crashing.
+                continue
+            existing.append(line)
+
+    existing.append(json.dumps(record))
+    kept = existing[-cap:] if cap and len(existing) > cap else existing
+    _atomic_write_text(path, "\n".join(kept) + "\n")
+
+
 def score(
     run_id: str,
     *,
@@ -1555,6 +1618,18 @@ def score(
     # QG R2 Fix 1: atomic write — prevents truncated last_run/per-iter on SIGINT/OOM/disk-full
     _atomic_write_text(out_path, json.dumps(payload, indent=2))
 
+    # #291 Task 3: append one lens-health history record per CANONICAL run.
+    # Gated on `not per_iter`: per-iter writes target .calibrate-state/ (one per
+    # calibration baseline_runs iteration) and must NOT be logged as runs — they
+    # would contaminate the trend series + the N-run sunset window. Telemetry is
+    # advisory and must never gate: a history-write failure logs [warn] to stderr
+    # and leaves score()'s return code unchanged.
+    if not per_iter:
+        try:
+            _append_history(run_id, payload["run_at"], grouped, source)
+        except Exception as e:  # noqa: BLE001 — telemetry must not gate score()
+            print(f"[warn] lens-health history append failed: {e}", file=sys.stderr)
+
     # --write-baseline + --compare-baseline — see Task 8 (stubs raise NotImplementedError)
     if write_baseline:
         _write_baseline(payload, current_template_sha)
@@ -1642,6 +1717,102 @@ def _render_summary(fixture_results: list[dict]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# #291 Task 4: lens-health report subcommand (advisory; never gates)
+# ---------------------------------------------------------------------------
+
+
+def report(
+    window: int = 5,
+    sunset_threshold: float = 0.70,
+    history_path: Path | None = None,
+) -> int:
+    """#291 Task 4: print a per-lens real-PR pass-rate trend + advisory SUNSET?.
+
+    Read-only; ALWAYS returns 0. Loads history.jsonl, filters to QUALIFYING runs
+    (records carrying real-PR data — source == "all"; source == "synthetic"
+    records are skipped so they never consume a window slot), takes the last
+    `window` qualifying records, and renders a fixed-width table to stdout: one
+    row per lens (Surgical/DRY/SRP/OCP, from _LENS_COLUMN_VALUES minus "none"),
+    one column per qualifying windowed run, a `mean` column (over non-null runs),
+    and a `SUNSET?` column.
+
+    SUNSET? fires only when the lens has real-PR data in ALL `window` qualifying
+    runs AND every such rate is < sunset_threshold; otherwise the cell shows
+    `n/a (need {window} runs)`. The need-N guard fires on the PER-LENS-PRESENT
+    qualifying-run count, not the raw record count. Prints `no history yet` and
+    returns 0 when the file is absent/empty or has no qualifying runs.
+    """
+    if history_path is None:
+        history_path = _resolve_history_path()
+
+    if not history_path.exists():
+        print("no history yet")
+        return 0
+
+    records: list[dict] = []
+    for line in history_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    # Filter to qualifying runs: carry real-PR data. source == "all" qualifies;
+    # source == "synthetic" never consumes a window slot.
+    qualifying = [r for r in records if r.get("source") == "all"]
+    if not qualifying:
+        print("no history yet")
+        return 0
+
+    windowed = qualifying[-window:]
+    lens_cols = tuple(v for v in _LENS_COLUMN_VALUES if v != "none")
+
+    # Per-lens real-PR rate series across the windowed qualifying runs.
+    def _rate(rec: dict, lens: str):
+        return ((rec.get("per_lens") or {}).get(lens) or {}).get("real-pr")
+
+    # Column widths.
+    n_cols = len(windowed)
+    cell_w = 7  # fits "1.00" / "n/a"
+    lens_w = max((len(l) for l in lens_cols), default=8)
+    lens_w = max(lens_w, len("lens"))
+
+    def _fmt_rate(v) -> str:
+        return f"{v:.2f}" if isinstance(v, (int, float)) else "n/a"
+
+    # Header
+    header = "lens".ljust(lens_w)
+    for i in range(n_cols):
+        header += " | " + f"r{i + 1}".rjust(cell_w)
+    header += " | " + "mean".rjust(cell_w) + " | " + "SUNSET?"
+    print(f"lens-health trend (last {n_cols} qualifying real-PR run(s), "
+          f"sunset<{sunset_threshold:.2f} across full window of {window})")
+    print(header)
+    print("-" * len(header))
+
+    for lens in lens_cols:
+        series = [_rate(rec, lens) for rec in windowed]
+        present = [v for v in series if isinstance(v, (int, float))]
+        row = lens.ljust(lens_w)
+        for v in series:
+            row += " | " + _fmt_rate(v).rjust(cell_w)
+        mean_val = (sum(present) / len(present)) if present else None
+        row += " | " + (_fmt_rate(mean_val)).rjust(cell_w)
+
+        # SUNSET? only when lens has real-PR data in ALL `window` qualifying
+        # runs AND every rate < threshold. Guard fires on per-lens-present count.
+        if len(present) >= window and all(v < sunset_threshold for v in present):
+            sunset_cell = "SUNSET"
+        else:
+            sunset_cell = f"n/a (need {window} runs)"
+        row += " | " + sunset_cell
+        print(row)
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -1692,6 +1863,17 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="(#290 S1) emit a placeholder calibration.json header if absent. "
              "Full calibration is computed by scripts/calibrate_tolerance.py "
              "after k=3 baseline runs via the 3-step protocol.")
+
+    # report — #291 Task 4 (advisory lens-health trend; always exits 0)
+    sp_report = sub.add_parser(
+        "report", help="Print per-lens real-PR pass-rate trend + advisory SUNSET? flag"
+    )
+    sp_report.add_argument("--window", type=int, default=5,
+        help="Number of most-recent qualifying runs in the trend window (default 5).")
+    sp_report.add_argument("--sunset-threshold", type=float, default=0.70,
+        help="Real-PR pass-rate below which a lens is flagged for sunset across the full window (default 0.70).")
+    sp_report.add_argument("--history", default=None,
+        help="Path to history.jsonl (overridable for test isolation).")
 
     # Legacy mock/replay paths (back-compat, no subcommand)
     # S3: All legacy flags use --legacy-* prefix to eliminate collision with subcommand flags.
@@ -1757,6 +1939,13 @@ def main(argv: list[str] | None = None) -> int:
                     file=sys.stderr,
                 )
         return rc
+
+    if args.cmd == "report":
+        return report(
+            window=args.window,
+            sunset_threshold=args.sunset_threshold,
+            history_path=Path(args.history) if args.history else None,
+        )
 
     # Legacy mock/replay path — preserved unchanged
     return _legacy_main(args)

--- a/skills/temper/evals/test_run_evals_report.py
+++ b/skills/temper/evals/test_run_evals_report.py
@@ -1,0 +1,349 @@
+"""Tests for #291 lens-health telemetry: _append_history + report subcommand.
+
+Isolation style (per #291 plan Task 5): monkeypatch `_EVALS_DIR` to `tmp_path`
+ONLY. The history path is resolved at call time via `_resolve_history_path()`
+(see run_evals.py), so the single `_EVALS_DIR` monkeypatch keeps history writes
+inside the sandbox — exactly as the post-Task-13.5 score tests rely on for the
+canonical/per-iter output paths. There is intentionally NO dedicated history
+constant to patch.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+from skills.temper.evals import run_evals
+from skills.temper.evals.run_evals import _append_history, report, score, stage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _grouped(real_rate=None, syn_rate=1.0, by_source=None):
+    """Build a minimal grouped-summary dict shaped like _compute_grouped_summary.
+
+    per_trial_rates carries the four wired lens columns; only `Surgical`'s
+    real-pr rate is parameterized (others default to None) so tests can drive
+    the sunset window off one lens.
+    """
+    if by_source is None:
+        by_source = {
+            "synthetic": [{"id": "1a", "verdict": "PASS"}],
+            "real-pr": [{"id": "surgical-real", "verdict": "PASS"}],
+        }
+    per = {}
+    for lens in ("Surgical", "DRY", "SRP", "OCP"):
+        per[lens] = {
+            "synthetic": syn_rate,
+            "real-pr": real_rate if lens == "Surgical" else None,
+        }
+    return {"by_source": by_source, "per_trial_rates": per, "drift_delta": {}}
+
+
+def _seed_qualifying(history_path, *, n, real_rate, run_id_prefix="R-q"):
+    """Append n qualifying (source=all) runs at a fixed Surgical real-pr rate."""
+    for i in range(n):
+        g = _grouped(real_rate=real_rate)
+        _append_history(
+            f"{run_id_prefix}{i}", f"2026-05-2{i}T00:00:00+00:00", g, "all",
+            path=history_path,
+        )
+
+
+def _seed_dispatch_dir(monkeypatch, tmp_path, run_id="R-hist"):
+    """Mirror test_run_evals_score.py isolation, but monkeypatch _EVALS_DIR only
+    (which now also routes the history path via call-time resolution)."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setenv("USER", "tester")
+    monkeypatch.setattr(run_evals, "_LAST_RUN", tmp_path / "last_run.json")
+    monkeypatch.setattr(run_evals, "_BASELINE_PATH", tmp_path / "baseline.json")
+    monkeypatch.setattr(run_evals, "_EVALS_DIR", tmp_path)
+    return stage(run_id)
+
+
+# ---------------------------------------------------------------------------
+# (a) _append_history appends one line per call + caps at _HISTORY_CAP
+# contract:telemetry:history-append-one-per-run
+# ---------------------------------------------------------------------------
+
+
+def test_append_history_one_per_call_and_caps(tmp_path):
+    """contract:telemetry:history-append-one-per-run
+
+    Writing cap+5 records leaves exactly cap lines, and the newest run_id is
+    retained (oldest evicted)."""
+    hp = tmp_path / "history.jsonl"
+    cap = run_evals._HISTORY_CAP
+    for i in range(cap + 5):
+        _append_history(
+            f"R-{i}", f"2026-01-01T00:00:0{i % 10}+00:00", _grouped(real_rate=0.5),
+            "all", path=hp,
+        )
+    lines = [l for l in hp.read_text().splitlines() if l.strip()]
+    assert len(lines) == cap, f"expected cap={cap} lines, got {len(lines)}"
+    last = json.loads(lines[-1])
+    assert last["run_id"] == f"R-{cap + 5 - 1}"
+    # Oldest (R-0) evicted.
+    ids = {json.loads(l)["run_id"] for l in lines}
+    assert "R-0" not in ids
+
+
+def test_append_history_record_shape(tmp_path):
+    """One call → one well-formed record with run_id/run_at/source/per_lens/by_source."""
+    hp = tmp_path / "history.jsonl"
+    g = _grouped(
+        real_rate=0.4,
+        by_source={
+            "synthetic": [
+                {"id": "a", "verdict": "PASS"},
+                {"id": "b", "verdict": "N/A"},
+            ],
+            "real-pr": [{"id": "c", "verdict": "FAIL"}],
+        },
+    )
+    _append_history("R-shape", "2026-05-28T12:00:00+00:00", g, "all", path=hp)
+    rec = json.loads(hp.read_text().splitlines()[0])
+    assert rec["run_id"] == "R-shape"
+    assert rec["run_at"] == "2026-05-28T12:00:00+00:00"
+    assert rec["source"] == "all"
+    assert rec["per_lens"]["Surgical"]["real-pr"] == 0.4
+    # by_source: pass = PASS count, total = len(entries) (N/A counts in total).
+    assert rec["by_source"]["synthetic"] == {"pass": 1, "total": 2}
+    assert rec["by_source"]["real-pr"] == {"pass": 0, "total": 1}
+
+
+# ---------------------------------------------------------------------------
+# (b) append tolerates absent file + malformed prior line
+# ---------------------------------------------------------------------------
+
+
+def test_append_history_tolerates_absent_and_malformed(tmp_path):
+    hp = tmp_path / "history.jsonl"
+    # Absent file (first run): must not raise.
+    _append_history("R-1", "2026-05-28T00:00:00+00:00", _grouped(real_rate=0.5), "all", path=hp)
+    # Inject a malformed line, then append again — malformed line skipped.
+    hp.write_text(hp.read_text() + "{ this is not json\n")
+    _append_history("R-2", "2026-05-28T01:00:00+00:00", _grouped(real_rate=0.5), "all", path=hp)
+    good = []
+    for l in hp.read_text().splitlines():
+        if not l.strip():
+            continue
+        try:
+            good.append(json.loads(l))
+        except json.JSONDecodeError:
+            pass
+    ids = {r["run_id"] for r in good}
+    assert ids == {"R-1", "R-2"}
+
+
+# ---------------------------------------------------------------------------
+# (c) report on empty/absent history prints 'no history yet' + returns 0
+# ---------------------------------------------------------------------------
+
+
+def test_report_absent_history(tmp_path, capsys):
+    rc = report(history_path=tmp_path / "nope.jsonl")
+    assert rc == 0
+    assert "no history yet" in capsys.readouterr().out
+
+
+def test_report_empty_history(tmp_path, capsys):
+    hp = tmp_path / "history.jsonl"
+    hp.write_text("")
+    rc = report(history_path=hp)
+    assert rc == 0
+    assert "no history yet" in capsys.readouterr().out
+
+
+def test_report_only_synthetic_runs_no_qualifying(tmp_path, capsys):
+    """Records with source=='synthetic' do not qualify → 'no history yet'."""
+    hp = tmp_path / "history.jsonl"
+    for i in range(3):
+        _append_history(f"R-s{i}", f"2026-05-2{i}T00:00:00+00:00",
+                        _grouped(real_rate=None), "synthetic", path=hp)
+    rc = report(history_path=hp)
+    assert rc == 0
+    assert "no history yet" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# (d) report renders a per-lens trend after 3 seeded qualifying runs
+# ---------------------------------------------------------------------------
+
+
+def test_report_renders_trend(tmp_path, capsys):
+    hp = tmp_path / "history.jsonl"
+    _seed_qualifying(hp, n=3, real_rate=0.9)
+    rc = report(history_path=hp)
+    assert rc == 0
+    out = capsys.readouterr().out
+    for lens in ("Surgical", "DRY", "SRP", "OCP"):
+        assert lens in out
+    assert "mean" in out
+    assert "SUNSET?" in out
+
+
+# ---------------------------------------------------------------------------
+# (e) sunset full-window-only
+# contract:telemetry:sunset-full-window-only
+# ---------------------------------------------------------------------------
+
+
+def test_sunset_fires_full_window_below_threshold(tmp_path, capsys):
+    """contract:telemetry:sunset-full-window-only
+
+    5 qualifying runs all at Surgical real-pr 0.5 (< 0.70) → SUNSET fires for
+    Surgical; lenses with no real-pr data show n/a (need 5 runs)."""
+    hp = tmp_path / "history.jsonl"
+    _seed_qualifying(hp, n=5, real_rate=0.5)
+    rc = report(window=5, sunset_threshold=0.70, history_path=hp)
+    assert rc == 0
+    out = capsys.readouterr().out
+    surgical_line = [l for l in out.splitlines() if l.startswith("Surgical")][0]
+    assert "SUNSET" in surgical_line
+    # A lens with no real-pr data must show the need-N-runs guard, not SUNSET.
+    dry_line = [l for l in out.splitlines() if l.startswith("DRY")][0]
+    assert "need 5 runs" in dry_line
+    assert "SUNSET" not in dry_line
+
+
+def test_sunset_does_not_fire_with_four_qualifying_runs(tmp_path, capsys):
+    """contract:telemetry:sunset-full-window-only — partial window → no SUNSET."""
+    hp = tmp_path / "history.jsonl"
+    _seed_qualifying(hp, n=4, real_rate=0.5)
+    report(window=5, sunset_threshold=0.70, history_path=hp)
+    out = capsys.readouterr().out
+    surgical_line = [l for l in out.splitlines() if l.startswith("Surgical")][0]
+    assert "SUNSET" not in surgical_line
+    assert "need 5 runs" in surgical_line
+
+
+def test_sunset_does_not_fire_with_null_run_in_window(tmp_path, capsys):
+    """A null Surgical rate inside the window breaks lens-present-in-all → no SUNSET."""
+    hp = tmp_path / "history.jsonl"
+    # 4 qualifying runs below threshold + 1 qualifying run with null Surgical.
+    _seed_qualifying(hp, n=4, real_rate=0.5)
+    _append_history("R-null", "2026-05-29T00:00:00+00:00",
+                    _grouped(real_rate=None,
+                             by_source={"synthetic": [{"id": "x", "verdict": "PASS"}],
+                                        "real-pr": [{"id": "y", "verdict": "PASS"}]}),
+                    "all", path=hp)
+    report(window=5, sunset_threshold=0.70, history_path=hp)
+    out = capsys.readouterr().out
+    surgical_line = [l for l in out.splitlines() if l.startswith("Surgical")][0]
+    assert "SUNSET" not in surgical_line
+    assert "need 5 runs" in surgical_line
+
+
+def test_sunset_does_not_fire_when_one_rate_above_threshold(tmp_path, capsys):
+    """All 5 present but one rate >= threshold → no SUNSET (every rate must be below)."""
+    hp = tmp_path / "history.jsonl"
+    _seed_qualifying(hp, n=4, real_rate=0.5)
+    _append_history("R-high", "2026-05-29T00:00:00+00:00",
+                    _grouped(real_rate=0.95), "all", path=hp)
+    report(window=5, sunset_threshold=0.70, history_path=hp)
+    out = capsys.readouterr().out
+    surgical_line = [l for l in out.splitlines() if l.startswith("Surgical")][0]
+    assert "SUNSET" not in surgical_line
+
+
+# ---------------------------------------------------------------------------
+# (f) source accounting: synthetic records do not consume a window slot
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_records_do_not_consume_window_slot(tmp_path, capsys):
+    """Interleave synthetic records among 5 qualifying runs; sunset still fires
+    off the 5 qualifying runs (synthetic ones are skipped, not counted)."""
+    hp = tmp_path / "history.jsonl"
+    for i in range(5):
+        # synthetic noise before each qualifying run
+        _append_history(f"R-syn{i}", f"2026-05-1{i}T00:00:00+00:00",
+                        _grouped(real_rate=None), "synthetic", path=hp)
+        _append_history(f"R-all{i}", f"2026-05-2{i}T00:00:00+00:00",
+                        _grouped(real_rate=0.5), "all", path=hp)
+    rc = report(window=5, sunset_threshold=0.70, history_path=hp)
+    assert rc == 0
+    out = capsys.readouterr().out
+    surgical_line = [l for l in out.splitlines() if l.startswith("Surgical")][0]
+    assert "SUNSET" in surgical_line, (
+        "synthetic records must not consume a window slot — 5 qualifying runs "
+        "remain and SUNSET should fire"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (g) per-iter gating regression: score(per_iter=True) appends zero history
+# ---------------------------------------------------------------------------
+
+
+def test_per_iter_score_appends_zero_history(monkeypatch, tmp_path):
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "Rcal-1")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    rc = score("Rcal-1", per_iter=True, allow_incomplete=False)
+    assert rc in (0, 1)
+    hp = tmp_path / "history.jsonl"
+    assert not hp.exists(), "per-iter score must NOT append to history.jsonl"
+
+
+def test_canonical_score_appends_one_history_line(monkeypatch, tmp_path):
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "Rcanon-1")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    rc = score("Rcanon-1", source="all", allow_incomplete=False)
+    assert rc in (0, 1)
+    hp = tmp_path / "history.jsonl"
+    assert hp.exists()
+    lines = [l for l in hp.read_text().splitlines() if l.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["run_id"] == "Rcanon-1"
+
+
+# ---------------------------------------------------------------------------
+# (h) test-isolation regression: score() under _EVALS_DIR-only monkeypatch
+# does NOT create/modify the real skills/temper/evals/history.jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_score_does_not_touch_real_history_log(monkeypatch, tmp_path):
+    real_history = Path(run_evals.__file__).resolve().parent / "history.jsonl"
+    existed_before = real_history.exists()
+    mtime_before = real_history.stat().st_mtime if existed_before else None
+    lines_before = (
+        len(real_history.read_text().splitlines()) if existed_before else None
+    )
+
+    d = _seed_dispatch_dir(monkeypatch, tmp_path, "Riso-1")
+    (d / ".collect-status").write_text("complete\nerrors: 0/0\n")
+    score("Riso-1", source="all", allow_incomplete=False)
+
+    if not existed_before:
+        assert not real_history.exists(), (
+            "score() under _EVALS_DIR-only monkeypatch created the REAL "
+            "history.jsonl — call-time resolution failed test isolation"
+        )
+    else:
+        assert real_history.stat().st_mtime == mtime_before
+        assert len(real_history.read_text().splitlines()) == lines_before
+
+
+# ---------------------------------------------------------------------------
+# (i) report/_append_history code paths never write evals.json / remove lenses
+# ---------------------------------------------------------------------------
+
+
+def test_report_codepath_does_not_mutate_registry():
+    """report-never-mutates-registry: scope the grep to report() and
+    _append_history() bodies, NOT the whole module (which references evals.json
+    elsewhere, e.g. _EVALS_JSON loads)."""
+    for fn in (run_evals.report, run_evals._append_history):
+        src = inspect.getsource(fn)
+        assert "evals.json" not in src, (
+            f"{fn.__name__} must not reference evals.json (advisory/read-only)"
+        )
+        assert "_EVALS_JSON" not in src
+        # No lens-removal / disabling verbs in these bodies.
+        for verb in ("del ", ".remove(", ".pop(", "disable"):
+            assert verb not in src, f"{fn.__name__} contains mutation verb {verb!r}"

--- a/skills/temper/evals/test_run_evals_report.py
+++ b/skills/temper/evals/test_run_evals_report.py
@@ -275,6 +275,60 @@ def test_synthetic_records_do_not_consume_window_slot(tmp_path, capsys):
     )
 
 
+def test_real_pr_records_count_as_qualifying_window_runs(tmp_path, capsys):
+    """source=='real-pr' records carry per-lens real-PR rates and MUST qualify,
+    participating in the trend/sunset window (mirrors the synthetic-exclusion
+    test, but real-pr DOES count)."""
+    hp = tmp_path / "history.jsonl"
+    for i in range(5):
+        _append_history(f"R-rpr{i}", f"2026-05-2{i}T00:00:00+00:00",
+                        _grouped(real_rate=0.5), "real-pr", path=hp)
+    rc = report(window=5, sunset_threshold=0.70, history_path=hp)
+    assert rc == 0
+    out = capsys.readouterr().out
+    surgical_line = [l for l in out.splitlines() if l.startswith("Surgical")][0]
+    assert "SUNSET" in surgical_line, (
+        "real-pr records carry real-PR data and must qualify — 5 such runs "
+        "below threshold should fire SUNSET"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (f2) non-positive window is clamped to 1 (no false SUNSET on unmeasured lens)
+# ---------------------------------------------------------------------------
+
+
+def test_window_zero_clamps_to_one_no_false_sunset(tmp_path, capsys):
+    """window==0 must clamp to 1; without the clamp `qualifying[-0:]` selects the
+    whole list and `len(present) >= 0` fires a spurious SUNSET on lenses with
+    ZERO real-PR data. One qualifying run with a null DRY rate → DRY must NOT
+    show SUNSET (it has no real-PR data)."""
+    hp = tmp_path / "history.jsonl"
+    _seed_qualifying(hp, n=1, real_rate=0.5)  # Surgical present, DRY/SRP/OCP null
+    rc = report(window=0, sunset_threshold=0.70, history_path=hp)
+    assert rc == 0
+    captured = capsys.readouterr()
+    out = captured.out
+    # Unmeasured lens must not be falsely sunset.
+    dry_line = [l for l in out.splitlines() if l.startswith("DRY")][0]
+    assert "SUNSET" not in dry_line
+    assert "need 1 runs" in dry_line  # clamped window is 1
+    # Clamp warning emitted to stderr.
+    assert "clamped to 1" in captured.err
+
+
+def test_window_negative_clamps_to_one(tmp_path, capsys):
+    """window<0 also clamps to 1 (left-trim slice would otherwise mis-window)."""
+    hp = tmp_path / "history.jsonl"
+    _seed_qualifying(hp, n=1, real_rate=0.5)
+    rc = report(window=-1, sunset_threshold=0.70, history_path=hp)
+    assert rc == 0
+    captured = capsys.readouterr()
+    dry_line = [l for l in captured.out.splitlines() if l.startswith("DRY")][0]
+    assert "SUNSET" not in dry_line
+    assert "clamped to 1" in captured.err
+
+
 # ---------------------------------------------------------------------------
 # (g) per-iter gating regression: score(per_iter=True) appends zero history
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements **#291 — temper lens-health telemetry + sunset criteria** (a #287 follow-up). Per-lens eval pass-rates were already computed every run by `_compute_grouped_summary` but discarded when `last_run.json` is overwritten; this captures them in a rolling log and surfaces drift.

- **Append-only history** — `_append_history()` writes one record per `score()` run to a gitignored, capped (50-line) `skills/temper/evals/history.jsonl` via atomic rewrite. Wired in right after the `last_run.json` write.
- **`report` subcommand** — `python -m skills.temper.evals.run_evals report [--window N] [--sunset-threshold X] [--history PATH]` renders a per-lens real-PR pass-rate trend table with an advisory `SUNSET?` flag. **Read-only, always exits 0** — never auto-removes a lens (human decision).
- **Sunset rule** — `SUNSET?` fires only when a lens has real-PR data in *all* `window` qualifying runs **and** every rate is below threshold (default <70% over 5); otherwise `n/a (need N runs)`.

Purely additive to `run_evals.py`; `lens_runner.py` untouched, no orchestrator changes.

## Design decisions (carried from /spec, then hardened by review)

- **Call-time history-path resolution** (`_resolve_history_path()`, no import-time constant) so the existing `_EVALS_DIR` test monkeypatch isolates history writes — a regression test asserts `score()` under isolation never touches the real log.
- **`not per_iter` gating** — calibration (`--per-iter`) runs write to `.calibrate-state/`, not the canonical log, so they don't pollute the trend series.
- **Source accounting** — only real-PR-bearing runs (`source in (all, real-pr)`) count toward the sunset window; `synthetic`-only runs never consume a window slot.
- **Telemetry never gates** — a history-write failure logs `[warn]` to stderr and leaves `score()`'s return code untouched.

## Pipeline provenance

- `/spec` produced + quality-gated the design/plan/contract (converged design→plan, R1→R2 clean).
- `/build`: single implementer (TDD), then **temper** Phase 4 — R1 had 0 Critical / 0 Important + 2 Minor; both fixed (a `--window 0` false-SUNSET slice bug and a `source == "real-pr"` exclusion) and re-verified green. Inquisitor/siege skipped with rationale (single-file, no cross-component or security surface).
- Contract invariants satisfied; 2 testable ones carry tagged tests (`contract:telemetry:history-append-one-per-run`, `contract:telemetry:sunset-full-window-only`).

## Test plan

- [x] `python3 -m pytest skills/temper/evals/test_run_evals_report.py` → **19 passed** (append/cap, malformed-line tolerance, empty-history, trend render, sunset boundary matrix, source accounting, per-iter gating, test-isolation, window-clamp).
- [x] Full suite: **223 passed, 1 failed**. The single failure (`test_legacy_modes.py::test_legacy_mock_reviewer_matches_snapshot`) **pre-exists on `main`** and is out of scope — see note below.
- [x] `report` CLI smoke on empty history → `no history yet`, exit 0.

## Noticed but not touching

`test_legacy_modes.py::test_legacy_mock_reviewer_matches_snapshot` fails on `main` independent of this change — a snapshot bootstrapped under Python 3.12 vs the suite running under 3.14. Filing a separate follow-up.

Closes #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
