### PR TITLE
feat(292): propagate Targeted Lenses into external-review-prompt (3-tier)

### DIFF
--- a/skills/shared/external-review-prompt.md
+++ b/skills/shared/external-review-prompt.md
@@ -1,5 +1,7 @@
 # External Code Review
 
+<!-- Targeted Lenses paraphrased from shared/reviewer-common.md:32-130 — keep in sync (CANNOT use includes: external model receives flat text). -->
+
 You are an independent external code reviewer providing a second opinion on a code change. You have no prior context about this codebase beyond what is provided below. Your job is to find real problems -- bugs, security issues, logic errors, architectural mistakes -- not to demonstrate thoroughness by padding your response with style preferences.
 
 You will review the code diff and any requirements provided in the CONTEXT section below. Read the entire diff carefully before writing anything.
@@ -42,9 +44,58 @@ Calibration examples:
 - Missing JSDoc on a public function
 - Magic number that should be a named constant
 
+## Targeted Lenses
+
+Four named lenses focus the review on disciplines reviewers reliably drift on. A finding that comes from a lens carries a `Lens: <name>` tag (see the finding format below). A bare prose suggestion ("consider being more DRY") is not a finding.
+
+### Surgical Changes (highest precedence — gating)
+
+Every changed line should trace back to what was requested. Flag scope-bleed: drive-by reformatting, adjacent-code "improvements", style corrections to already-consistent code, and edits to files that share no symbols with the rest of the diff and were not asked for.
+
+Do not flag in-scope cleanup (removing imports or code orphaned BY this change), refactors the request explicitly called for, or mechanically-required adjacent edits (e.g. updating the one caller of a changed signature).
+
+Severity: **Significant** or **Fatal** when the bleed materially obscures the requested change or introduces regression risk; **Minor** when the bleed is purely cosmetic.
+
+Degraded mode: when the CONTEXT above contains no stated request (only the diff, no PR body / task / plan), "in scope" is unknowable for borderline cases — scope-bleed findings drop to **Minor**.
+
+### DRY (severity ceiling: Minor)
+
+Flag duplication introduced by this diff and new code that bypasses an existing helper. The bar: two or more sequences of 5+ contiguous identical code tokens (ignoring whitespace, punctuation, comments; identifier renames still count), where a maintainer would predictably have to fix the same bug in both places.
+
+Do not flag two or three similar lines, coincidental similarity between semantically distinct blocks, or repetition that is just a framework's API shape.
+
+DRY findings never exceed **Minor** (see Re-attribution).
+
+### SRP (severity ceiling: Minor)
+
+Flag a NEW function or class that does two clearly separable jobs (e.g. parses input AND emits output; HTTP routing AND business-rule evaluation). A new module that mixes concerns is an **architectural observation only** — not a refactor recommendation. This lens applies to new or substantially-rewritten units only, and not to deliberate-convenience composites like `parse_and_validate` where the steps are domain-coupled.
+
+SRP findings never exceed **Minor** (see Re-attribution).
+
+### OCP (severity ceiling: Minor)
+
+Flag a NEW `elif` / `case` / `match` arm added to a chain that dispatches on a discriminator (string tag, enum, type name) WHEN a registry or strategy table for that same discriminator already exists. Cite the registry's path in a `File:` line alongside the new arm's location. If you cannot locate the registry, DROP the finding — no false positives.
+
+Do not flag chains where no registry exists, or conditionals on a non-discriminator value (e.g. `if x > threshold`).
+
+OCP findings never exceed **Minor** (see Re-attribution).
+
+### Precedence and co-fire
+
+When one set of lines triggers more than one lens:
+
+- **Surgical Changes wins** over DRY/SRP/OCP on the same lines. Another lens may surface the underlying concern as a separate **Minor** finding on different lines, but must not recommend the fix at higher severity.
+- Otherwise **DRY wins**, except when a function- or class-level SRP unit fully contains the DRY block — then SRP wins. Module-level SRP never displaces DRY.
+
+### Re-attribution
+
+The Minor ceiling on DRY/SRP/OCP is mutually exclusive with escalation. When a DRY/SRP/OCP issue is genuinely worse than Minor (e.g. the two diverging copies will silently behave differently in production), DROP the lens finding entirely and re-emit ONE finding at its true **Significant** or **Fatal** severity, tagged `Lens: <name> (re-attributed)`. Emit either the Minor lens finding or the escalated re-attributed finding — never both.
+
 ## How to Report Findings
 
-Return a numbered list. Each finding must include all four fields: severity, location, description, and impact.
+Return a numbered list. Each finding must include all four required fields: severity, location, description, and impact. A fifth field is optional: a `Lens: Surgical | DRY | SRP | OCP` line, present only when the finding originated from a Targeted Lens (omit it otherwise). For a re-attributed finding, write `Lens: <name> (re-attributed)` on its own line immediately after the severity tag.
+
+Location discipline: state the location as `File: <path>:<line>` (or `<path>:<lo>-<hi>`) using the actual line numbers from the diff's `@@` hunks, not function or class names. This prompt intentionally diverges from the canonical reviewer mandate: a **Fatal** or **Significant** finding is KEPT even when no numeric line is available (external second-opinion findings do not feed fix-routing, so a missing line is not disqualifying), but a **Minor** finding — including any DRY/SRP/OCP lens finding — that lacks a numeric location is DROPPED before emit.
 
 Format:
 
