### PR TITLE
fix(py3.14): restore temper-evals + consensus test suites (#311, #313)

### DIFF
--- a/mcp-servers/crucible-consensus/tests/conftest.py
+++ b/mcp-servers/crucible-consensus/tests/conftest.py
@@ -71,6 +71,9 @@ _mcp_server_stdio_mod = ModuleType("mcp.server.stdio")
 _mcp_types_mod = ModuleType("mcp.types")
 
 _mcp_server_mod.Server = _MockServer
+# Mirror server.py's `from mcp.server import Server, InitializationOptions, NotificationOptions` (ref #313).
+_mcp_server_mod.InitializationOptions = MagicMock()
+_mcp_server_mod.NotificationOptions = MagicMock()
 _mcp_server_stdio_mod.stdio_server = MagicMock()
 _mcp_types_mod.Tool = _MockTool
 _mcp_types_mod.TextContent = _MockTextContent

--- a/skills/temper/evals/mock_snapshot.json
+++ b/skills/temper/evals/mock_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "bootstrap_python": "3.12",
+  "bootstrap_python": "3.14",
   "verdicts": {
     "1a": "PASS",
     "1b": "PASS",

--- a/skills/temper/evals/test_legacy_modes.py
+++ b/skills/temper/evals/test_legacy_modes.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+import warnings
 from pathlib import Path
 import pytest
 
@@ -48,21 +49,24 @@ def test_legacy_mock_reviewer_matches_snapshot(tmp_path):
             f"BOTH bootstrap_snapshot.py and mock_snapshot.json before pushing."
         )
     snapshot = json.loads(_SNAPSHOT.read_text())
-    # S-R7-2: snapshot is a structured envelope {"bootstrap_python": "X.Y", "verdicts": {...}}.
-    # Pin the snapshot to the bootstrapping Python's MAJOR.MINOR so cross-env drift
-    # surfaces loudly. If lens_runner output is empirically version-stable across
-    # 3.10/3.11/3.12 (per AC-8), this check can be softened to a warning via a
-    # follow-up issue once stability is empirically established.
-    # TODO(S-R7-2): track cross-version stability; relax to warning once confirmed.
+    # S-R7-2 (resolved, ref #311): snapshot is a structured envelope
+    # {"bootstrap_python": "X.Y", "verdicts": {...}}. Cross-version stability of
+    # lens_runner output was empirically confirmed 3.12->3.14, so the bootstrap_python
+    # pin is softened from a hard assert to a non-fatal warning. The verdict-equality
+    # assertion below remains the real drift signal.
     expected_py = snapshot.get("bootstrap_python")
     runtime_py = f"{sys.version_info.major}.{sys.version_info.minor}"
-    assert expected_py == runtime_py, (
-        f"snapshot was bootstrapped under Python {expected_py!r} but tests are running "
-        f"under {runtime_py!r}. Either (a) re-bootstrap under Python {runtime_py} via "
-        f"`python -m skills.temper.evals.bootstrap_snapshot`, or (b) if you have "
-        f"empirically confirmed cross-version stability of lens_runner output, "
-        f"update the snapshot's `bootstrap_python` field manually and document why."
-    )
+    if expected_py != runtime_py:
+        warnings.warn(
+            f"temper-evals snapshot bootstrapped under Python {expected_py}, running "
+            f"under {runtime_py}; verdict-equality still enforced.",
+            stacklevel=2,
+        )
+        print(
+            f"[temper-evals] snapshot bootstrap_python={expected_py} runtime={runtime_py}; "
+            f"verdict-equality still enforced.",
+            file=sys.stderr,
+        )
     expected = snapshot["verdicts"]
     # S-R4-2: sanity-floor assertions. If a prior bootstrap silently produced a
     # truncated/empty snapshot (e.g. subprocess error swallowed), the equality


### PR DESCRIPTION
Restores two test suites that were red under the repo's Python 3.14 environment. Both fixes are **test-layer only** — no runtime/production code changes; `server.py` and `requirements.txt` are untouched. Specced via `/spec` (design+plan+contract per ticket, R1→R2 CLEAN), built via `/build` (Phase 4 code gate CLEAN).

## #313 — consensus suite was uncollectable
**Issue's diagnosis was wrong** (it blamed the mcp SDK / Python 3.14). Real root cause, confirmed by git history: `server.py` gained `from mcp.server import Server, InitializationOptions, NotificationOptions` in commit `1459f0a` (2026-04-06), but the in-repo test mock in `tests/conftest.py` was never updated to provide the two new symbols. The mock (injected via `sys.modules.setdefault`) always wins, so `test_server.py` failed collection with `ImportError: cannot import name 'InitializationOptions' from 'mcp.server' (unknown location)` — **deterministically, since April, on any interpreter.** Not a 3.14 issue; it just surfaced when the suite was next run.

**Fix:** add `InitializationOptions` + `NotificationOptions` (MagicMock) to the mock `mcp.server` module. The symbols are only passed to the real SDK at server *startup* (never invoked by tests), so import-time presence is sufficient — no test-masking. The suite mocks all heavy SDKs by design, so no real mcp/anthropic/openai/google install is needed.
- Before: `test_server.py` uncollectable. After: **66 passed** (3.14 + pytest-asyncio).

## #311 — temper-evals legacy snapshot test red under 3.14
The test deliberately hard-asserted `snapshot.bootstrap_python == runtime` (a cross-env tripwire), with an embedded `TODO(S-R7-2)` to relax it to a warning *once cross-version stability was empirically confirmed*. Confirmed via the bootstrap verify path: the 15 mock-reviewer verdicts are **byte-identical** 3.12→3.14.

**Fix:** soften the version pin to a non-fatal `warnings.warn` + stderr note that falls through to the (still strict) verdict-equality check; re-bootstrap the snapshot to `bootstrap_python: "3.14"` (verdicts unchanged); resolve the TODO. The real drift signal (`assert actual == expected` + sanity floors) is preserved — verified by a negative check (mutated verdict still fails). This also stops the suite re-breaking on every future interpreter bump.
- Before: `1 failed, 223 passed`. After: **224 passed**.

## Scope
Repo-wide 3.14 drift sweep confirmed scope is narrow — no stdlib removals, no other version-fragile imports. Closes #311 and #313.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)