### PR TITLE
feat(temper): #267 scope-cut follow-ups — cited_files, mutex hard-fail, global Pre-flight matcher (#294, #295, #296)

### DIFF
--- a/scripts/check_canonical_drift.py
+++ b/scripts/check_canonical_drift.py
@@ -55,6 +55,12 @@ DISCIPLINE_PINS = [
 PREFLIGHT_PINS = [
     "### Pre-flight",
     "deployed right now",
+    # Load-bearing authoring instructions: pin the format ("dash bullets"),
+    # the always-emit mandate, and the MISSING marker so a divergence in any of
+    # the three templates is caught, not just the heading + intro phrase.
+    "dash bullets",
+    "Always emit",
+    "MISSING",
 ]
 
 def extract_canon(text: str) -> str:

--- a/scripts/check_canonical_drift.py
+++ b/scripts/check_canonical_drift.py
@@ -49,6 +49,14 @@ DISCIPLINE_PINS = [
     "callback",
 ]
 
+# Pre-flight feature-delivery section pins (#295) — must appear in BOTH
+# canonical and build-paraphrase (file-level grep). The "deployed right now"
+# phrase is a verbatim drift-check pin; "### Pre-flight" anchors the section.
+PREFLIGHT_PINS = [
+    "### Pre-flight",
+    "deployed right now",
+]
+
 def extract_canon(text: str) -> str:
     # Include Targeted Lenses + the sibling ### Lens precedence... section
     # (where the co-fire table lives), stopping at the next non-precedence ###.
@@ -86,6 +94,9 @@ def check_disciplines(name: str, text: str) -> list[str]:
         if title not in text:
             errs.append(f"{name}: missing discipline title '{title}'")
     for pin in DISCIPLINE_PINS:
+        if pin not in text:
+            errs.append(f"{name}: missing pin '{pin}'")
+    for pin in PREFLIGHT_PINS:
         if pin not in text:
             errs.append(f"{name}: missing pin '{pin}'")
     return errs

--- a/skills/build/build-reviewer-prompt.md
+++ b/skills/build/build-reviewer-prompt.md
@@ -218,6 +218,9 @@ Task tool (general-purpose, model: opus or sonnet — lead decides per task comp
     - **Missing coverage:** [List with specific code paths]
     - **Test quality issues:** [List — independence, determinism, mock overuse, wrong test level]
 
+    ### Pre-flight
+    Always emit. If this PR were deployed right now, what must be true for it to actually deliver its claimed feature? List prerequisites — config, env vars, schema/migrations, downstream services, feature flags — as dash bullets, verifying each against the diff or marking it **MISSING**. If self-contained, state: "No external prerequisites — change is self-contained."
+
     ### Overall
     - **Combined verdict:** Approved | Needs fixes (list them) | Escalate
 

--- a/skills/shared/reviewer-common.md
+++ b/skills/shared/reviewer-common.md
@@ -222,6 +222,9 @@ AI agents produce characteristic padding patterns that aren't bugs but inflate d
 - Missing coverage: [specific code paths without tests]
 - Stale / dead tests: [tests that need updating or removal]
 
+### Pre-flight
+If this PR were deployed right now, what would have to be true for it to actually deliver the feature it claims to deliver? Always emit this block. Enumerate prerequisites — config, environment variables, schema/migrations, downstream services, feature flags — as dash bullets, and for each verify it against the diff or mark it **MISSING**. If the change is self-contained, state explicitly: "No external prerequisites — change is self-contained."
+
 ### Overall
 - Combined verdict: Approved | Needs Fixes (list them) | Escalate
 

--- a/skills/temper/evals/evals.json
+++ b/skills/temper/evals/evals.json
@@ -1,5 +1,14 @@
 {
   "skill_name": "temper",
+  "global_expectations": [
+    {
+      "type": "mechanical",
+      "check": "report-has-block",
+      "params": {
+        "heading": "Pre-flight"
+      }
+    }
+  ],
   "evals": [
     {
       "id": "1a",
@@ -478,6 +487,91 @@
           "check": "category-finding-does-not-fire",
           "params": {
             "category": "Tenancy"
+          }
+        },
+        {
+          "type": "mechanical",
+          "check": "findings-count-at-least",
+          "params": {
+            "n": 1
+          }
+        }
+      ]
+    },
+    {
+      "id": "9-enumerate-sites-partial",
+      "source": "synthetic",
+      "lens_column": "none",
+      "pr_description": "Add idempotency guards to the new `apply_order_writes` path in `migrations/0042_orders.py`. The migration performs three `INSERT ... ON CONFLICT` upserts (orders, order_lines, order_audit) so a replayed migration does not duplicate rows.",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`. The diff adds three `ON CONFLICT` upsert sites to a single migration file.\n\n```diff\n--- /dev/null\n+++ b/migrations/0042_orders.py\n@@ -0,0 +1,60 @@\n+\"\"\"backfill orders, order_lines, order_audit with idempotent upserts\"\"\"\n+from alembic import op\n+\n+\n+def upgrade():\n+    # site 1: orders\n+    op.execute(\n+        \"INSERT INTO orders (id, status) \"\n+        \"SELECT id, 'migrated' FROM staging_orders \"\n+        \"ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status\"\n+    )\n+\n+    # site 2: order_lines\n+    op.execute(\n+        \"INSERT INTO order_lines (id, order_id, qty) \"\n+        \"SELECT id, order_id, qty FROM staging_order_lines \"\n+        \"ON CONFLICT (id) DO UPDATE SET qty = EXCLUDED.qty\"\n+    )\n+\n+    # site 3: order_audit\n+    op.execute(\n+        \"INSERT INTO order_audit (id, order_id, event) \"\n+        \"SELECT id, order_id, event FROM staging_order_audit \"\n+        \"ON CONFLICT DO NOTHING\"\n+    )\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format.",
+      "expected_output": "A single finding enumerates all three ON CONFLICT sites in the same migration file (cites three File: lines) and names the third site as MISSING a proper conflict target / guard.",
+      "files": [
+        "migrations/0042_orders.py"
+      ],
+      "allowed_files": [
+        "migrations/0042_orders.py"
+      ],
+      "lens_under_test": "enumerate-sites",
+      "replicate_rule": {
+        "trials": 5,
+        "threshold": 3
+      },
+      "expectations": [
+        {
+          "type": "mechanical",
+          "check": "finding-cites-n-files",
+          "params": {
+            "n": 3
+          }
+        },
+        {
+          "type": "mechanical",
+          "check": "finding-body-contains",
+          "params": {
+            "pattern": "MISSING"
+          }
+        },
+        {
+          "type": "mechanical",
+          "check": "findings-count-at-least",
+          "params": {
+            "n": 1
+          }
+        }
+      ]
+    },
+    {
+      "id": "10-preflight-missing-migration",
+      "source": "synthetic",
+      "lens_column": "none",
+      "pr_description": "Add a `tier` read to the account handler in `src/handler.py` so premium accounts get the expedited path. The handler reads `accounts.tier` from the row returned by the existing query.",
+      "prompt": "Review the following diff using the temper-reviewer checklist. Treat this as the full set of changes under review. The base reference is `main`; assume the diff represents `main..HEAD`. The handler now reads a new `accounts.tier` column.\n\n```diff\n--- a/src/handler.py\n+++ b/src/handler.py\n@@ -80,6 +80,12 @@ def handle_account(account_id):\n     row = db.execute(\n         \"SELECT * FROM accounts WHERE id = :id\",\n         {\"id\": account_id},\n     ).fetchone()\n     if row is None:\n         return None\n+    # New: premium accounts get the expedited path.\n+    if row.tier == \"premium\":\n+        return expedite(row)\n     return standard(row)\n```\n\nApply the standard reviewer output format (### Code Review with Verdict, Issues, etc.). Tag any Targeted Lens findings with `Lens:` lines per the canonical Report Format. Include a `### Pre-flight` section enumerating prerequisites and their status.",
+      "expected_output": "An ordinary correctness finding fires on handler.py, and the Pre-flight block flags the `accounts.tier` column migration as MISSING from this diff.",
+      "files": [
+        "src/handler.py"
+      ],
+      "allowed_files": [
+        "src/handler.py"
+      ],
+      "lens_under_test": "preflight-missing",
+      "replicate_rule": {
+        "trials": 5,
+        "threshold": 3
+      },
+      "expectations": [
+        {
+          "type": "mechanical",
+          "check": "report-block-contains",
+          "params": {
+            "heading": "Pre-flight",
+            "pattern": "MISSING"
+          }
+        },
+        {
+          "type": "mechanical",
+          "check": "finding-body-contains",
+          "params": {
+            "pattern": "MISSING"
           }
         },
         {

--- a/skills/temper/evals/lens_runner.py
+++ b/skills/temper/evals/lens_runner.py
@@ -49,6 +49,19 @@ _REPORT_SECTIONS = frozenset(
     {"Pre-flight", "Strengths", "Overall", "Recommendations", "Assessment"}
 )
 
+# Trailing parenthetical annotation on a heading, e.g. the "(feature delivery)"
+# in `### Pre-flight (feature delivery)`. Stripped before the _REPORT_SECTIONS
+# membership test so a decorated heading still suppresses phantom findings.
+_HEADING_ANNOTATION_RE = re.compile(r"\s*\([^)]*\)\s*$")
+
+
+def _section_key(heading: str | None) -> str | None:
+    """Normalize a `### ` heading to its bare section name for _REPORT_SECTIONS
+    lookup: drop a trailing parenthetical annotation and a trailing colon."""
+    if heading is None:
+        return None
+    return _HEADING_ANNOTATION_RE.sub("", heading).strip().rstrip(":")
+
 
 # ---------------------------------------------------------------------------
 # Parser
@@ -95,7 +108,7 @@ def _parse_findings(output: str) -> list[dict]:
         # Numbered/list items inside report-prose sections (esp. Pre-flight)
         # are NOT findings — skip them. Boundary pre-pass is unchanged so block
         # extents for real findings stay correct.
-        if current_section in _REPORT_SECTIONS:
+        if _section_key(current_section) in _REPORT_SECTIONS:
             continue
 
         # Find this finding's end: next boundary strictly after idx.
@@ -478,7 +491,7 @@ def report_has_block(output: str, heading: str, min_chars: int = 1) -> Result:
     blocks = _report_blocks(output, heading)
     if not blocks:
         return ("FAIL", f"no ### {heading} heading")
-    nonws = sum(1 for c in "".join(blocks) if not c.isspace())
+    nonws = sum(1 for c in "\n".join(blocks) if not c.isspace())
     if nonws >= min_chars:
         return ("PASS", f"### {heading} block has {nonws} non-ws char(s)")
     return ("FAIL", f"### {heading} block empty ({nonws} < {min_chars} non-ws char(s))")
@@ -488,8 +501,9 @@ def report_block_contains(
     output: str, heading: str, pattern: str, case_insensitive: bool = True
 ) -> Result:
     """PASS if `pattern` matches (regex search) within the union of all
-    `### <heading>` blocks."""
-    union = "".join(_report_blocks(output, heading))
+    `### <heading>` blocks. Blocks are joined with a newline so a pattern can
+    never falsely match across a block boundary (e.g. two Pre-flight sections)."""
+    union = "\n".join(_report_blocks(output, heading))
     flags = re.I if case_insensitive else 0
     if re.search(pattern, union, flags):
         return ("PASS", f"{pattern!r} found in ### {heading} block(s)")

--- a/skills/temper/evals/lens_runner.py
+++ b/skills/temper/evals/lens_runner.py
@@ -26,11 +26,28 @@ maintainers reading the regexes see them immediately):
 from __future__ import annotations
 
 import re
-import sys
 from typing import Literal
 
 Verdict = Literal["PASS", "FAIL", "N/A"]
 Result = tuple[Verdict, str]
+
+
+class MutexViolationError(ValueError):
+    """Raised when a single finding is tagged with both Lens: and Category:.
+
+    These dimensions are mutually exclusive per Design D7. The scorer catches
+    this and fails the fixture loudly rather than silently merging both fields.
+    """
+
+    pass
+
+
+# Report-prose sections under which numbered/list items are NOT findings.
+# A `### Pre-flight` block (and friends) may contain numbered checklists; those
+# must not be parsed as phantom findings.
+_REPORT_SECTIONS = frozenset(
+    {"Pre-flight", "Strengths", "Overall", "Recommendations", "Assessment"}
+)
 
 
 # ---------------------------------------------------------------------------
@@ -48,9 +65,12 @@ _CATEGORY_RE = re.compile(r"^\s*[-*]?\s*Category:\s+(\S+)\s*$")
 
 def _parse_findings(output: str) -> list[dict]:
     """Return list of findings with keys file, line_range, severity, lens,
-    lens_reattributed, category, body, section. Pathless findings include
-    file=None. A WARNING is emitted to stderr when a finding carries both
-    Lens: and Category: lines (mutex tripwire — does not fail the parse)."""
+    lens_reattributed, category, cited_files, body, section. Pathless findings
+    include file=None. A MutexViolationError is raised when a finding carries
+    both Lens: and Category: lines (mutex tripwire — fails the parse).
+
+    Numbered/list items inside report-prose sections (see _REPORT_SECTIONS,
+    esp. `### Pre-flight`) are skipped — they are not findings."""
     lines = output.splitlines()
 
     # Pre-pass: identify boundary line indices (finding headers + ### headings).
@@ -72,11 +92,18 @@ def _parse_findings(output: str) -> list[dict]:
         if not _FINDING_HEADER_RE.match(line):
             continue
 
+        # Numbered/list items inside report-prose sections (esp. Pre-flight)
+        # are NOT findings — skip them. Boundary pre-pass is unchanged so block
+        # extents for real findings stay correct.
+        if current_section in _REPORT_SECTIONS:
+            continue
+
         # Find this finding's end: next boundary strictly after idx.
         end = next(b for b in boundaries if b > idx)
 
         block = lines[idx + 1 : end]
         header_line = line
+        cited_files: list[tuple[str, tuple[int, int]]] = []
         file_path: str | None = None
         line_range: tuple[int, int] | None = None
         severity: str | None = None
@@ -87,10 +114,9 @@ def _parse_findings(output: str) -> list[dict]:
         for child in block:
             m = _FILE_RE.match(child)
             if m:
-                file_path = m.group(1)
                 lo = int(m.group(2))
                 hi = int(m.group(3)) if m.group(3) else lo
-                line_range = (lo, hi)
+                cited_files.append((m.group(1), (lo, hi)))
                 continue
             m = _SEVERITY_RE.match(child)
             if m:
@@ -106,13 +132,15 @@ def _parse_findings(output: str) -> list[dict]:
                 category = m.group(1)
                 continue
 
-        # Mutex tripwire: WARN only, don't fail the parse. A 3rd category
-        # arrival triggers a hard mutex check upgrade (filed as follow-up).
+        # First citation drives the back-compat scalar file/line_range fields.
+        if cited_files:
+            file_path = cited_files[0][0]
+            line_range = cited_files[0][1]
+
+        # Mutex tripwire: a finding cannot carry both a Lens: and a Category:.
         if lens is not None and category is not None:
-            print(
-                f"WARNING: finding has both Lens: {lens} and Category: {category} "
-                f"(mutex violation, see #267); header: {header_line.strip()!r}",
-                file=sys.stderr,
+            raise MutexViolationError(
+                f"finding tagged both Lens: {lens} and Category: {category}"
             )
 
         # Capture finding body (header + block lines, joined) for
@@ -124,6 +152,7 @@ def _parse_findings(output: str) -> list[dict]:
             {
                 "file": file_path,
                 "line_range": line_range,
+                "cited_files": cited_files,
                 "severity": severity,
                 "lens": lens,
                 "lens_reattributed": reattributed,
@@ -134,6 +163,29 @@ def _parse_findings(output: str) -> list[dict]:
         )
 
     return findings
+
+
+def _report_blocks(output: str, heading: str) -> list[str]:
+    """Return the text blocks under every `### <heading>` section.
+
+    Each block runs from the line after the heading to the next `### ` heading
+    or EOF, joined by newlines. The heading line itself is excluded."""
+    heading_re = re.compile(rf"^###\s+{re.escape(heading)}\s*$")
+    next_heading_re = re.compile(r"^###\s+")
+    lines = output.splitlines()
+    blocks: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if heading_re.match(lines[i]):
+            j = i + 1
+            while j < n and not next_heading_re.match(lines[j]):
+                j += 1
+            blocks.append("\n".join(lines[i + 1 : j]))
+            i = j
+        else:
+            i += 1
+    return blocks
 
 
 # ---------------------------------------------------------------------------
@@ -360,6 +412,90 @@ def no_lens_findings_overlap_region(
     return ("PASS", f"no overlap between {primary_lens} and {secondary_lens} regions")
 
 
+def finding_cites_n_files(
+    output: str,
+    n: int | None = None,
+    files: list[str] | None = None,
+    lens: str | None = None,
+    category: str | None = None,
+) -> Result:
+    """Assert findings cite enough File: sites and/or specific paths.
+
+    `n` counts File: citation SITES (not distinct paths) across matching
+    findings. `files` checks distinct-path coverage. Findings are filtered by
+    `lens`/`category` when given. At least one of n/files is required."""
+    findings = _parse_findings(output)
+    matching = [
+        f
+        for f in findings
+        if (lens is None or f["lens"] == lens)
+        and (category is None or f["category"] == category)
+    ]
+
+    if n is None and files is None:
+        return ("N/A", "no n or files param")
+
+    if n is not None:
+        sites = sum(len(f["cited_files"]) for f in matching)
+        if sites < n:
+            return ("FAIL", f"{sites} File: citation site(s), need ≥ {n}")
+
+    if files is not None:
+        distinct_paths = {
+            path for f in matching for (path, _rng) in f["cited_files"]
+        }
+        missing = set(files) - distinct_paths
+        if missing:
+            return ("FAIL", f"missing cited path(s): {', '.join(sorted(missing))}")
+
+    scope = []
+    if n is not None:
+        scope.append(f"≥ {n} site(s)")
+    if files is not None:
+        scope.append(f"{len(files)} required path(s) covered")
+    return ("PASS", "; ".join(scope))
+
+
+def finding_body_contains(
+    output: str, pattern: str, case_insensitive: bool = True
+) -> Result:
+    """Positive mirror of finding_body_does_not_contain. PASS if ANY finding's
+    body contains `pattern` (substring match)."""
+    findings = _parse_findings(output)
+    if not findings:
+        return ("N/A", "no findings")
+    needle = pattern.lower() if case_insensitive else pattern
+    for f in findings:
+        haystack = f["body"].lower() if case_insensitive else f["body"]
+        if needle in haystack:
+            return ("PASS", f"{pattern!r} appears in finding at {f['file']}")
+    return ("FAIL", f"{pattern!r} appears in no finding body")
+
+
+def report_has_block(output: str, heading: str, min_chars: int = 1) -> Result:
+    """PASS if a `### <heading>` block exists with >= min_chars non-whitespace
+    characters. Distinguishes 'no heading' from 'heading present but empty'."""
+    blocks = _report_blocks(output, heading)
+    if not blocks:
+        return ("FAIL", f"no ### {heading} heading")
+    nonws = sum(1 for c in "".join(blocks) if not c.isspace())
+    if nonws >= min_chars:
+        return ("PASS", f"### {heading} block has {nonws} non-ws char(s)")
+    return ("FAIL", f"### {heading} block empty ({nonws} < {min_chars} non-ws char(s))")
+
+
+def report_block_contains(
+    output: str, heading: str, pattern: str, case_insensitive: bool = True
+) -> Result:
+    """PASS if `pattern` matches (regex search) within the union of all
+    `### <heading>` blocks."""
+    union = "".join(_report_blocks(output, heading))
+    flags = re.I if case_insensitive else 0
+    if re.search(pattern, union, flags):
+        return ("PASS", f"{pattern!r} found in ### {heading} block(s)")
+    return ("FAIL", f"{pattern!r} not found in ### {heading} block(s)")
+
+
 # ---------------------------------------------------------------------------
 # Dispatcher + replicate aggregator
 # ---------------------------------------------------------------------------
@@ -377,7 +513,11 @@ _CHECK_REGISTRY = {
     "category-finding-fires": category_finding_fires,
     "category-finding-does-not-fire": category_finding_does_not_fire,
     "finding-body-does-not-contain": finding_body_does_not_contain,
+    "finding-body-contains": finding_body_contains,
     "findings-count-at-least": findings_count_at_least,
+    "finding-cites-n-files": finding_cites_n_files,
+    "report-has-block": report_has_block,
+    "report-block-contains": report_block_contains,
 }
 
 # Checks that take (output, fixture, ocp_carveout) — fixture-aware.

--- a/skills/temper/evals/mock-fixtures/10-preflight-missing-migration.txt
+++ b/skills/temper/evals/mock-fixtures/10-preflight-missing-migration.txt
@@ -1,0 +1,29 @@
+### Code Review
+
+Verdict: changes-requested
+
+The handler now branches on `row.tier`, but the diff reads a column the
+schema does not yet have and does not guard against the column being absent.
+The required migration for `accounts.tier` is MISSING from this diff, so the
+read will raise on any environment that has not been hand-patched.
+
+### Issues
+
+1. handle_account reads accounts.tier with no migration and no guard
+   - File: src/handler.py:88
+   - Severity: Important
+   - Lens: Surgical
+   The new branch dereferences `row.tier`, but the column `accounts.tier`
+   is introduced by no migration in this change set — the migration is
+   MISSING. On a fresh or production database the `SELECT *` row will not
+   carry a `tier` attribute and `row.tier` raises `AttributeError`. Ship the
+   schema migration alongside this read, and treat an absent/NULL tier as the
+   standard path rather than letting the access fault.
+
+### Pre-flight
+
+- New column `accounts.tier` read at `src/handler.py:88` — migration
+  **MISSING** from this diff. The handler assumes the column exists; no
+  Alembic revision adding it is present in the change set.
+- `expedite()` and `standard()` are pre-existing helpers in this module — no
+  new prerequisite there.

--- a/skills/temper/evals/mock-fixtures/1a.txt
+++ b/skills/temper/evals/mock-fixtures/1a.txt
@@ -18,3 +18,9 @@ PEP8 reformat — the Surgical lens flags the scope bleed.
    commit makes the formatting churn hide a (trivially equivalent but still
    distinct) expression rewrite. Split the f-string conversion into its own
    commit so the formatter pass is purely mechanical.
+
+### Pre-flight
+
+- No external prerequisites — the change is self-contained within `src/foo.py`.
+- The new `get_timeout_seconds` helper and `logging` import add no new config
+  keys, schema changes, or call-site obligations elsewhere.

--- a/skills/temper/evals/mock-fixtures/1b.txt
+++ b/skills/temper/evals/mock-fixtures/1b.txt
@@ -19,3 +19,9 @@ the immediate problem is scope, not duplication.
    precedence: do not file a DRY finding for the banner/footer near-clone
    here — the duplication is real but the immediate ask is to land the
    reformat surgically; a DRY refactor belongs in a follow-up.)
+
+### Pre-flight
+
+- No external prerequisites — the change is self-contained within `src/foo.py`.
+- Both `render_banner` and `render_footer` are pure formatters with no new
+  config or downstream call-site dependencies.

--- a/skills/temper/evals/mock-fixtures/2-reattrib.txt
+++ b/skills/temper/evals/mock-fixtures/2-reattrib.txt
@@ -18,3 +18,9 @@ input; the new parser-side helper silently drops that bound.
    silently relaxes a bound the other enforces. Re-attributing this
    from DRY → Correctness: either call `normalize_input` from
    `parser.py` or apply the same `MAX_LEN` cap inline.
+
+### Pre-flight
+
+- No external prerequisites — both `src/parser.py` and `src/util.py` already
+  exist and the `MAX_LEN` constant is defined in `util`.
+- The fix reuses the existing bound; it adds no new config key or migration.

--- a/skills/temper/evals/mock-fixtures/2.txt
+++ b/skills/temper/evals/mock-fixtures/2.txt
@@ -19,3 +19,10 @@ to import `util.normalize_input` instead of re-rolling it.
    the existing helper rather than copying it — the duplicate regex
    `_PARSER_WS_RE` is also redundant. Drop `_clean_token` and call
    `normalize_input` directly from `parse_header` and `parse_record`.
+
+### Pre-flight
+
+- No external prerequisites — the change is self-contained across `src/parser.py`
+  and `src/util.py`.
+- `util.normalize_input` already exists and is importable; reusing it introduces
+  no new dependency or schema obligation.

--- a/skills/temper/evals/mock-fixtures/3.txt
+++ b/skills/temper/evals/mock-fixtures/3.txt
@@ -18,3 +18,10 @@ out into its own helper so each layer is independently testable.
    `_parse_record(raw) -> dict` helper and let `process_record` only
    handle the formatting + write. Tests for the parser then need not
    capture stdout.
+
+### Pre-flight
+
+- No external prerequisites — the change is self-contained within
+  `src/processor.py`.
+- Extracting `_parse_record` is a pure-refactor follow-up with no schema, config,
+  or call-site obligations beyond this file.

--- a/skills/temper/evals/mock-fixtures/4.txt
+++ b/skills/temper/evals/mock-fixtures/4.txt
@@ -20,3 +20,10 @@ add the new arm to the registry instead of growing the conditional.
    through `dispatch`), not by extending the elif ladder in
    `src/handler.py`. Each future op then becomes a one-line registry
    entry — open for extension, closed for modification.
+
+### Pre-flight
+
+- Prerequisite: `handle_restore` must exist in `.handlers` — it is already
+  imported in this diff, so the dependency is satisfied.
+- No schema change or config key is introduced; routing through the existing
+  `HANDLERS` registry is a local refactor.

--- a/skills/temper/evals/mock-fixtures/5.txt
+++ b/skills/temper/evals/mock-fixtures/5.txt
@@ -10,3 +10,9 @@ and leaves the rest of the module untouched. No lens findings.
 ### Issues
 
 No findings.
+
+### Pre-flight
+
+- No external prerequisites — the change is self-contained within `src/clean.py`.
+- `slugify_with_max_length` reuses the existing `slugify` helper; no new config,
+  schema, or call-site obligation is introduced.

--- a/skills/temper/evals/mock-fixtures/6-tenancy-forged-callback.txt
+++ b/skills/temper/evals/mock-fixtures/6-tenancy-forged-callback.txt
@@ -22,3 +22,10 @@ tenant-B's row. Tenancy fires at Important.
    `AND tenant_id = :tenant_id` to the WHERE clause; otherwise a
    correctly-signed callback from tenant-A can mutate any order whose
    id is known/guessable across the whole table.
+
+### Pre-flight
+
+- Prerequisite: the `orders` table already carries `tenant_id` and `order_id`
+  columns (stated in the diff context) — satisfied by the existing schema.
+- `verify_signature` and the per-tenant auth context already exist; the fix
+  resolves `tenant_id` from that context and needs no new migration.

--- a/skills/temper/evals/mock-fixtures/7-rollback-orphan-fk.txt
+++ b/skills/temper/evals/mock-fixtures/7-rollback-orphan-fk.txt
@@ -23,3 +23,10 @@ Rollback fires at Important.
    `op.drop_column("customers", "region_id")` before dropping
    `regions`. Reversibility of migrations is a hard requirement —
    without it, prod rollback ladders break.
+
+### Pre-flight
+
+- Prerequisite: the `customers` table already exists — satisfied; this migration
+  only adds the `region_id` column and the new `regions` parent table.
+- Revision chain is declared (`Revises: 9c81e2d`); no out-of-band schema step is
+  required to apply `upgrade()`.

--- a/skills/temper/evals/mock-fixtures/8-defense-in-depth-not-slop.txt
+++ b/skills/temper/evals/mock-fixtures/8-defense-in-depth-not-slop.txt
@@ -20,3 +20,10 @@ should not be flagged. The unrelated rename of `get_orderr` →
    fine; combining them makes the diff harder to bisect if the
    security-layer change ever needs to be reverted. Split the
    rename into its own commit.
+
+### Pre-flight
+
+- Prerequisite: `assert_can_read_tenant` and `current_user` already exist in
+  `.auth` — both are imported in this diff, so the dependency is satisfied.
+- No schema change or config key is introduced; the RLS layer and the
+  application-layer assertion both operate on existing columns.

--- a/skills/temper/evals/mock-fixtures/9-enumerate-sites-partial.txt
+++ b/skills/temper/evals/mock-fixtures/9-enumerate-sites-partial.txt
@@ -1,0 +1,34 @@
+### Code Review
+
+Verdict: changes-requested
+
+The migration adds three `INSERT ... ON CONFLICT` upsert sites in the same
+file. The first two sites declare an explicit conflict target and upsert
+correctly, but the third site uses `ON CONFLICT DO NOTHING` with no conflict
+target — on a replay it silently drops audit rows instead of upserting them,
+so the third site is MISSING the idempotency guarantee the other two provide.
+
+### Issues
+
+1. order_audit upsert at site 3 is MISSING a conflict target — not idempotent
+   - File: migrations/0042_orders.py:18
+   - File: migrations/0042_orders.py:34
+   - File: migrations/0042_orders.py:51
+   - Severity: Important
+   - Category: Rollback
+   All three upsert sites live in the same migration. Site 1 (orders, :18)
+   and site 2 (order_lines, :34) both name an explicit `ON CONFLICT (id)`
+   target and refresh the conflicting row, so a replayed migration converges.
+   Site 3 (order_audit, :51) instead uses `ON CONFLICT DO NOTHING` with no
+   target column — the guard is effectively MISSING there, so a replay leaves
+   audit rows stale and divergent from orders/order_lines. Give site 3 the
+   same explicit conflict target and `DO UPDATE` arm as the other two so all
+   three sites are idempotent.
+
+### Pre-flight
+
+- All three target tables (`orders`, `order_lines`, `order_audit`) and their
+  `staging_*` sources already exist from prior migrations — no schema
+  prerequisite is introduced by this diff.
+- No external prerequisites — the change is self-contained within this
+  migration file.

--- a/skills/temper/evals/mock_snapshot.json
+++ b/skills/temper/evals/mock_snapshot.json
@@ -1,6 +1,7 @@
 {
   "bootstrap_python": "3.14",
   "verdicts": {
+    "10-preflight-missing-migration": "PASS",
     "1a": "PASS",
     "1b": "PASS",
     "2": "PASS",
@@ -11,6 +12,7 @@
     "6-tenancy-forged-callback": "PASS",
     "7-rollback-orphan-fk": "PASS",
     "8-defense-in-depth-not-slop": "PASS",
+    "9-enumerate-sites-partial": "PASS",
     "dry-real": "N/A",
     "mixed-real": "N/A",
     "ocp-real": "N/A",

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -351,10 +351,13 @@ def _validate_global_expectations(global_expectations: list[dict]) -> None:
                 f"global_expectations[{idx}] must have type=='mechanical' "
                 f"(got {ge.get('type')!r})"
             )
-        check = ge.get("check")
+        # Normalize snake_case → kebab-case exactly as evaluate_expectation does
+        # at runtime, so a global with check "report_has_block" is accepted here
+        # rather than rejected only to resolve fine when actually dispatched.
+        check = lens_runner._normalize_check_name(ge.get("check"))
         if check not in lens_runner._CHECK_REGISTRY:
             raise FixtureValidationError(
-                f"global_expectations[{idx}] check {check!r} not in "
+                f"global_expectations[{idx}] check {ge.get('check')!r} not in "
                 f"lens_runner._CHECK_REGISTRY"
             )
 
@@ -1569,7 +1572,11 @@ def score(
     # Recompute per-trial fixture_sha; refuse mismatches unless --force-rescore.
     # `_load_evals` folds global_expectations into each eval IN PLACE before the
     # sha is recomputed below, mirroring stage() so the shas match.
-    _evals_list, _ = _load_evals(_EVALS_JSON)
+    _evals_list, _global_expectations = _load_evals(_EVALS_JSON)
+    # Validate globals here too: score may run against an evals.json edited after
+    # stage, and a malformed global would otherwise fold a silent FAIL/N/A into
+    # every fixture instead of being rejected loudly.
+    _validate_global_expectations(_global_expectations)
     fixtures_by_id = {f["id"]: f for f in _evals_list}
 
     # Task 10 (#290): score-time --source filter. Restrict fixtures_by_id to
@@ -2034,9 +2041,14 @@ def _legacy_main(args: argparse.Namespace) -> int:
     # Load fixtures via the shared `_load_evals` path so any top-level
     # global_expectations are folded into each eval identically to stage/score.
     try:
-        fixtures, _ = _load_evals(_EVALS_JSON)
+        fixtures, _global_expectations = _load_evals(_EVALS_JSON)
     except (OSError, json.JSONDecodeError) as e:
         print(f"[fatal] cannot load evals.json: {e}", file=sys.stderr)
+        return 2
+    try:
+        _validate_global_expectations(_global_expectations)
+    except FixtureValidationError as e:
+        print(f"[fatal] {e}", file=sys.stderr)
         return 2
 
     if args.legacy_fixture:

--- a/skills/temper/evals/run_evals.py
+++ b/skills/temper/evals/run_evals.py
@@ -304,6 +304,61 @@ class BaselineQualityError(FixtureValidationError):
 _SOURCE_PR_RE = re.compile(r"^#\d+ @ [0-9a-f]{7,40}$")
 
 
+def _load_evals(path: Path) -> tuple[list[dict], list[dict]]:
+    """Load evals.json and fold any top-level `global_expectations` into each eval.
+
+    Reads the JSON at `path`, extracts the optional top-level
+    `global_expectations` array (default `[]`), and appends EVERY global
+    expectation entry to EACH eval's `expectations` list (creating the list if
+    absent). The append mutates the eval dicts IN PLACE so that any subsequent
+    `fixture_sha(fix)` reflects the merged expectations — and does so
+    identically across the `stage` and `score` load paths (their shas match).
+
+    On the current evals.json (no `global_expectations` key) this is a clean
+    no-op: each eval is returned unchanged and `global_expectations` is `[]`.
+
+    Returns: `(evals, global_expectations)`.
+    """
+    data = json.loads(path.read_text(encoding="utf-8"))
+    evals = data.get("evals", [])
+    global_expectations = data.get("global_expectations", []) or []
+    if global_expectations:
+        for ev in evals:
+            if not isinstance(ev, dict):
+                continue
+            exps = ev.get("expectations")
+            if not isinstance(exps, list):
+                exps = []
+                ev["expectations"] = exps
+            for ge in global_expectations:
+                exps.append(ge)
+    return evals, global_expectations
+
+
+def _validate_global_expectations(global_expectations: list[dict]) -> None:
+    """Validate each top-level `global_expectations` entry (Pre-flight matcher).
+
+    Every entry must be a dict with `type == "mechanical"` and a `check` present
+    in `lens_runner._CHECK_REGISTRY`. Raises `FixtureValidationError` otherwise.
+    """
+    for idx, ge in enumerate(global_expectations):
+        if not isinstance(ge, dict):
+            raise FixtureValidationError(
+                f"global_expectations[{idx}] is not an object: {ge!r}"
+            )
+        if ge.get("type") != "mechanical":
+            raise FixtureValidationError(
+                f"global_expectations[{idx}] must have type=='mechanical' "
+                f"(got {ge.get('type')!r})"
+            )
+        check = ge.get("check")
+        if check not in lens_runner._CHECK_REGISTRY:
+            raise FixtureValidationError(
+                f"global_expectations[{idx}] check {check!r} not in "
+                f"lens_runner._CHECK_REGISTRY"
+            )
+
+
 def _validate_fixtures(
     evals_data: dict,
     *,
@@ -725,12 +780,16 @@ def stage(
     if timeout < 1:
         raise ValueError(f"--timeout must be >= 1 (got {timeout})")
 
-    # Load fixtures
-    evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
+    # Load fixtures. `_load_evals` folds any top-level `global_expectations`
+    # into each eval's `expectations` list IN PLACE before any fixture_sha is
+    # computed, so stage- and score-side shas stay identical.
+    fixtures, global_expectations = _load_evals(_EVALS_JSON)
     # Task 8 (#290 F2): schema gate at stage-time. Raises FixtureValidationError
-    # for any (a)-(k) failure; rc=2 propagates via the main() handler.
-    _validate_fixtures(evals_data, strict_source_pr=strict_source_pr)
-    fixtures = evals_data.get("evals", [])
+    # for any (a)-(k) failure; rc=2 propagates via the main() handler. Pass the
+    # post-merge fixtures so validation sees the same records that get hashed.
+    _validate_fixtures({"evals": fixtures}, strict_source_pr=strict_source_pr)
+    # Global Pre-flight matcher: validate each global_expectations entry.
+    _validate_global_expectations(global_expectations)
 
     # --source filter
     if source != "all":
@@ -907,7 +966,16 @@ def _aggregate_from_outputs(
                 per_trial_verdicts.append("N/A")
                 per_trial_rationales.append("dispatch failure: no reviewer output")
                 continue
-            verdict, rationale = lens_runner.evaluate_expectation(expectation, out, fix)
+            try:
+                verdict, rationale = lens_runner.evaluate_expectation(expectation, out, fix)
+            except lens_runner.MutexViolationError:
+                # T1: a reviewer finding tagged with BOTH Lens: and Category:
+                # is a mutex violation (Design D7). Score the trial FAIL with a
+                # clear rationale instead of letting the raise crash the run.
+                verdict, rationale = (
+                    "FAIL",
+                    "mutex violation: finding tagged both Lens and Category",
+                )
             per_trial_verdicts.append(verdict)
             per_trial_rationales.append(rationale)
         aggregated = lens_runner.aggregate_replicates(per_trial_verdicts, threshold)  # type: ignore[arg-type]
@@ -1498,9 +1566,11 @@ def score(
                     file=sys.stderr,
                 )
 
-    # Recompute per-trial fixture_sha; refuse mismatches unless --force-rescore
-    evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
-    fixtures_by_id = {f["id"]: f for f in evals_data.get("evals", [])}
+    # Recompute per-trial fixture_sha; refuse mismatches unless --force-rescore.
+    # `_load_evals` folds global_expectations into each eval IN PLACE before the
+    # sha is recomputed below, mirroring stage() so the shas match.
+    _evals_list, _ = _load_evals(_EVALS_JSON)
+    fixtures_by_id = {f["id"]: f for f in _evals_list}
 
     # Task 10 (#290): score-time --source filter. Restrict fixtures_by_id to
     # those matching the requested source. Trials referencing filtered-out
@@ -1528,7 +1598,7 @@ def score(
     by_fixture: dict[str, list[tuple[int, dict, str | None]]] = {}
     # Track fixture ids in the live evals.json (pre-filter) for distinguishing
     # "filtered-out" (skip silently) from "deleted-from-evals" (fatal).
-    _all_evals_ids = {f["id"] for f in evals_data.get("evals", [])}
+    _all_evals_ids = {f["id"] for f in _evals_list}
     for entry in manifest["trials"]:
         seq = entry["seq"]
         fid = entry["fixture_id"]
@@ -1961,14 +2031,14 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _legacy_main(args: argparse.Namespace) -> int:
-    # Load fixtures
+    # Load fixtures via the shared `_load_evals` path so any top-level
+    # global_expectations are folded into each eval identically to stage/score.
     try:
-        evals_data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
+        fixtures, _ = _load_evals(_EVALS_JSON)
     except (OSError, json.JSONDecodeError) as e:
         print(f"[fatal] cannot load evals.json: {e}", file=sys.stderr)
         return 2
 
-    fixtures = evals_data.get("evals", [])
     if args.legacy_fixture:
         fixtures = [f for f in fixtures if f["id"] == args.legacy_fixture]
         if not fixtures:

--- a/skills/temper/evals/test_lens_runner.py
+++ b/skills/temper/evals/test_lens_runner.py
@@ -818,6 +818,58 @@ def test_report_block_contains_matches_second_block():
     assert verdict == "PASS"
 
 
+# Two Pre-flight blocks; the pattern "AB" spans the boundary — "...A" ends the
+# first block, "B..." starts the second. Blocks must be joined with a newline so
+# the regex can never falsely match across the boundary.
+SAMPLE_CROSS_BLOCK_PREFLIGHT = """
+### Pre-flight
+- ends in A
+
+### Issues
+
+1. **Real finding**
+   - File: src/foo.py:1
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: real.
+
+### Pre-flight
+- B begins here
+"""
+
+
+def test_report_block_contains_no_cross_block_false_match():
+    # "A\nB" must NOT match "AB" across the block boundary (newline-joined union).
+    verdict, _ = report_block_contains(
+        SAMPLE_CROSS_BLOCK_PREFLIGHT, heading="Pre-flight", pattern="AB"
+    )
+    assert verdict == "FAIL"
+
+
+# A decorated Pre-flight heading must still suppress phantom findings.
+SAMPLE_PREFLIGHT_ANNOTATED_HEADING = """
+### Pre-flight (feature delivery)
+1. Foo checklist item
+2. Bar checklist item
+
+### Issues
+
+1. **Real finding**
+   - File: src/foo.py:10-12
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: real.
+"""
+
+
+def test_annotated_preflight_heading_still_suppresses_phantom_findings():
+    from skills.temper.evals.lens_runner import _parse_findings
+
+    findings = _parse_findings(SAMPLE_PREFLIGHT_ANNOTATED_HEADING)
+    assert len(findings) == 1
+    assert findings[0]["section"] == "Issues"
+
+
 # ---------------------------------------------------------------------------
 # aggregate_replicates
 # ---------------------------------------------------------------------------

--- a/skills/temper/evals/test_lens_runner.py
+++ b/skills/temper/evals/test_lens_runner.py
@@ -13,12 +13,15 @@ import json
 import pytest
 
 from skills.temper.evals.lens_runner import (
+    MutexViolationError,
     aggregate_replicates,
     all_findings_have_file_line,
     category_finding_does_not_fire,
     category_finding_fires,
     evaluate_expectation,
+    finding_body_contains,
     finding_body_does_not_contain,
+    finding_cites_n_files,
     findings_count_at_least,
     lens_finding_cites_file,
     lens_finding_does_not_fire,
@@ -26,6 +29,8 @@ from skills.temper.evals.lens_runner import (
     lens_findings_in_allowed_files,
     no_lens_findings_overlap_region,
     reattributed_finding_fires,
+    report_block_contains,
+    report_has_block,
 )
 
 
@@ -596,10 +601,9 @@ def test_category_does_not_leak_into_lens_field():
     assert findings[0]["lens"] is None  # category does not populate lens field
 
 
-def test_mutex_tripwire_warns_on_both_tags(capsys):
-    """When a finding has both Lens: and Category:, parser logs WARNING to
-    stderr but still parses both fields. Verdict-affecting checks may then
-    flag the inconsistency independently."""
+def test_mutex_raises_on_both_tags():
+    """When a finding has both Lens: and Category:, the parser raises
+    MutexViolationError — the two dimensions are mutually exclusive."""
     sample = """
 ### Code Review
 
@@ -611,14 +615,207 @@ def test_mutex_tripwire_warns_on_both_tags(capsys):
 """
     from skills.temper.evals.lens_runner import _parse_findings
 
-    findings = _parse_findings(sample)
+    with pytest.raises(MutexViolationError):
+        _parse_findings(sample)
+
+
+# ---------------------------------------------------------------------------
+# D1a regression: report-prose sections do not emit phantom findings
+# ---------------------------------------------------------------------------
+
+SAMPLE_PREFLIGHT_NUMBERED = """
+### Pre-flight
+1. Foo checklist item
+2. Bar checklist item
+
+### Issues
+
+1. **Real finding**
+   - File: src/foo.py:10-12
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: real.
+"""
+
+
+def test_preflight_numbered_list_emits_zero_phantom_findings():
+    """Numbered items under ### Pre-flight must not parse as findings."""
+    from skills.temper.evals.lens_runner import _parse_findings
+
+    findings = _parse_findings(SAMPLE_PREFLIGHT_NUMBERED)
+    # Only the one real finding under ### Issues survives.
     assert len(findings) == 1
     assert findings[0]["lens"] == "DRY"
-    assert findings[0]["category"] == "Tenancy"
-    captured = capsys.readouterr()
-    assert "WARNING" in captured.err
-    assert "Lens: DRY" in captured.err
-    assert "Category: Tenancy" in captured.err
+    assert findings[0]["section"] == "Issues"
+
+
+# ---------------------------------------------------------------------------
+# cited_files accumulation (multiple File: lines per finding)
+# ---------------------------------------------------------------------------
+
+SAMPLE_THREE_FILE_LINES = """
+### Issues
+
+1. **Triple citation**
+   - File: src/foo.py:10-12
+   - File: src/foo.py:30-31
+   - File: src/foo.py:50
+   - Severity: Minor
+   - Lens: DRY
+   - Issue: duplicated across three sites.
+"""
+
+
+def test_cited_files_accumulates_all_file_lines():
+    from skills.temper.evals.lens_runner import _parse_findings
+
+    findings = _parse_findings(SAMPLE_THREE_FILE_LINES)
+    assert len(findings) == 1
+    f = findings[0]
+    assert len(f["cited_files"]) == 3
+    assert f["file"] == f["cited_files"][0][0]
+    assert f["file"] == "src/foo.py"
+    assert f["line_range"] == (10, 12)
+
+
+# ---------------------------------------------------------------------------
+# finding_cites_n_files
+# ---------------------------------------------------------------------------
+
+
+def test_finding_cites_n_files_site_count_pass():
+    verdict, _ = finding_cites_n_files(SAMPLE_THREE_FILE_LINES, n=3)
+    assert verdict == "PASS"
+
+
+def test_finding_cites_n_files_site_count_fail():
+    verdict, _ = finding_cites_n_files(SAMPLE_THREE_FILE_LINES, n=4)
+    assert verdict == "FAIL"
+
+
+def test_finding_cites_n_files_distinct_paths_pass():
+    verdict, _ = finding_cites_n_files(
+        SAMPLE_SRP_AND_DRY_DISJOINT, files=["src/svc.py"]
+    )
+    assert verdict == "PASS"
+
+
+def test_finding_cites_n_files_distinct_paths_fail():
+    verdict, rationale = finding_cites_n_files(
+        SAMPLE_SRP_AND_DRY_DISJOINT, files=["src/svc.py", "src/missing.py"]
+    )
+    assert verdict == "FAIL"
+    assert "src/missing.py" in rationale
+
+
+def test_finding_cites_n_files_na_when_no_params():
+    verdict, _ = finding_cites_n_files(SAMPLE_THREE_FILE_LINES)
+    assert verdict == "N/A"
+
+
+# ---------------------------------------------------------------------------
+# finding_body_contains
+# ---------------------------------------------------------------------------
+
+
+def test_finding_body_contains_pass():
+    verdict, _ = finding_body_contains(SAMPLE_AI_SLOP, pattern="over-defensive")
+    assert verdict == "PASS"
+
+
+def test_finding_body_contains_fail():
+    verdict, _ = finding_body_contains(SAMPLE_AI_SLOP, pattern="totally-absent-phrase")
+    assert verdict == "FAIL"
+
+
+def test_finding_body_contains_na_when_no_findings():
+    verdict, _ = finding_body_contains(SAMPLE_NO_CATEGORY, pattern="anything")
+    assert verdict == "N/A"
+
+
+# ---------------------------------------------------------------------------
+# report_has_block / report_block_contains
+# ---------------------------------------------------------------------------
+
+SAMPLE_REPORT_WITH_BLOCKS = """
+### Pre-flight
+Scope looks correct; touched 3 files.
+
+### Issues
+
+1. **A finding**
+   - File: src/foo.py:1
+   - Severity: Minor
+   - Lens: DRY
+"""
+
+SAMPLE_REPORT_EMPTY_BLOCK = """
+### Pre-flight
+
+
+### Issues
+- Verdict: Clean
+"""
+
+SAMPLE_TWO_PREFLIGHT = """
+### Pre-flight
+
+
+### Pre-flight
+Second block has real content here.
+
+### Issues
+- Verdict: Clean
+"""
+
+
+def test_report_has_block_present_nonempty_pass():
+    verdict, _ = report_has_block(SAMPLE_REPORT_WITH_BLOCKS, heading="Pre-flight")
+    assert verdict == "PASS"
+
+
+def test_report_has_block_missing_heading_fail():
+    verdict, rationale = report_has_block(
+        SAMPLE_REPORT_WITH_BLOCKS, heading="Strengths"
+    )
+    assert verdict == "FAIL"
+    assert "no ###" in rationale
+
+
+def test_report_has_block_whitespace_only_fail():
+    verdict, rationale = report_has_block(
+        SAMPLE_REPORT_EMPTY_BLOCK, heading="Pre-flight"
+    )
+    assert verdict == "FAIL"
+    assert "empty" in rationale
+
+
+def test_report_has_block_two_blocks_union_counted():
+    # First Pre-flight is empty, second has content; union is non-empty → PASS.
+    verdict, _ = report_has_block(SAMPLE_TWO_PREFLIGHT, heading="Pre-flight")
+    assert verdict == "PASS"
+
+
+def test_report_block_contains_pass():
+    verdict, _ = report_block_contains(
+        SAMPLE_REPORT_WITH_BLOCKS, heading="Pre-flight", pattern="Scope"
+    )
+    assert verdict == "PASS"
+
+
+def test_report_block_contains_fail():
+    verdict, _ = report_block_contains(
+        SAMPLE_REPORT_WITH_BLOCKS, heading="Pre-flight", pattern="nonexistent-token"
+    )
+    assert verdict == "FAIL"
+
+
+def test_report_block_contains_matches_second_block():
+    # Pattern only present in the 2nd Pre-flight block → union search PASSes.
+    verdict, _ = report_block_contains(
+        SAMPLE_TWO_PREFLIGHT, heading="Pre-flight", pattern="real content"
+    )
+    assert verdict == "PASS"
 
 
 # ---------------------------------------------------------------------------

--- a/skills/temper/evals/test_run_evals_global_expectations.py
+++ b/skills/temper/evals/test_run_evals_global_expectations.py
@@ -171,3 +171,10 @@ def test_validate_global_expectations_rejects_non_mechanical():
 def test_validate_global_expectations_accepts_valid():
     good = [{"type": "mechanical", "check": "all-findings-have-file-line"}]
     _validate_global_expectations(good)  # no raise
+
+
+def test_validate_global_expectations_accepts_snake_case_check():
+    # snake_case must be normalized to kebab-case (as runtime dispatch does)
+    # rather than rejected only to resolve fine when actually run.
+    good = [{"type": "mechanical", "check": "report_has_block"}]
+    _validate_global_expectations(good)  # no raise

--- a/skills/temper/evals/test_run_evals_global_expectations.py
+++ b/skills/temper/evals/test_run_evals_global_expectations.py
@@ -70,17 +70,29 @@ def test_load_evals_noop_when_key_absent(tmp_path):
     assert "expectations" not in evals[1]
 
 
-def test_real_evals_json_is_noop():
-    """The live evals.json must round-trip cleanly through _load_evals (no
-    global_expectations key yet — that's a later task)."""
+def test_real_evals_json_folds_preflight_global():
+    """The live evals.json now carries the global Pre-flight matcher (T4).
+    `_load_evals` must surface it and fold it into EVERY eval's expectations."""
     from skills.temper.evals.run_evals import _EVALS_JSON
 
     raw = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
     evals, globals_returned = _load_evals(_EVALS_JSON)
-    assert globals_returned == []
-    # Expectation lists must be byte-for-byte identical to the on-disk file.
+
+    # The single global expectation is the Pre-flight report-has-block matcher.
+    assert globals_returned == [
+        {
+            "type": "mechanical",
+            "check": "report-has-block",
+            "params": {"heading": "Pre-flight"},
+        }
+    ]
+
+    # Every eval's loaded expectations = its on-disk expectations + each global.
     for raw_ev, loaded_ev in zip(raw["evals"], evals):
-        assert raw_ev.get("expectations") == loaded_ev.get("expectations")
+        expected = list(raw_ev.get("expectations") or []) + globals_returned
+        assert loaded_ev.get("expectations") == expected
+        # And the Pre-flight matcher is present on each eval.
+        assert globals_returned[0] in loaded_ev["expectations"]
 
 
 def test_stage_and_score_fixture_sha_match_with_global_expectations(tmp_path):

--- a/skills/temper/evals/test_run_evals_global_expectations.py
+++ b/skills/temper/evals/test_run_evals_global_expectations.py
@@ -1,0 +1,161 @@
+"""Tests for global_expectations Pre-flight matcher + mutex hard-fail wiring.
+
+Covers (T2):
+  - `_load_evals` folds top-level `global_expectations` into every eval, and is
+    a clean no-op when the key is absent.
+  - stage- and score-side `fixture_sha` match for the same fixture once the
+    global expectations are folded in (the merged expectations list is
+    identical across both load paths).
+  - a reviewer output with a finding tagged BOTH `Lens:` and `Category:` scores
+    a per-trial FAIL with the mutex rationale through `_aggregate_from_outputs`
+    (not an uncaught raise).
+  - an invalid `global_expectations` entry (unknown check) raises
+    `FixtureValidationError` at validation.
+"""
+
+import json
+
+import pytest
+
+from skills.temper.evals import lens_runner
+from skills.temper.evals.run_evals import (
+    FixtureValidationError,
+    _aggregate_from_outputs,
+    _load_evals,
+    _validate_global_expectations,
+)
+from skills.temper.evals._dispatch_paths import fixture_sha
+
+
+def _write_evals(tmp_path, payload: dict):
+    p = tmp_path / "evals.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def test_load_evals_appends_global_expectations_to_every_eval(tmp_path):
+    ge = {"type": "mechanical", "check": "all-findings-have-file-line"}
+    payload = {
+        "global_expectations": [ge],
+        "evals": [
+            {"id": "a", "expectations": [{"type": "mechanical", "check": "findings-count-at-least"}]},
+            {"id": "b"},  # no expectations key — helper must create it
+        ],
+    }
+    p = _write_evals(tmp_path, payload)
+    evals, globals_returned = _load_evals(p)
+
+    assert globals_returned == [ge]
+    # eval "a": original expectation preserved + global appended
+    assert evals[0]["expectations"][-1] == ge
+    assert len(evals[0]["expectations"]) == 2
+    # eval "b": expectations list created with the global appended
+    assert evals[1]["expectations"] == [ge]
+
+
+def test_load_evals_noop_when_key_absent(tmp_path):
+    payload = {
+        "evals": [
+            {"id": "a", "expectations": [{"type": "mechanical", "check": "findings-count-at-least"}]},
+            {"id": "b"},
+        ],
+    }
+    p = _write_evals(tmp_path, payload)
+    evals, globals_returned = _load_evals(p)
+
+    assert globals_returned == []
+    # eval "a" unchanged
+    assert evals[0]["expectations"] == [{"type": "mechanical", "check": "findings-count-at-least"}]
+    # eval "b" gained NO expectations key (clean no-op)
+    assert "expectations" not in evals[1]
+
+
+def test_real_evals_json_is_noop():
+    """The live evals.json must round-trip cleanly through _load_evals (no
+    global_expectations key yet — that's a later task)."""
+    from skills.temper.evals.run_evals import _EVALS_JSON
+
+    raw = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
+    evals, globals_returned = _load_evals(_EVALS_JSON)
+    assert globals_returned == []
+    # Expectation lists must be byte-for-byte identical to the on-disk file.
+    for raw_ev, loaded_ev in zip(raw["evals"], evals):
+        assert raw_ev.get("expectations") == loaded_ev.get("expectations")
+
+
+def test_stage_and_score_fixture_sha_match_with_global_expectations(tmp_path):
+    """The merged expectations list (and thus fixture_sha) is identical across
+    the two independent load paths a real stage/score pair would take."""
+    ge = {"type": "mechanical", "check": "all-findings-have-file-line"}
+    payload = {
+        "global_expectations": [ge],
+        "evals": [
+            {"id": "a", "expectations": [{"type": "mechanical", "check": "findings-count-at-least"}]},
+        ],
+    }
+    p = _write_evals(tmp_path, payload)
+
+    # Two independent loads (stage path and score path both call _load_evals).
+    stage_evals, _ = _load_evals(p)
+    score_evals, _ = _load_evals(p)
+
+    stage_fix = {f["id"]: f for f in stage_evals}["a"]
+    score_fix = {f["id"]: f for f in score_evals}["a"]
+
+    assert stage_fix["expectations"] == score_fix["expectations"]
+    assert fixture_sha(stage_fix) == fixture_sha(score_fix)
+
+
+def test_mutex_violation_scores_trial_fail(monkeypatch):
+    """A reviewer output with a finding carrying BOTH Lens: and Category: must
+    score a per-trial FAIL with the mutex rationale, not raise."""
+    reviewer_output = (
+        "### Findings\n\n"
+        "1. Something is wrong\n"
+        "   - File: src/foo.py:10\n"
+        "   - Severity: Important\n"
+        "   - Lens: DRY\n"
+        "   - Category: Tenancy\n"
+        "   This is the body.\n"
+    )
+    # Sanity: confirm the parser itself raises on this output.
+    with pytest.raises(lens_runner.MutexViolationError):
+        lens_runner.evaluate_expectation(
+            {"type": "mechanical", "check": "all-findings-have-file-line"},
+            reviewer_output,
+            {"id": "x"},
+        )
+
+    fix = {
+        "id": "mutex-fix",
+        "expectations": [
+            {"type": "mechanical", "check": "all-findings-have-file-line"},
+        ],
+    }
+    result = _aggregate_from_outputs(
+        fix, [reviewer_output], n_trials=1, threshold=1
+    )
+
+    er = result["expectations"][0]
+    assert er["per_trial_verdicts"] == ["FAIL"]
+    assert er["per_trial_rationales"] == [
+        "mutex violation: finding tagged both Lens and Category"
+    ]
+    assert result["verdict"] == "FAIL"
+
+
+def test_validate_global_expectations_rejects_unknown_check():
+    bad = [{"type": "mechanical", "check": "no-such-check-xyz"}]
+    with pytest.raises(FixtureValidationError, match="_CHECK_REGISTRY"):
+        _validate_global_expectations(bad)
+
+
+def test_validate_global_expectations_rejects_non_mechanical():
+    bad = [{"type": "semantic", "check": "all-findings-have-file-line"}]
+    with pytest.raises(FixtureValidationError, match="mechanical"):
+        _validate_global_expectations(bad)
+
+
+def test_validate_global_expectations_accepts_valid():
+    good = [{"type": "mechanical", "check": "all-findings-have-file-line"}]
+    _validate_global_expectations(good)  # no raise

--- a/skills/temper/temper-reviewer.md
+++ b/skills/temper/temper-reviewer.md
@@ -264,6 +264,9 @@ AI agents produce characteristic padding patterns that aren't bugs but inflate d
 - Missing coverage: [specific code paths without tests]
 - Stale / dead tests: [tests that need updating or removal]
 
+### Pre-flight
+If this PR were deployed right now, what would have to be true for it to actually deliver the feature it claims to deliver? Always emit this block. Enumerate prerequisites — config, environment variables, schema/migrations, downstream services, feature flags — as dash bullets, and for each verify it against the diff or mark it **MISSING**. If the change is self-contained, state explicitly: "No external prerequisites — change is self-contained."
+
 ### Overall
 - Combined verdict: Approved | Needs Fixes (list them) | Escalate
 


### PR DESCRIPTION
## Summary

The deferred D + E + mutex tail of the #267 temper-reviewer tenancy/rollback work (parent design `2026-05-21-temper-267`). Three issues, one combined PR off `main`:

- **#294** — additive per-finding `cited_files` accumulation in the eval parser; scalar `file`/`line_range` become `cited_files[0]` (back-compat: every current mock cites ≤1 File/finding, so existing matchers are unaffected). New `finding-cites-n-files` check counts **citation sites** (Enumerate-**Sites** semantics — 3 `ON CONFLICT` clauses in one file = 3 sites), and `finding-body-contains` (positive mirror).
- **#295** — global `### Pre-flight` feature-delivery matcher: reviewer templates always emit a Pre-flight block; a top-level `global_expectations` entry (`report-has-block`) is folded into every eval; `_REPORT_SECTIONS` parser guard prevents numbered Pre-flight items from parsing as phantom findings; new `report-has-block` / `report-block-contains` checks.
- **#296** — unconditional hard `MutexViolationError` when a single finding is tagged with both `Lens:` and `Category:` (mutually exclusive per #267 D7); the scorer catches it and fails the trial loudly.

## Commits

1. `784b700` — `lens_runner`: `cited_files` + mutex hard-fail + report-block checks
2. `70afe5a` — reviewer templates: always-emit Pre-flight block + drift pins
3. `74cc5e4` — `run_evals`: `global_expectations` loader (single load path, folds before `fixture_sha`) + mutex→FAIL scoring + validation
4. `0d727ce` — `evals.json` `global_expectations` + fixtures 9 (enumerate-sites-partial) & 10 (preflight-missing-migration) + all 10 mocks migrated + snapshot regen
5. `9f42af1` — Phase-4 adversarial-review fold (see below)

## Review (Phase 4)

Design + plan each took an adversarial + clean-verification round (9 findings folded pre-code). The final review collapsed temper + inquisitor + quality-gate into **one adversarial pass — 4 parallel fresh-eyes agents** on the full diff (per the standing #303 cost-cap), which surfaced 5 real findings, all fixed in `9f42af1`:

- **Significant** — `report_block_contains`/`report_has_block` joined `### <heading>` blocks with `""`, letting a regex falsely match across a two-block boundary → now newline-joined (+regression test).
- **Significant** — `global_expectations` were validated only at `stage()`; `score()`/`_legacy_main()` folded them unchecked → now validated in all three paths.
- **Minor** — a decorated heading (`### Pre-flight (feature delivery)`) bypassed the `_REPORT_SECTIONS` exact-match skip → heading now normalized before lookup (+regression test).
- **Minor** — stage validator rejected snake_case `check` names that runtime dispatch accepts → now normalized (+test).
- **Minor** — drift guard didn't pin the load-bearing Pre-flight phrases → added `dash bullets` / `Always emit` / `MISSING` pins.

**Deferred by design** (not bugs): `report_block_contains` is intentionally a regex matcher; `cited_files[0]` scalar-first is the documented #294 back-compat (inert — no mock cites >1 distinct path/finding); the global-fold OR-combination of fixture verdicts is an architectural follow-up (untriggered today). Snapshot confirmed **not stale** (verify-mode re-runs the mock reviewer live; stores verdict tiers, not body hashes).

## Verification

- `python3 -m pytest skills/temper/evals/` → **252 passed**
- `python3 scripts/check_canonical_drift.py` → exit 0
- `python3 -m skills.temper.evals.bootstrap_snapshot` (verify) → 12/17 PASS, 0 FAIL, 5 N/A, snapshot matches

Refs #294, #295, #296 (left open — review before closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)