### PR TITLE
fix(hooks): canonical settings.json schema in README + sha256sum guard (#316, #317)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -96,7 +96,7 @@ Add the following to your `.claude/settings.json` (project-level) or `~/.claude/
 }
 ```
 
-> **Note:** `"matcher": "*"` — the hook intercepts all PreToolUse events and filters internally for Write and Edit tool calls. This ensures both tools are gated. (You may narrow to `"matcher": "Write|Edit"` to let Claude Code filter upstream; the hook's internal target-path check makes either choice safe.)
+> **Note:** `"matcher": "*"` — the hook intercepts all PreToolUse events and filters internally for Write and Edit tool calls. This ensures both tools are gated. (You may narrow to `"matcher": "Write|Edit"` to let Claude Code filter upstream; the hook's internal target-path check makes either choice safe.) The maintainer's actual user-global registration uses `Write|Edit` (see the MIN-5-R6 Parity Note below); the `*` shown here is simply the simplest illustrative form.
 
 ### Verification
 
@@ -151,7 +151,7 @@ Add the following to **user-global `~/.claude/settings.json`** (NOT `.claude/set
       {
         "matcher": "Agent",
         "hooks": [
-          { "type": "command", "command": "bash /mnt/e/Coding/crucible/hooks/build-routing-advisor.sh", "timeout": 500 }
+          { "type": "command", "command": "bash /absolute/path/to/crucible/hooks/build-routing-advisor.sh", "timeout": 500 }
         ]
       }
     ]

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -15,13 +15,17 @@ Add the following to your `.claude/settings.json` (project-level) or `~/.claude/
   "hooks": {
     "PostToolUse": [
       {
-        "command": "bash hooks/session-index.sh",
-        "timeout": 500
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "bash hooks/session-index.sh", "timeout": 500 }
+        ]
       }
     ]
   }
 }
 ```
+
+> Each event entry needs a `matcher` plus a nested `hooks` array whose items carry `"type": "command"`. A flat `{ "command": ... }` entry parses but Claude Code silently ignores it, so the hook never fires. `timeout` is in seconds.
 
 ### Verification
 
@@ -67,7 +71,7 @@ Remove the `PostToolUse` entry from your `settings.json`. Existing session index
 ### Dependencies
 
 - `jq` must be installed and on the PATH
-- `sha256sum` (standard on Linux, available via coreutils on macOS)
+- `sha256sum` (standard on Linux, coreutils on macOS) — falls back to `shasum -a 256` when absent, so minimal/older macOS still works
 
 ## Gate Ledger Guard
 
@@ -82,15 +86,17 @@ Add the following to your `.claude/settings.json` (project-level) or `~/.claude/
   "hooks": {
     "PreToolUse": [
       {
-        "command": "bash hooks/gate-ledger-guard.sh",
-        "timeout": 500
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "bash hooks/gate-ledger-guard.sh", "timeout": 500 }
+        ]
       }
     ]
   }
 }
 ```
 
