### PR TITLE
feat(compass): #286 relax D8.5 grammar to timestamp-shape anchor (v1.1)

### DIFF
--- a/eval/compass/test-multi-arc-tc3.py
+++ b/eval/compass/test-multi-arc-tc3.py
@@ -336,20 +336,49 @@ def test_tc3_15_paused_entry_timestamp_is_second_resolution(tmp_path):
     )
 
 
-def test_tc3_16_current_arc_space_at_space_rejection(tmp_path):
-    """current_arc with ' @ ' (space-at-space) raises ValueError (D8.5 delimiter conflict)."""
+def test_tc3_16_current_arc_timestamp_shape_rejection(tmp_path):
+    """v1.1: current_arc rejects only a ' @ <timestamp-shape>' suffix (D8.5 collision),
+    not any literal ' @ '. A subject like 'review @ noon' is now permitted."""
     r = _update(tmp_path, "current_arc", ["#1: base"])
     assert r.returncode == 0, f"Bootstrap failed: {r.stderr}"
 
-    # Contains literal ' @ ' — must be rejected (known v1 grammar restriction)
+    # ' @ <ISO timestamp>' shape — must still be rejected (would collide with D8.5 parser)
     r = _update(tmp_path, "current_arc", ["#273: subject @ 2026-05-19T10:00:00"])
     assert r.returncode != 0, (
-        "Expected failure for current_arc with ' @ ' delimiter (D8.5 conflict, known v1 restriction)"
+        "Expected failure for current_arc with ' @ <timestamp>' suffix (D8.5 collision)"
     )
 
-    # Without space-at-space — must succeed
+    # ' @ ' that is NOT a timestamp shape — now valid under v1.1
+    r = _update(tmp_path, "current_arc", ["#273: review @ noon"])
+    assert r.returncode == 0, f"Subject 'review @ noon' should be valid under v1.1: {r.stderr}"
+
+    # @mention (no space-at-space) — still valid
     r = _update(tmp_path, "current_arc", ["#273: subject with @mention"])
-    assert r.returncode == 0, f"Subject with @mention (no space-at-space) should be valid: {r.stderr}"
+    assert r.returncode == 0, f"Subject with @mention should be valid: {r.stderr}"
+
+
+def test_tc3_16b_d8_d85_thrash_with_literal_at_in_subject(tmp_path):
+    """v1.1: D8/D8.5 round-trip thrash works on subjects containing literal '@'.
+    The paused-entry delimiter must still parse despite '@' in the subject body."""
+    a = "#100: review @ noon"
+    b = "#200: deploy @ dusk"
+    for arc in (a, b, a, b):
+        r = _update(tmp_path, "current_arc", [arc])
+        assert r.returncode == 0, f"Thrash set {arc!r} failed: {r.stderr}"
+
+    content = (tmp_path / COMPASS_REL).read_text()
+    # D11 dedup still holds: at most one [paused] #100: entry despite the '@' subject
+    loops = _parse_open_loops(content)
+    paused_a = [l for l in loops if "[paused] #100:" in l]
+    assert len(paused_a) <= 1, f"Expected ≤1 [paused] #100: after thrash, got: {paused_a}"
+
+    # Resume A → D8.5 must remove the paused #100 entry even though its subject has '@'
+    r = _update(tmp_path, "current_arc", [a])
+    assert r.returncode == 0, f"Resume {a!r} failed: {r.stderr}"
+    loops = _parse_open_loops((tmp_path / COMPASS_REL).read_text())
+    assert not [l for l in loops if "[paused] #100:" in l], (
+        f"D8.5 should remove [paused] #100: on resume despite '@' in subject, got: {loops}"
+    )
 
 
 def test_tc3_17_update_many_append_dedup(tmp_path):

--- a/eval/compass/test-multi-arc-tc3.py
+++ b/eval/compass/test-multi-arc-tc3.py
@@ -370,7 +370,7 @@ def test_tc3_16b_d8_d85_thrash_with_literal_at_in_subject(tmp_path):
     # D11 dedup still holds: at most one [paused] #100: entry despite the '@' subject
     loops = _parse_open_loops(content)
     paused_a = [l for l in loops if "[paused] #100:" in l]
-    assert len(paused_a) <= 1, f"Expected ≤1 [paused] #100: after thrash, got: {paused_a}"
+    assert len(paused_a) == 1, f"Expected exactly one [paused] #100: after A→B→A→B thrash, got: {paused_a}"
 
     # Resume A → D8.5 must remove the paused #100 entry even though its subject has '@'
     r = _update(tmp_path, "current_arc", [a])