@@ -60,7 +111,8 @@ FINDINGS:
    Impact: Upstream systems will treat failures as successes, causing silent data inconsistency.
 
 3. [Minor] utils.ts:7
-   Description: `getData` is a vague name for a function that specifically fetches user preferences.
+   Lens: DRY
+   Description: This block re-implements the parsing already done by `parseConfig` in config.ts:30 instead of calling it.
    Impact: Readability -- next developer will have to read the implementation to understand the call site.
 
 VERDICT: [Needs Fixes | Approved | Approved with Minor Notes]

--- a/skills/shared/external-review-prompt.md
+++ b/skills/shared/external-review-prompt.md
@@ -76,6 +76,8 @@ SRP findings never exceed **Minor** (see Re-attribution).
 
 Flag a NEW `elif` / `case` / `match` arm added to a chain that dispatches on a discriminator (string tag, enum, type name) WHEN a registry or strategy table for that same discriminator already exists. Cite the registry's path in a `File:` line alongside the new arm's location. If you cannot locate the registry, DROP the finding — no false positives.
 
+OCP is the only lens that may cite a path outside the diff (the registry); for Surgical/DRY/SRP, every cited path must appear in the diff under review.
+
 Do not flag chains where no registry exists, or conditionals on a non-discriminator value (e.g. `if x > threshold`).
 
 OCP findings never exceed **Minor** (see Re-attribution).
@@ -89,7 +91,7 @@ When one set of lines triggers more than one lens:
 
 ### Re-attribution
 
-The Minor ceiling on DRY/SRP/OCP is mutually exclusive with escalation. When a DRY/SRP/OCP issue is genuinely worse than Minor (e.g. the two diverging copies will silently behave differently in production), DROP the lens finding entirely and re-emit ONE finding at its true **Significant** or **Fatal** severity, tagged `Lens: <name> (re-attributed)`. Emit either the Minor lens finding or the escalated re-attributed finding — never both.
+The Minor ceiling on DRY/SRP/OCP is mutually exclusive with escalation. When a DRY/SRP/OCP issue is genuinely worse than Minor (e.g. the two diverging copies will silently behave differently in production), DROP the lens finding entirely and re-emit ONE finding at its true **Significant** or **Fatal** severity, tagged `Lens: <name> (re-attributed)`. Re-emit it as an ordinary finding in the main numbered list at its true Significant or Fatal severity. Emit either the Minor lens finding or the escalated re-attributed finding — never both.
 
 ## How to Report Findings
 


### PR DESCRIPTION
## Summary

Implements **#292 — propagate lens awareness into `shared/external-review-prompt.md`** (a #287 follow-up). The 4 Targeted Lenses (Surgical, DRY, SRP, OCP) landed in `reviewer-common.md` + `build-reviewer-prompt.md` during #287 but were intentionally excluded from external-review to avoid a blocked severity-mapping decision. This resolves the mapping and propagates the lenses.

- Adds a `## Targeted Lenses` section (Surgical / DRY / SRP / OCP) paraphrased from `reviewer-common.md:32-130` into external-review's terse, flat-text prose.
- Adds an optional `Lens:` field + a `File:<line>` discipline note to the finding-format block.
- Adds a maintainer comment flagging the keep-in-sync relationship (no CANONICAL include — external models receive flat text).
- Severity Definitions, `VERDICT:`, "What NOT to Do", and "Final Notes" are byte-unchanged.

## The gating decision — 4-tier ↔ 3-tier mapping (resolved, HIGH confidence)

| Host (4-tier) | External (3-tier) |
|---|---|
| Critical | Fatal |
| Important | Significant |
| Minor | Minor |
| Suggestion | Minor (collapsed) |

- **DRY / SRP / OCP** cap at **Minor**; **Surgical** stays **gating** (Significant/Fatal), with a degraded-mode Minor floor when the context carries no stated request.
- **Re-attribution** escape hatch preserved (mutually exclusive: drop the Minor-ceiling finding, re-emit one at true Significant/Fatal in the main list).
- **File:line discipline** is an *intentional divergence* from `reviewer-common.md:34`'s hard-drop-all mandate: external findings keep Fatal/Significant even without a line ref (the mandate serves host fix-routing, which external second opinions don't feed); only unlocated Minor-ceiling findings are dropped. Documented as a deliberate fork.

## No regression

- The whole-file guard `grep -E "Critical|Important|\bNit\b|Suggestion"` returns **zero matches** — vocabulary stays exactly Fatal/Significant/Minor (INV-2). All four lens names present; ceilings stated (INV-1).
- Markdown-only change. The `external_review` handler (`server.py:217-267`) returns prompt content **verbatim** and the consensus aggregator parses only its own JSON output (not severity tokens), so the new prompt text cannot regress any downstream parser — verified by reading the code.

> ⚠️ The consensus test suite (`mcp-servers/crucible-consensus/tests/test_server.py`) is **currently uncollectable in this environment** due to a pre-existing mcp-SDK import error (`cannot import name 'InitializationOptions' from 'mcp.server'` under Python 3.14) — unrelated to this change (no Python touched). Filing a separate follow-up.

## Pipeline provenance

- `/spec` produced + quality-gated design/plan/contract (design→plan converged R1→R2 clean); the severity-mapping decision is the centerpiece, resolved at HIGH confidence.
- `/build`: single implementer (markdown edit), then **temper** Phase 4 — R1: 0 Critical / 0 Important + 2 Minor (OCP out-of-scope carve-out framing + re-attribution routing), both fixed. Inquisitor/siege skipped (no code, no security surface).

Closes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