-> **Note:** No `matcher` field — the hook intercepts all PreToolUse events and filters internally for Write and Edit tool calls. This ensures both tools are gated.
+> **Note:** `"matcher": "*"` — the hook intercepts all PreToolUse events and filters internally for Write and Edit tool calls. This ensures both tools are gated. (You may narrow to `"matcher": "Write|Edit"` to let Claude Code filter upstream; the hook's internal target-path check makes either choice safe.)
 
 ### Verification
 
@@ -144,8 +150,9 @@ Add the following to **user-global `~/.claude/settings.json`** (NOT `.claude/set
     "PreToolUse": [
       {
         "matcher": "Agent",
-        "command": "bash /mnt/e/Coding/crucible/hooks/build-routing-advisor.sh",
-        "timeout": 500
+        "hooks": [
+          { "type": "command", "command": "bash /mnt/e/Coding/crucible/hooks/build-routing-advisor.sh", "timeout": 500 }
+        ]
       }
     ]
   }

--- a/hooks/build-routing-advisor.sh
+++ b/hooks/build-routing-advisor.sh
@@ -9,8 +9,8 @@
 # all utility failures → exit 0 silently.
 #
 # Configured in ~/.claude/settings.json:
-#   "hooks": { "PreToolUse": [{ "matcher": "Agent",
-#     "command": "bash hooks/build-routing-advisor.sh", "timeout": 500 }] }
+#   "hooks": { "PreToolUse": [{ "matcher": "Agent", "hooks": [{ "type": "command",
+#     "command": "bash hooks/build-routing-advisor.sh", "timeout": 500 }] }] }
 
 # Disable errexit — this hook must never fail fatally
 set +e

--- a/hooks/gate-ledger-guard.sh
+++ b/hooks/gate-ledger-guard.sh
@@ -6,7 +6,7 @@
 # Exit 0 = allow, non-zero = block (reason on stderr).
 #
 # Configured in .claude/settings.json:
-#   "hooks": { "PreToolUse": [{ "command": "bash hooks/gate-ledger-guard.sh", "timeout": 500 }] }
+#   "hooks": { "PreToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "bash hooks/gate-ledger-guard.sh", "timeout": 500 }] }] }
 
 # Disable errexit — this hook must never fail fatally
 set +e

--- a/hooks/session-index.sh
+++ b/hooks/session-index.sh
@@ -5,7 +5,7 @@
 # Must ALWAYS exit 0 — never block tool execution.
 #
 # Configured in .claude/settings.json:
-#   "hooks": { "PostToolUse": [{ "command": "bash hooks/session-index.sh", "timeout": 500 }] }
+#   "hooks": { "PostToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "bash hooks/session-index.sh", "timeout": 500 }] }] }
 
 # Disable errexit — this hook must never fail fatally
 set +e

--- a/hooks/session-index.sh
+++ b/hooks/session-index.sh
@@ -36,7 +36,15 @@ esac
 
 # ── Compute session index path ──────────────────────────────────────────
 PROJECT_DIR="$(pwd)"
-PROJECT_HASH="$(echo -n "$PROJECT_DIR" | sha256sum | cut -c1-16)"
+# Guard sha256sum: it is absent on minimal/older macOS, where a bare call would
+# yield an empty hash and land the index in the wrong path. Fall back to
+# shasum -a 256 (always present on Darwin); both emit the same SHA-256 hex, so
+# the resolved path is identical for anyone who has either tool.
+if command -v sha256sum &>/dev/null; then
+  PROJECT_HASH="$(echo -n "$PROJECT_DIR" | sha256sum | cut -c1-16)"
+else
+  PROJECT_HASH="$(echo -n "$PROJECT_DIR" | shasum -a 256 | cut -c1-16)"
+fi
 CLAUDE_PROJECTS_DIR="$HOME/.claude/projects/$PROJECT_HASH"
 SESSION_INDEX_BASE="$CLAUDE_PROJECTS_DIR/memory/session-index"
 


### PR DESCRIPTION
## Summary

Two ForerunnerBC bug reports against the hooks docs/scripts, both confirmed live on `main`:

- **#317** — `hooks/session-index.sh` called bare `sha256sum` to compute `PROJECT_HASH`, which *forms a filesystem path*. On minimal/older macOS without coreutils the call yields an empty hash and the session index lands in the wrong path. Now guarded with a `shasum -a 256` fallback (parity with `build-routing-advisor.sh`). Both tools emit identical SHA-256 hex, so the resolved path is byte-identical for anyone who has either — **no index-path regression** for existing users.
- **#316** — the hook-install JSON snippets used the flat `{"command": ...}` form, which Claude Code parses but **silently ignores** (the hook never fires). Rewrote every snippet to the canonical `matcher` + nested `hooks:[{type:"command", command, timeout}]` shape, verified against the official hooks docs.

## Scope

The fix covers **all** the flat-form snippets across the hooks tree, not just the three the issue named:
- `hooks/README.md` — 3 install snippets (session-index PostToolUse, gate-ledger-guard PreToolUse, build-routing-advisor PreToolUse) + a "flat form is silently ignored" note + the `sha256sum` dependency line.
- The three hook **scripts' own header comments** (`session-index.sh`, `gate-ledger-guard.sh`, `build-routing-advisor.sh`) embedded the same broken snippet — a user copying from the script comment hit the identical trap. Swept to canonical form (this miss was caught by the quality gate, not the original pass).
- The build-routing-advisor README snippet's stale machine path (`/mnt/e/Coding/crucible`) → `/absolute/path/to/crucible` placeholder.

## Quality gate

Ran `/quality-gate` (artifact: code). Per the #303 cost-cap, the default 10-round window was collapsed to **1 red-team round + 1 look-harder confirmation** (diminishing returns are immediate on a ~30-line docs+shell diff — documented in the verdict marker). Round 1 surfaced 1 Significant (the script-header flat-form miss) + 3 Minor; the fix agent resolved them; the look-harder round returned **0 Fatal / 0 Significant**; Minor Issue Handling swept the remainder. **Verdict: PASS (clean-pass).**

## Verification

- `bash -n` clean on all four hook scripts
- `sha256sum` and `shasum -a 256` produce identical 16-char hashes (`85614e7212f1866f`); fallback branch matches primary; primary branch byte-identical to the old bare call
- All 3 README JSON blocks **and** all 3 script-header fragments parse and are canonically structured (matcher + nested `hooks[].type=="command"`)

Refs #316, #317 (left open — review before closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)