--- a/scripts/compass.py
+++ b/scripts/compass.py
@@ -430,8 +430,8 @@ def _validate_value(field, value):
             return
         if CURRENT_ARC_TS_COLLISION_RE.search(value):
             raise ValueError(
-                f"current_arc cannot contain a ' @ <timestamp>' suffix matching "
-                f"the D8.5 paused-entry delimiter shape "
+                f"current_arc cannot contain a ' @ <timestamp>' sequence (anywhere) "
+                f"matching the D8.5 paused-entry delimiter shape "
                 f"(' @ YYYY-MM-DDTHH:MM:SS') — it would collide with paused-arc "
                 f"parsing. Got: {value!r}"
             )

--- a/scripts/compass.py
+++ b/scripts/compass.py
@@ -37,6 +37,12 @@ SPIN_INTERVAL_S = 0.05
 PAUSED_LINE_RE = re.compile(
     r"^\[paused\] #(?P<id>\d+): .+ @ \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$"
 )
+# v1.1 (D8.5): only a ` @ <timestamp-shape>` suffix collides with the paused
+# delimiter, so reject just that shape instead of any literal ' @ '. A subject
+# like "review @ noon" is now permitted; "prior @ 2026-05-20T10:00:00" is not.
+CURRENT_ARC_TS_COLLISION_RE = re.compile(
+    r" @ \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+)
 TICKET_ID_RE = re.compile(r"^#(\d+):")
 CURRENT_ARC_GRAMMAR_RE = re.compile(r"^#\d+:\s")
 COMMIT_GRAMMAR_RE = re.compile(r"^[^:]+:.+")  # sha:subject (must contain colon)
@@ -422,11 +428,12 @@ def _validate_value(field, value):
         if value in ("", "<pending>"):
             # empty is arc-closure; <pending> is rejected at higher level (R15-S2)
             return
-        if " @ " in value:
+        if CURRENT_ARC_TS_COLLISION_RE.search(value):
             raise ValueError(
-                f"current_arc cannot contain literal ' @ ' (space-at-space) — "
-                f"this is a known v1 grammar restriction (D8.5 delimiter conflict). "
-                f"Got: {value!r}"
+                f"current_arc cannot contain a ' @ <timestamp>' suffix matching "
+                f"the D8.5 paused-entry delimiter shape "
+                f"(' @ YYYY-MM-DDTHH:MM:SS') — it would collide with paused-arc "
+                f"parsing. Got: {value!r}"
             )
         if not CURRENT_ARC_GRAMMAR_RE.match(value):
             raise ValueError(

--- a/skills/compass/SKILL.md
+++ b/skills/compass/SKILL.md
@@ -74,7 +74,7 @@ python scripts/compass.py <subcommand> [args]
 - `current_arc` must match `#NNN: <subject>` (leading `#` required) or be empty string (arc-closure).
 - `last_meaningful_commit` must contain a colon (`sha:subject`). `<pending>` and `<pending-merge:#NNN>` are valid sentinels.
 - Setting `current_arc` to `<pending>` directly raises `ValueError` — that sentinel is internal to bootstrap only.
-- `current_arc` subjects cannot contain the literal substring ` @ ` (space-at-space) — known v1 grammar restriction (D8.5 delimiter conflict).
+- `current_arc` subjects may contain literal `@` characters but cannot contain a ` @ <timestamp-shape>` suffix (` @ YYYY-MM-DDTHH:MM:SS`) — it would collide with the D8.5 paused-entry delimiter (v1.1; see #286).
 
 ## Integration points
 

--- a/skills/compass/SKILL.md
+++ b/skills/compass/SKILL.md
@@ -74,7 +74,7 @@ python scripts/compass.py <subcommand> [args]
 - `current_arc` must match `#NNN: <subject>` (leading `#` required) or be empty string (arc-closure).
 - `last_meaningful_commit` must contain a colon (`sha:subject`). `<pending>` and `<pending-merge:#NNN>` are valid sentinels.
 - Setting `current_arc` to `<pending>` directly raises `ValueError` — that sentinel is internal to bootstrap only.
-- `current_arc` subjects may contain literal `@` characters but cannot contain a ` @ <timestamp-shape>` suffix (` @ YYYY-MM-DDTHH:MM:SS`) — it would collide with the D8.5 paused-entry delimiter (v1.1; see #286).
+- `current_arc` subjects may contain literal `@` characters but cannot contain a ` @ <timestamp-shape>` sequence (` @ YYYY-MM-DDTHH:MM:SS`) anywhere in the value — it would collide with the D8.5 paused-entry delimiter (v1.1; see #286).
 
 ## Integration points
 

--- a/skills/shared/compass-protocol.md
+++ b/skills/shared/compass-protocol.md
@@ -196,7 +196,8 @@ entry.
 
 **Grammar restriction (D8.5, v1.1):** `current_arc` subjects may contain literal
 `@` characters — including ` @ ` (space-at-space) — but may **not** contain a
-` @ <timestamp-shape>` suffix matching the paused-entry delimiter shape
+` @ <timestamp-shape>` sequence (anywhere in the subject) matching the
+paused-entry delimiter shape
 ` @ \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}` (e.g. ` @ 2026-05-20T10:00:00`), which
 would collide with D8.5 paused-arc parsing. A subject such as "review @ noon" is
 permitted; "prior @ 2026-05-20T10:00:00" is rejected. (v1 rejected any ` @ `;

--- a/skills/shared/compass-protocol.md
+++ b/skills/shared/compass-protocol.md
@@ -185,7 +185,7 @@ this exact order (R7-F3):
    `[OPEN] Started new arc <new> with prior arc <old> still active — prior arc moved to open_loops`.
 
 **Paused-entry grammar (formal):**
-`[paused] #<NNN>: <subject> @ <YYYY-MM-DDTHH:MM>` (minute-resolution UTC).
+`[paused] #<NNN>: <subject> @ <YYYY-MM-DDTHH:MM:SS>` (second-resolution UTC).
 
 **Dedup on thrash:** if a `[paused] #<old-id>:` entry already exists in
 `open_loops`, UPDATE it in place (refresh subject + timestamp) rather than
@@ -194,12 +194,13 @@ entry.
 
 **D8.5 resume advisory:** stderr `[RESUME] Resuming paused arc <X>`.
 
-**Known v1 grammar restriction (D8.5):** `current_arc` subjects cannot contain
-the literal substring ` @ ` (space-at-space). D8.5 uses ` @ ` as the
-timestamp delimiter when scanning paused entries. A subject such as "review @
-noon" would corrupt D8.5 parsing. **This is a known limitation.** v1.1 will
-relax D8.5 match to anchor on timestamp shape only. Do not silently remove this
-restriction in cleanup — it is a tracked design debt.
+**Grammar restriction (D8.5, v1.1):** `current_arc` subjects may contain literal
+`@` characters — including ` @ ` (space-at-space) — but may **not** contain a
+` @ <timestamp-shape>` suffix matching the paused-entry delimiter shape
+` @ \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}` (e.g. ` @ 2026-05-20T10:00:00`), which
+would collide with D8.5 paused-arc parsing. A subject such as "review @ noon" is
+permitted; "prior @ 2026-05-20T10:00:00" is rejected. (v1 rejected any ` @ `;
+v1.1 narrows the guard to the timestamp shape only — see #286.)
 
 ## CLI surface
 


### PR DESCRIPTION
## What

Relaxes the compass `current_arc` grammar guard (D8.5, v1 → v1.1). Subjects may now contain literal `@` characters — including ` @ ` (space-at-space) — and are rejected **only** if they contain a ` @ <timestamp-shape>` suffix matching the paused-entry delimiter shape ` @ \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`, which would collide with D8.5 paused-arc parsing.

- `#42: review @ noon` → **accepted** (was rejected in v1)
- `#42: prior @ 2026-05-20T10:00:00` → **still rejected** (D8.5 collision)

## Why

v1 used a blunt substring guard (`' @ ' in value`) that rejected legitimate subjects like "review @ noon". Only the timestamp shape actually collides with the paused-entry delimiter, so the guard is narrowed to that shape. Follow-up from #273 (PR #284).

## Changes

- `scripts/compass.py` — `CURRENT_ARC_TS_COLLISION_RE` regex replaces the literal-substring rejection in `_validate_value`.
- `eval/compass/test-multi-arc-tc3.py` — invert T-C3.16 to assert `@ noon` acceptance + keep timestamp-shape rejection; add **T-C3.16b** D8/D8.5 round-trip thrash on `@`-containing subjects (verifies the greedy `.+` in `PAUSED_LINE_RE` still anchors on the real timestamp, and D8.5 removal-by-id is unaffected).
- `skills/shared/compass-protocol.md` + `skills/compass/SKILL.md` — amend the v1-restriction paragraph; also fix a stale **minute→second** paused-entry timestamp-resolution drift (code emits second resolution via `_now_second_str`).

## Acceptance (all verified)

- `current_arc = '#42: review @ noon'` succeeds ✅
- `current_arc = '#42: prior @ 2026-05-20T10:00:00'` rejected ✅
- D8/D8.5 round-trip thrash works on subjects containing literal `@` ✅

## Verification

- `python3 -m pytest eval/compass/test-multi-arc-tc3.py` → 19 passed
- `python3 -m pytest skills/temper/evals/` → 252 passed
- `python3 scripts/check_canonical_drift.py` → exit 0

## Notes / out of scope

- **Pre-existing failure, unrelated to this PR:** `eval/compass/test-doctor-tc7.py::test_tc7_8` fails because the committed `.gitignore:5` ignores `docs/compass.md`, while the test's C-9 invariant asserts it must *not* be gitignored. This contradiction predates this branch (no files touched here are involved). Worth a separate decision — is `compass.md` committed repo state or local session state?
- The issue's `[BACKFILL]` marker note refers to a local-only design doc (`docs/plans/`, gitignored); not part of this code-only PR.

Refs #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)