### PR TITLE
feat(#272): /ledger weekly renderer + inflation-detector (Phase 5)

### DIFF
--- a/docs/ledger/weekly-2026-W14.md
+++ b/docs/ledger/weekly-2026-W14.md
@@ -1,0 +1,37 @@
+# Crucible Calibration Ledger — 2026-W14
+
+_Generated 2026-05-31T20:27:31Z_
+
+## Crucible caught 0 silent bugs
+
+Forward-captured runs with `would_have_shipped_without_gate: true`, excluding backfilled entries (the honest count, per L-3/L-5).
+
+## Verdict breakdown
+
+- Total runs this week: **1**
+- PASS: 1
+
+## Per-skill severity rates (forward-captured only)
+
+_No forward-captured entries this week — rates unavailable. (Backfilled entries carry `severity_histogram: null` by design.)_
+
+_Inflation detector is silent for a skill until 4 weeks of forward-captured data exist for it (§4a bootstrap)._
+
+## Backfilled historical context
+
+1 backfilled entry this week (excluded from the caught headline and from severity rates; `severity_histogram: null` by design):
+
+- PR #125 — `quality-gate` PASS
+
+## Falsified verdicts (cross-link)
+
+Falsified ledger entries (all-time, via the L-9 reduction over `falsification.jsonl`): **0**.
+
+_No falsification data yet (reconciler / Phase 4 not present, or no verdicts falsified)._
+
+## Monthly spot-check
+
+First `/ledger` run of the month — spot-check protocol (advisory, not blocking):
+
+- [ ] Spot-check 5 random `would_have_shipped_without_gate: true` entries — do their `highest_finding` quotes match the rubric in `skills/shared/severity-rubric.md`?
+- [ ] Review any inflation alerts above for calibration drift.

--- a/docs/ledger/weekly-2026-W15.md
+++ b/docs/ledger/weekly-2026-W15.md
@@ -1,0 +1,38 @@
+# Crucible Calibration Ledger — 2026-W15
+
+_Generated 2026-05-31T20:27:31Z_
+
+## Crucible caught 0 silent bugs
+
+Forward-captured runs with `would_have_shipped_without_gate: true`, excluding backfilled entries (the honest count, per L-3/L-5).
+
+## Verdict breakdown
+
+- Total runs this week: **2**
+- PASS: 2
+
+## Per-skill severity rates (forward-captured only)
+
+_No forward-captured entries this week — rates unavailable. (Backfilled entries carry `severity_histogram: null` by design.)_
+
+_Inflation detector is silent for a skill until 4 weeks of forward-captured data exist for it (§4a bootstrap)._
+
+## Backfilled historical context
+
+2 backfilled entries this week (excluded from the caught headline and from severity rates; `severity_histogram: null` by design):
+
+- PR #162 — `quality-gate` PASS
+- PR #152 — `quality-gate` PASS
+
+## Falsified verdicts (cross-link)
+
+Falsified ledger entries (all-time, via the L-9 reduction over `falsification.jsonl`): **0**.
+
+_No falsification data yet (reconciler / Phase 4 not present, or no verdicts falsified)._
+
+## Monthly spot-check
+
+First `/ledger` run of the month — spot-check protocol (advisory, not blocking):
+
+- [ ] Spot-check 5 random `would_have_shipped_without_gate: true` entries — do their `highest_finding` quotes match the rubric in `skills/shared/severity-rubric.md`?
+- [ ] Review any inflation alerts above for calibration drift.

--- a/docs/ledger/weekly-2026-W16.md
+++ b/docs/ledger/weekly-2026-W16.md
@@ -1,0 +1,32 @@
+# Crucible Calibration Ledger — 2026-W16
+
+_Generated 2026-05-31T20:27:31Z_
+
+## Crucible caught 0 silent bugs
+
+Forward-captured runs with `would_have_shipped_without_gate: true`, excluding backfilled entries (the honest count, per L-3/L-5).
+
+## Verdict breakdown
+
+- Total runs this week: **3**
+- PASS: 3
+
+## Per-skill severity rates (forward-captured only)
+
+_No forward-captured entries this week — rates unavailable. (Backfilled entries carry `severity_histogram: null` by design.)_
+
+_Inflation detector is silent for a skill until 4 weeks of forward-captured data exist for it (§4a bootstrap)._
+
+## Backfilled historical context
+
+3 backfilled entries this week (excluded from the caught headline and from severity rates; `severity_histogram: null` by design):
+
+- PR #193 — `quality-gate` PASS
+- PR #192 — `quality-gate` PASS
+- PR #191 — `quality-gate` PASS
+
+## Falsified verdicts (cross-link)
+
+Falsified ledger entries (all-time, via the L-9 reduction over `falsification.jsonl`): **0**.
+
+_No falsification data yet (reconciler / Phase 4 not present, or no verdicts falsified)._

--- a/docs/ledger/weekly-2026-W20.md
+++ b/docs/ledger/weekly-2026-W20.md
@@ -1,0 +1,37 @@
+# Crucible Calibration Ledger — 2026-W20
+
+_Generated 2026-05-31T20:27:31Z_
+
+## Crucible caught 0 silent bugs
+
+Forward-captured runs with `would_have_shipped_without_gate: true`, excluding backfilled entries (the honest count, per L-3/L-5).
+
+## Verdict breakdown
+
+- Total runs this week: **1**
+- PASS: 1
+
+## Per-skill severity rates (forward-captured only)
+
+_No forward-captured entries this week — rates unavailable. (Backfilled entries carry `severity_histogram: null` by design.)_
+
+_Inflation detector is silent for a skill until 4 weeks of forward-captured data exist for it (§4a bootstrap)._
+
+## Backfilled historical context
+
+1 backfilled entry this week (excluded from the caught headline and from severity rates; `severity_histogram: null` by design):
+
+- PR #264 — `quality-gate` PASS
+
+## Falsified verdicts (cross-link)
+
+Falsified ledger entries (all-time, via the L-9 reduction over `falsification.jsonl`): **0**.
+
+_No falsification data yet (reconciler / Phase 4 not present, or no verdicts falsified)._
+
+## Monthly spot-check
+
+First `/ledger` run of the month — spot-check protocol (advisory, not blocking):
+
+- [ ] Spot-check 5 random `would_have_shipped_without_gate: true` entries — do their `highest_finding` quotes match the rubric in `skills/shared/severity-rubric.md`?
+- [ ] Review any inflation alerts above for calibration drift.

--- a/docs/ledger/weekly-2026-W21.md
+++ b/docs/ledger/weekly-2026-W21.md
@@ -1,0 +1,30 @@
+# Crucible Calibration Ledger — 2026-W21
+
+_Generated 2026-05-31T20:27:31Z_
+
+## Crucible caught 0 silent bugs
+
+Forward-captured runs with `would_have_shipped_without_gate: true`, excluding backfilled entries (the honest count, per L-3/L-5).
+
+## Verdict breakdown
+
+- Total runs this week: **1**
+- PASS: 1
+
+## Per-skill severity rates (forward-captured only)
+
+_No forward-captured entries this week — rates unavailable. (Backfilled entries carry `severity_histogram: null` by design.)_
+
+_Inflation detector is silent for a skill until 4 weeks of forward-captured data exist for it (§4a bootstrap)._
+
+## Backfilled historical context
+
+1 backfilled entry this week (excluded from the caught headline and from severity rates; `severity_histogram: null` by design):
+
+- PR #301 — `quality-gate` PASS
+
+## Falsified verdicts (cross-link)
+
+Falsified ledger entries (all-time, via the L-9 reduction over `falsification.jsonl`): **0**.
+
+_No falsification data yet (reconciler / Phase 4 not present, or no verdicts falsified)._

--- a/docs/ledger/weekly-2026-W22.md
+++ b/docs/ledger/weekly-2026-W22.md
@@ -1,0 +1,32 @@
+# Crucible Calibration Ledger — 2026-W22
+
+_Generated 2026-05-31T20:27:31Z_
+
+## Crucible caught 0 silent bugs
+
+Forward-captured runs with `would_have_shipped_without_gate: true`, excluding backfilled entries (the honest count, per L-3/L-5).
+
+## Verdict breakdown
+
+- Total runs this week: **3**
+- PASS: 3
+
+## Per-skill severity rates (forward-captured only)
+
+_No forward-captured entries this week — rates unavailable. (Backfilled entries carry `severity_histogram: null` by design.)_
+
+_Inflation detector is silent for a skill until 4 weeks of forward-captured data exist for it (§4a bootstrap)._
+
+## Backfilled historical context
+
+3 backfilled entries this week (excluded from the caught headline and from severity rates; `severity_histogram: null` by design):
+
+- PR #320 — `quality-gate` PASS
+- PR #318 — `quality-gate` PASS
+- PR #314 — `quality-gate` PASS
+
+## Falsified verdicts (cross-link)
+
+Falsified ledger entries (all-time, via the L-9 reduction over `falsification.jsonl`): **0**.
+
+_No falsification data yet (reconciler / Phase 4 not present, or no verdicts falsified)._

--- a/eval/calibration-ledger/test-ledger-headline-t5.py
+++ b/eval/calibration-ledger/test-ledger-headline-t5.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""T-5: /ledger honest "caught N" headline + supporting renderer tests.
+
+The Phase-5 renderer core lives at `scripts/render_ledger.py`. Its filename is
+underscore-named, so it imports normally as `scripts.render_ledger` (unlike the
+hyphenated `backfill-ledger.py`, which requires importlib).
+
+T-5 (required, design §4 + §4a "Honest count" + L-3/L-5):
+  The "caught N silent bugs" headline counts entries with
+  `would_have_shipped_without_gate == True` EXCLUDING `backfilled == True`.
+  Backfilled entries carry `severity_histogram: null` -> WHS null -> excluded.
+  The fixture mixes, in ONE ISO week:
+    - a backfilled WHS-null entry      (excluded: backfilled + WHS null)
+    - a forward WHS:true entry         (counted)
+    - a forward WHS:false entry        (excluded: WHS false)
+  Assert caught_count == exactly the forward-WHS-true count (== 1).
+
+Supporting tests: iso_week grouping, tolerant load (malformed line skipped),
+missing runs.jsonl -> load_runs == [] and main prints "no ledger data yet",
+falsified_count == 0 when falsification.jsonl absent, raw rates computed from
+forward entries only (backfilled excluded from rate denominator).
+
+Run: python3 -m pytest eval/calibration-ledger/test-ledger-headline-t5.py -v
+"""
+import io
+import json
+import os
+import sys
+from contextlib import redirect_stdout
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from scripts import render_ledger as rl  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Entry builders                                                              #
+# --------------------------------------------------------------------------- #
+
+def _forward_entry(run_id, *, whs, fatal=0, significant=0, minor=0, nit=0,
+                   skill="quality-gate", verdict="PASS",
+                   timestamp="2026-05-18T12:00:00Z"):
+    """A forward-captured entry: backfilled=False, real severity_histogram."""
+    return {
+        "schema_version": 1,
+        "run_id": run_id,
+        "skill": skill,
+        "tier": "A",
+        "artifact_type": "code",
+        "verdict": verdict,
+        "confidence": 0.8,
+        "artifact_hash": "a" * 64,
+        "chunk_hash": None,
+        "gated_files": ["x.py"],
+        "findings_count": fatal + significant + minor + nit,
+        "severity_histogram": {
+            "fatal": fatal, "significant": significant,
+            "minor": minor, "nit": nit,
+        },
+        "highest_finding": "some finding" if (fatal or significant) else None,
+        "would_have_shipped_without_gate": whs,
+        "rounds": 1,
+        "timestamp": timestamp,
+        "backfilled": False,
+        "falsified": None,
+        "falsified_by": None,
+        "gated_files_truncated": 0,
+        "comment": None,
+        "predicted_falsifier": None,
+    }
+
+
+def _backfilled_entry(run_id, *, timestamp="2026-05-18T12:00:00Z",
+                      skill="quality-gate"):
+    """A backfilled entry: backfilled=True, severity_histogram null, WHS null."""
+    return {
+        "schema_version": 1,
+        "run_id": run_id,
+        "skill": skill,
+        "tier": "A",
+        "artifact_type": "code",
+        "verdict": "PASS",
+        "confidence": None,
+        "artifact_hash": None,
+        "chunk_hash": None,
+        "gated_files": ["y.py"],
+        "findings_count": None,
+        "severity_histogram": None,
+        "highest_finding": None,
+        "would_have_shipped_without_gate": None,
+        "rounds": None,
+        "timestamp": timestamp,
+        "backfilled": True,
+        "falsified": None,
+        "falsified_by": None,
+        "gated_files_truncated": 0,
+        "comment": "inferred-from-fix",
+        "predicted_falsifier": None,
+    }
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e, separators=(",", ":")) + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# T-5: THE headline                                                           #
+# --------------------------------------------------------------------------- #
+
+def test_t5_caught_count_excludes_backfilled_and_whs_false():
+    """T-5: caught_count == forward-WHS-true count, in a mixed single ISO week."""
+    entries = [
+        _backfilled_entry("backfill-100-quality-gate"),          # WHS null -> excluded
+        _forward_entry("fwd-true", whs=True, significant=1),     # counted
+        _forward_entry("fwd-false", whs=False, minor=2),         # WHS false -> excluded
+    ]
+    # All three land in the SAME ISO week (2026-05-18 is in 2026-W21).
+    weeks = {rl.iso_week(e) for e in entries}
+    assert len(weeks) == 1, f"fixture entries must share one ISO week: {weeks}"
+
+    assert rl.caught_count(entries) == 1
+
+    # Make the discrimination explicit: a backfilled entry with WHS forced True
+    # must STILL be excluded (the exclusion is on `backfilled`, not just WHS null).
+    sneaky = _backfilled_entry("backfill-evil-quality-gate")
+    sneaky["would_have_shipped_without_gate"] = True  # pathological
+    assert rl.caught_count(entries + [sneaky]) == 1
+
+
+# --------------------------------------------------------------------------- #
+# iso_week                                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_iso_week_format_and_grouping():
+    e1 = _forward_entry("a", whs=True, significant=1, timestamp="2026-05-18T00:00:00Z")
+    e2 = _forward_entry("b", whs=True, significant=1, timestamp="2026-05-25T00:00:00Z")
+    assert rl.iso_week(e1) == "2026-W21"
+    assert rl.iso_week(e2) == "2026-W22"
+
+
+def test_iso_week_handles_trailing_z_and_offset():
+    z = _forward_entry("z", whs=False, timestamp="2026-05-18T23:59:59Z")
+    off = _forward_entry("o", whs=False, timestamp="2026-05-18T23:59:59+00:00")
+    assert rl.iso_week(z) == rl.iso_week(off) == "2026-W21"
+
+
+# --------------------------------------------------------------------------- #
+# tolerant load                                                               #
+# --------------------------------------------------------------------------- #
+
+def test_load_runs_skips_malformed_and_blank_lines(tmp_path):
+    p = tmp_path / "runs.jsonl"
+    good1 = json.dumps(_forward_entry("g1", whs=True, significant=1))
+    good2 = json.dumps(_forward_entry("g2", whs=False))
+    with open(p, "w", encoding="utf-8") as f:
+        f.write(good1 + "\n")
+        f.write("\n")                       # blank line
+        f.write("{not valid json\n")        # malformed line
+        f.write(good2 + "\n")
+    rows = rl.load_runs(str(p))
+    assert len(rows) == 2
+    assert {r["run_id"] for r in rows} == {"g1", "g2"}
+
+
+def test_load_runs_drops_partial_trailing_line(tmp_path):
+    p = tmp_path / "runs.jsonl"
+    good = json.dumps(_forward_entry("ok", whs=True, significant=1))
+    with open(p, "w", encoding="utf-8") as f:
+        f.write(good + "\n")
+        f.write('{"run_id":"partial"')      # no terminating newline
+    rows = rl.load_runs(str(p))
+    assert [r["run_id"] for r in rows] == ["ok"]
+
+
+def test_load_runs_dedup_latest_position_wins(tmp_path):
+    p = tmp_path / "runs.jsonl"
+    first = _forward_entry("dup", whs=False, significant=0)
+    second = _forward_entry("dup", whs=True, significant=1)  # same (run_id, skill)
+    _write_jsonl(p, [first, second])
+    rows = rl.load_runs(str(p))
+    assert len(rows) == 1
+    assert rows[0]["would_have_shipped_without_gate"] is True  # latest wins
+
+
+def test_load_runs_missing_file_returns_empty():
+    assert rl.load_runs("/nonexistent/path/to/runs.jsonl") == []
+
+
+# --------------------------------------------------------------------------- #
+# missing runs.jsonl -> main prints notice, exits 0                           #
+# --------------------------------------------------------------------------- #
+
+def test_main_missing_runs_prints_notice(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # no .crucible/ledger/runs.jsonl here
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = rl.main(["--weeks", "1"])
+    assert rc == 0
+    assert "no ledger data yet" in buf.getvalue().lower()
+    # MUST NOT write an empty report.
+    assert not (tmp_path / "docs" / "ledger").exists() or \
+        not list((tmp_path / "docs" / "ledger").glob("weekly-*.md"))
+
+
+# --------------------------------------------------------------------------- #
+# falsified_count graceful degradation                                        #
+# --------------------------------------------------------------------------- #
+
+def test_falsified_count_absent_file_returns_zero(tmp_path):
+    absent = tmp_path / "falsification.jsonl"
+    assert not absent.exists()
+    assert rl.falsified_count(str(absent)) == 0
+
+
+def test_falsified_count_reads_reduction(tmp_path):
+    p = tmp_path / "falsification.jsonl"
+    with open(p, "w", encoding="utf-8") as f:
+        f.write(json.dumps({"ledger_entry_hash": "h1", "falsified": True}) + "\n")
+        f.write(json.dumps({"ledger_entry_hash": "h2", "falsified": True}) + "\n")
+        f.write(json.dumps({"ledger_entry_hash": "h1", "falsified": True}) + "\n")  # L-9 dup
+    assert rl.falsified_count(str(p)) == 2  # h1 deduped by hash
+
+
+# --------------------------------------------------------------------------- #
+# raw rates from forward entries only                                         #
+# --------------------------------------------------------------------------- #
+
+def test_week_summary_rates_exclude_backfilled():
+    """significant_rate / fatal_rate denominators use forward entries only."""
+    entries = [
+        # forward QG: 2 findings, 1 significant, 1 nit -> sig_rate 0.5, fatal_rate 0
+        _forward_entry("f1", whs=True, significant=1, nit=1),
+        # backfilled QG: must NOT enter the rate denominator at all
+        _backfilled_entry("backfill-9-quality-gate"),
+    ]
+    summary = rl.week_summary(entries)
+    qg = summary["per_skill"]["quality-gate"]
+    assert qg["findings"] == 2          # only the forward entry's findings
+    assert qg["significant_rate"] == pytest.approx(0.5)
+    assert qg["fatal_rate"] == pytest.approx(0.0)
+    assert summary["backfilled"] == 1   # reported separately
+    assert summary["caught_count"] == 1
+
+
+def test_week_summary_all_backfilled_zero_caught_and_no_rate():
+    """The real corpus shape: all backfilled -> caught 0, rates 0 (no forward)."""
+    entries = [_backfilled_entry(f"backfill-{i}-quality-gate") for i in range(5)]
+    summary = rl.week_summary(entries)
+    assert summary["caught_count"] == 0
+    assert summary["backfilled"] == 5
+    qg = summary["per_skill"]["quality-gate"]
+    assert qg["findings"] == 0
+    assert qg["significant_rate"] == 0.0
+    assert qg["fatal_rate"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# inflation alert: silent under 4 weeks of forward data                       #
+# --------------------------------------------------------------------------- #
+
+def test_inflation_alert_silent_without_4wk_baseline():
+    per_skill = {"quality-gate": {"significant_rate": 0.9, "fatal_rate": 0.5}}
+    baselines = {}  # no rolling history -> silent
+    assert rl.inflation_alert(per_skill, baselines) == []
+
+
+def test_inflation_alert_fires_above_3x_with_baseline():
+    per_skill = {"quality-gate": {"significant_rate": 0.9, "fatal_rate": 0.0}}
+    # 4 weeks of forward median present, low -> 0.9 > 3*0.1 -> alert
+    baselines = {"quality-gate": {
+        "significant_median": 0.1, "fatal_median": 0.0, "weeks": 4,
+    }}
+    alerts = rl.inflation_alert(per_skill, baselines)
+    assert len(alerts) == 1
+    assert alerts[0]["skill"] == "quality-gate"
+
+
+# --------------------------------------------------------------------------- #
+# Monthly spot-check: deterministic, idempotent across re-renders (§4a)        #
+# --------------------------------------------------------------------------- #
+
+def _write_corpus(out_dir):
+    """3 backfilled entries each in 2026-W22 (May) and 2026-W16 (April)."""
+    ledger = out_dir / "runs.jsonl"
+    entries = []
+    for run, ts in [("backfill-320-quality-gate", "2026-05-31T01:00:00Z"),
+                    ("backfill-318-quality-gate", "2026-05-30T01:00:00Z"),
+                    ("backfill-314-quality-gate", "2026-05-29T01:00:00Z"),
+                    ("backfill-193-quality-gate", "2026-04-17T01:00:00Z"),
+                    ("backfill-192-quality-gate", "2026-04-16T01:00:00Z"),
+                    ("backfill-191-quality-gate", "2026-04-15T01:00:00Z")]:
+        entries.append(_backfilled_entry(run, timestamp=ts))
+    _write_jsonl(ledger, entries)
+    return ledger
+
+
+def _spotcheck_count(path):
+    return path.read_text(encoding="utf-8").count("## Monthly spot-check")
+
+
+def test_first_of_month_weeks_deterministic_one_per_month():
+    """Pure helper: exactly the earliest selected week per calendar month."""
+    selected = ["2026-W22", "2026-W21", "2026-W20", "2026-W16", "2026-W15"]
+    fom = rl.first_of_month_weeks(selected)
+    # May weeks W20-W22 -> earliest is W20; April weeks W15-W16 -> earliest W15.
+    assert fom == {"2026-W20", "2026-W15"}
+
+
+def test_monthly_spotcheck_idempotent_across_rerenders(tmp_path):
+    """Re-rendering the same corpus must NOT drop the spot-check checklist."""
+    ledger = _write_corpus(tmp_path)
+    out_dir = tmp_path / "out"
+    falsif = tmp_path / "falsification.jsonl"  # absent -> count 0
+
+    argv = ["--weeks", "12", "--ledger", str(ledger),
+            "--falsification", str(falsif), "--out-dir", str(out_dir)]
+
+    # First render.
+    assert rl.main(argv) == 0
+    w22 = out_dir / "weekly-2026-W22.md"
+    w16 = out_dir / "weekly-2026-W16.md"
+    w20 = out_dir / "weekly-2026-W20.md"
+    w15 = out_dir / "weekly-2026-W15.md"
+    # NOTE: the corpus only has W22 (May) and W16 (April). Earliest-per-month
+    # among the SELECTED weeks => W22 is the only May week, W16 the only April
+    # week, so both carry the checklist on render 1.
+    assert _spotcheck_count(w22) == 1
+    assert _spotcheck_count(w16) == 1
+
+    # Second render of the SAME corpus into the SAME out-dir.
+    assert rl.main(argv) == 0
+    # The checklist must SURVIVE — this is the regression the QG flagged.
+    assert _spotcheck_count(w22) == 1
+    assert _spotcheck_count(w16) == 1
+
+    # At-most-once-per-month still holds: no other May/April week gets it.
+    assert not w20.exists()  # corpus has no W20
+    assert not w15.exists()  # corpus has no W15
+
+
+def test_monthly_spotcheck_at_most_once_per_month(tmp_path):
+    """Two weeks in the same month -> only the earliest gets the checklist."""
+    ledger = tmp_path / "runs.jsonl"
+    _write_jsonl(ledger, [
+        _backfilled_entry("backfill-1-quality-gate", timestamp="2026-05-31T01:00:00Z"),  # W22
+        _backfilled_entry("backfill-2-quality-gate", timestamp="2026-05-11T01:00:00Z"),  # W20
+    ])
+    out_dir = tmp_path / "out"
+    argv = ["--weeks", "12", "--ledger", str(ledger),
+            "--out-dir", str(out_dir)]
+    assert rl.main(argv) == 0
+    # W20 (earlier May week) gets the checklist; W22 does not.
+    assert _spotcheck_count(out_dir / "weekly-2026-W20.md") == 1
+    assert _spotcheck_count(out_dir / "weekly-2026-W22.md") == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/render_ledger.py
+++ b/scripts/render_ledger.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""`/ledger` weekly renderer — the testable render core (Phase 5).
+
+Reads `.crucible/ledger/runs.jsonl`, groups entries by ISO week, computes
+per-week stats, and renders `docs/ledger/weekly-YYYY-Www.md`. The honest
+"caught N silent bugs" headline counts forward `would_have_shipped_without_gate`
+entries EXCLUDING backfilled ones (design §4 "Honest count" + L-3/L-5).
+
+Structural inflation-detector (§4a "WHS Guard Rails"): per-skill
+`significant_rate` / `fatal_rate` from forward-captured entries only, alerting
+when a rate exceeds 3x its 4-week rolling median. Silent until 4 weeks of
+forward data exist for a skill. Raw rates are printed from week 1.
+
+The SKILL.md (`skills/ledger/SKILL.md`) is a thin prompt wrapper; THIS module is
+the source of truth. Pure stdlib; no third-party deps.
+
+Run: python3 scripts/render_ledger.py --weeks N
+"""
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from scripts.ledger_reduce import reduce as _falsification_reduce  # noqa: E402
+
+# Defaults are CWD-relative: /ledger is invoked from the repo root, and the
+# ledger lives under that repo's working tree. Keeping these relative (rather
+# than pinned to this file's REPO_ROOT) lets the tool operate on whatever repo
+# it is run from, and lets tests isolate via a chdir into tmp_path.
+LEDGER_PATH = os.path.join(".crucible", "ledger", "runs.jsonl")
+FALSIFICATION_PATH = os.path.join(".crucible", "ledger", "falsification.jsonl")
+REPORT_DIR = os.path.join("docs", "ledger")
+
+# 3x the 4-week rolling median per §4a. Starting heuristic; re-evaluate after a
+# quarter of forward data.
+INFLATION_FACTOR = 3.0
+MIN_BASELINE_WEEKS = 4
+
+
+# --------------------------------------------------------------------------- #
+# Loading                                                                     #
+# --------------------------------------------------------------------------- #
+
+def load_runs(path: str) -> list:
+    """Tolerant read of runs.jsonl, deduped by (run_id, skill) latest-wins.
+
+    Skips blank lines, malformed JSON, and a partial trailing line (no
+    terminating newline) — same tolerance as scripts/ledger_reduce.reduce.
+    Missing file -> []. runs.jsonl is already deduped at write time (L-2), but
+    we dedup defensively here: later file positions win.
+    """
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, "rb") as f:
+            raw = f.read()
+    except OSError:
+        return []
+    if not raw:
+        return []
+
+    parts = raw.split(b"\n")
+    if not raw.endswith(b"\n"):
+        # Last element is a partial trailing line (crash-mid-append) — drop it.
+        parts = parts[:-1]
+
+    by_key = {}  # (run_id, skill) -> entry; later positions overwrite earlier
+    order = []   # preserve first-seen order of keys for stable output
+    for chunk in parts:
+        if not chunk:
+            continue
+        try:
+            obj = json.loads(chunk)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        key = (obj.get("run_id"), obj.get("skill"))
+        if key not in by_key:
+            order.append(key)
+        by_key[key] = obj
+    return [by_key[k] for k in order]
+
+
+# --------------------------------------------------------------------------- #
+# ISO week                                                                    #
+# --------------------------------------------------------------------------- #
+
+def iso_week(entry: dict) -> str:
+    """Return "YYYY-Www" from the entry's ISO-8601 `timestamp`.
+
+    Handles a trailing `Z` (UTC). Uses datetime.isocalendar(), whose week year
+    can differ from the calendar year near year boundaries — that is correct
+    ISO-8601 behavior.
+    """
+    ts = entry.get("timestamp") or ""
+    dt = _dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    iso = dt.isocalendar()
+    return f"{iso.year:04d}-W{iso.week:02d}"
+
+
+# --------------------------------------------------------------------------- #
+# Headline + stats                                                            #
+# --------------------------------------------------------------------------- #
+
+def _is_forward(entry: dict) -> bool:
+    """Forward-captured: not backfilled AND has a real severity_histogram.
+
+    Per §4a the inflation baseline and raw rates use ONLY these entries.
+    """
+    return (entry.get("backfilled") is not True
+            and entry.get("severity_histogram") is not None)
+
+
+def caught_count(entries: list) -> int:
+    """THE headline. Count of WHS==True entries, EXCLUDING backfilled ones.
+
+    Per L-3/L-5: backfilled entries (WHS null by the mechanical histogram rule)
+    are excluded; so are WHS-null/WHS-false forward entries. This is exactly
+    what T-5 asserts. The exclusion keys on `backfilled` itself, not merely on
+    WHS being null — a pathological backfilled entry with WHS forced True is
+    still excluded.
+    """
+    n = 0
+    for e in entries:
+        if e.get("backfilled") is True:
+            continue
+        if e.get("would_have_shipped_without_gate") is True:
+            n += 1
+    return n
+
+
+def _verdict_breakdown(entries: list) -> dict:
+    counts = {}
+    for e in entries:
+        v = e.get("verdict") or "UNKNOWN"
+        counts[v] = counts.get(v, 0) + 1
+    return counts
+
+
+def week_summary(entries: list) -> dict:
+    """Per-week stats: totals, verdict breakdown, caught_count, per-skill rates.
+
+    Per-skill `significant_rate` and `fatal_rate` are computed FROM
+    FORWARD-CAPTURED ENTRIES ONLY (backfilled excluded, severity_histogram
+    not null). The backfilled count is reported separately.
+    """
+    per_skill = {}
+    backfilled = 0
+    for e in entries:
+        skill = e.get("skill") or "unknown"
+        slot = per_skill.setdefault(
+            skill,
+            {"findings": 0, "fatal": 0, "significant": 0,
+             "significant_rate": 0.0, "fatal_rate": 0.0, "forward_entries": 0},
+        )
+        if e.get("backfilled") is True:
+            backfilled += 1
+            continue
+        if not _is_forward(e):
+            # forward but null histogram (shouldn't happen for non-backfilled,
+            # but be safe) — not a measurable severity sample.
+            continue
+        hist = e["severity_histogram"]
+        f = int(hist.get("fatal", 0) or 0)
+        s = int(hist.get("significant", 0) or 0)
+        m = int(hist.get("minor", 0) or 0)
+        nt = int(hist.get("nit", 0) or 0)
+        slot["findings"] += f + s + m + nt
+        slot["fatal"] += f
+        slot["significant"] += s
+        slot["forward_entries"] += 1
+
+    for slot in per_skill.values():
+        total = slot["findings"]
+        if total > 0:
+            slot["significant_rate"] = slot["significant"] / total
+            slot["fatal_rate"] = slot["fatal"] / total
+        else:
+            slot["significant_rate"] = 0.0
+            slot["fatal_rate"] = 0.0
+
+    return {
+        "total_runs": len(entries),
+        "verdicts": _verdict_breakdown(entries),
+        "caught_count": caught_count(entries),
+        "backfilled": backfilled,
+        "per_skill": per_skill,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Inflation detector (§4a)                                                    #
+# --------------------------------------------------------------------------- #
+
+def inflation_alert(per_skill_rates: dict, baseline_medians: dict) -> list:
+    """§4a structural inflation-detector.
+
+    Alert when a skill's `significant_rate` > 3x its 4-week rolling median, OR
+    `fatal_rate` > 3x its rolling median. SILENT for a skill until 4 weeks of
+    forward data exist for it (so for v1, with no forward history, this returns
+    []). Raw rates are always computed and printed regardless — see
+    render_week — but the ALERT only fires once the baseline is armed.
+
+    `baseline_medians` maps skill -> {"significant_median", "fatal_median",
+    "weeks"}. A skill missing from the dict, or with weeks < 4, stays silent.
+    """
+    alerts = []
+    for skill, rates in per_skill_rates.items():
+        base = baseline_medians.get(skill)
+        if not base or base.get("weeks", 0) < MIN_BASELINE_WEEKS:
+            continue  # silent bootstrap
+        sig_med = base.get("significant_median", 0.0)
+        fat_med = base.get("fatal_median", 0.0)
+        sig = rates.get("significant_rate", 0.0)
+        fat = rates.get("fatal_rate", 0.0)
+        sig_hit = sig_med > 0 and sig > INFLATION_FACTOR * sig_med
+        fat_hit = fat_med > 0 and fat > INFLATION_FACTOR * fat_med
+        if sig_hit or fat_hit:
+            alerts.append({
+                "skill": skill,
+                "significant_rate": sig,
+                "fatal_rate": fat,
+                "significant_median": sig_med,
+                "fatal_median": fat_med,
+            })
+    return alerts
+
+
+# --------------------------------------------------------------------------- #
+# Falsification cross-link (graceful degradation)                            #
+# --------------------------------------------------------------------------- #
+
+def falsified_count(falsification_path: str) -> int:
+    """Count of distinct falsified ledger entries via the L-9 reduction.
+
+    GRACEFUL DEGRADATION: scripts.ledger_reduce.reduce() returns {} when
+    falsification.jsonl is absent (Phase 4 not built yet) -> count 0. Never
+    crashes on a missing file. Counts only entries whose reduced record has
+    `falsified == True` (other records may be unfalsifiable / not-yet-checked).
+    """
+    reduced = _falsification_reduce(falsification_path)
+    return sum(1 for rec in reduced.values() if rec.get("falsified") is True)
+
+
+# --------------------------------------------------------------------------- #
+# Commit citation (v1-schema limitation)                                      #
+# --------------------------------------------------------------------------- #
+
+def _commit_citation(entry: dict):
+    """Return a human citation string for an entry, or None if unavailable.
+
+    v1-schema LIMITATION: the schema has NO commit field — `artifact_hash` is
+    null for backfilled entries, and forward entries carry a UUIDv7 run_id with
+    no embedded commit. So:
+      - Backfilled entries (`backfill-<PR>-quality-gate`) -> cite "PR #<PR>".
+      - Forward (UUID run_id) entries -> no commit available in v1 -> None.
+    We do NOT invent commit SHAs. A future schema rev that captures the gating
+    commit can replace this with a real SHA citation.
+    """
+    run_id = entry.get("run_id") or ""
+    if entry.get("backfilled") is True and run_id.startswith("backfill-"):
+        rest = run_id[len("backfill-"):]
+        pr = rest.split("-", 1)[0]
+        if pr.isdigit():
+            return f"PR #{pr}"
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Rendering                                                                   #
+# --------------------------------------------------------------------------- #
+
+def _fmt_pct(x: float) -> str:
+    return f"{x * 100:.0f}%"
+
+
+def render_week(week: str, entries: list, *, baseline_medians=None,
+                falsified=0, is_first_of_month=False) -> str:
+    """Render the markdown report for one ISO week.
+
+    Sections: honest "caught N" headline, verdict breakdown, raw per-skill
+    rates (printed from week 1), inflation alerts (silent during bootstrap),
+    a separate backfilled-historical-context section (kept OUT of the caught
+    headline), the falsified cross-link count, and — if this is the first
+    /ledger run of the month — a monthly spot-check checklist (§4a).
+    """
+    baseline_medians = baseline_medians or {}
+    summary = week_summary(entries)
+    caught = summary["caught_count"]
+    per_skill = summary["per_skill"]
+    alerts = inflation_alert(per_skill, baseline_medians)
+
+    lines = []
+    lines.append(f"# Crucible Calibration Ledger — {week}")
+    lines.append("")
+    lines.append(f"_Generated {_dt.datetime.now(_dt.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}_")
+    lines.append("")
+
+    # Inflation alert block goes at the TOP per §4a.
+    if alerts:
+        lines.append("## ⚠ Inflation alert")
+        lines.append("")
+        for a in alerts:
+            lines.append(
+                f"- **{a['skill']}**: significant_rate={_fmt_pct(a['significant_rate'])} "
+                f"(4wk median {_fmt_pct(a['significant_median'])}), "
+                f"fatal_rate={_fmt_pct(a['fatal_rate'])} "
+                f"(4wk median {_fmt_pct(a['fatal_median'])})."
+            )
+        lines.append("")
+        lines.append(
+            "Review `highest_finding` quotes for this week to verify severities "
+            "are calibrated."
+        )
+        lines.append("")
+
+    # Headline.
+    lines.append(f"## Crucible caught {caught} silent bug{'s' if caught != 1 else ''}")
+    lines.append("")
+    lines.append(
+        f"Forward-captured runs with `would_have_shipped_without_gate: true`, "
+        f"excluding backfilled entries (the honest count, per L-3/L-5)."
+    )
+    lines.append("")
+
+    # Top-severity findings with commit citations (forward, WHS-true entries).
+    caught_entries = [
+        e for e in entries
+        if e.get("backfilled") is not True
+        and e.get("would_have_shipped_without_gate") is True
+    ]
+    if caught_entries:
+        lines.append("### Findings")
+        lines.append("")
+        for e in caught_entries:
+            hf = e.get("highest_finding") or "(no quote captured)"
+            cite = _commit_citation(e)
+            cite_str = f" — {cite}" if cite else ""
+            lines.append(f"- `{e.get('skill')}`: {hf}{cite_str}")
+        lines.append("")
+
+    # Verdict breakdown.
+    lines.append("## Verdict breakdown")
+    lines.append("")
+    lines.append(f"- Total runs this week: **{summary['total_runs']}**")
+    for verdict in sorted(summary["verdicts"]):
+        lines.append(f"- {verdict}: {summary['verdicts'][verdict]}")
+    lines.append("")
+
+    # Raw per-skill rates (printed from week 1; no alert threshold).
+    lines.append("## Per-skill severity rates (forward-captured only)")
+    lines.append("")
+    forward_skills = {
+        s: r for s, r in per_skill.items() if r["forward_entries"] > 0
+    }
+    if forward_skills:
+        lines.append("| skill | forward runs | findings | significant_rate | fatal_rate |")
+        lines.append("|-------|-------------:|---------:|-----------------:|-----------:|")
+        for skill in sorted(forward_skills):
+            r = forward_skills[skill]
+            lines.append(
+                f"| {skill} | {r['forward_entries']} | {r['findings']} | "
+                f"{_fmt_pct(r['significant_rate'])} | {_fmt_pct(r['fatal_rate'])} |"
+            )
+    else:
+        lines.append(
+            "_No forward-captured entries this week — rates unavailable. "
+            "(Backfilled entries carry `severity_histogram: null` by design.)_"
+        )
+    lines.append("")
+    lines.append(
+        "_Inflation detector is silent for a skill until 4 weeks of "
+        "forward-captured data exist for it (§4a bootstrap)._"
+    )
+    lines.append("")
+
+    # Backfilled historical context — SEPARATE from the caught headline.
+    backfilled_entries = [e for e in entries if e.get("backfilled") is True]
+    if backfilled_entries:
+        lines.append("## Backfilled historical context")
+        lines.append("")
+        lines.append(
+            f"{len(backfilled_entries)} backfilled entr"
+            f"{'y' if len(backfilled_entries) == 1 else 'ies'} this week "
+            f"(excluded from the caught headline and from severity rates; "
+            f"`severity_histogram: null` by design):"
+        )
+        lines.append("")
+        for e in backfilled_entries:
+            cite = _commit_citation(e)
+            cite_str = cite if cite else "(no PR citation)"
+            lines.append(f"- {cite_str} — `{e.get('skill')}` {e.get('verdict')}")
+        lines.append("")
+
+    # Falsified cross-link.
+    lines.append("## Falsified verdicts (cross-link)")
+    lines.append("")
+    lines.append(
+        f"Falsified ledger entries (all-time, via the L-9 reduction over "
+        f"`falsification.jsonl`): **{falsified}**."
+    )
+    if falsified == 0:
+        lines.append("")
+        lines.append(
+            "_No falsification data yet (reconciler / Phase 4 not present, or "
+            "no verdicts falsified)._"
+        )
+    lines.append("")
+
+    # Monthly spot-check checklist (§4a) — first /ledger run of the month.
+    if is_first_of_month:
+        lines.append("## Monthly spot-check")
+        lines.append("")
+        lines.append(
+            "First `/ledger` run of the month — spot-check protocol (advisory, "
+            "not blocking):"
+        )
+        lines.append("")
+        lines.append(
+            "- [ ] Spot-check 5 random `would_have_shipped_without_gate: true` "
+            "entries — do their `highest_finding` quotes match the rubric in "
+            "`skills/shared/severity-rubric.md`?"
+        )
+        lines.append(
+            "- [ ] Review any inflation alerts above for calibration drift."
+        )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                          #
+# --------------------------------------------------------------------------- #
+
+def _group_by_week(entries: list) -> dict:
+    groups = {}
+    for e in entries:
+        try:
+            wk = iso_week(e)
+        except (ValueError, TypeError):
+            continue  # unparseable timestamp -> skip (tolerant)
+        groups.setdefault(wk, []).append(e)
+    return groups
+
+
+def _week_month(week_key: str):
+    """Return the "%Y-%m" calendar month of an ISO week's Monday, or None.
+
+    The month is derived from the week's Monday (ISO weekday 1), matching how
+    the rest of the renderer locates a week in the calendar.
+    """
+    try:
+        year_s, wk_s = week_key.split("-W")
+        monday = _dt.date.fromisocalendar(int(year_s), int(wk_s), 1)
+    except (ValueError, TypeError):
+        return None
+    return monday.strftime("%Y-%m")
+
+
+def first_of_month_weeks(week_keys) -> set:
+    """Return the subset of `week_keys` that are the chronologically-EARLIEST
+    selected week in their calendar month — DETERMINISTIC from the data being
+    rendered in THIS invocation (no filesystem scan).
+
+    §4a's monthly spot-check must be idempotent: re-rendering the same corpus
+    must reproduce the same checklist placement. A mutable filesystem scan (does
+    a weekly-*.md already exist this month?) silently dropped the checklist on
+    re-render — a real regression, since the spot-check is the only drift guard
+    during the 4-week bootstrap. We instead mark exactly one week per month: the
+    earliest among the weeks selected in this invocation.
+    """
+    earliest_by_month = {}  # month -> earliest week_key seen this invocation
+    for wk in week_keys:
+        month = _week_month(wk)
+        if month is None:
+            continue
+        cur = earliest_by_month.get(month)
+        if cur is None or wk < cur:  # "YYYY-Www" sorts chronologically as text
+            earliest_by_month[month] = wk
+    return set(earliest_by_month.values())
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render the Crucible calibration ledger weekly report(s)."
+    )
+    parser.add_argument(
+        "--weeks", type=int, default=1,
+        help="number of most-recent ISO weeks to render (default: 1)",
+    )
+    parser.add_argument(
+        "--ledger", default=LEDGER_PATH,
+        help="path to runs.jsonl (default: .crucible/ledger/runs.jsonl)",
+    )
+    parser.add_argument(
+        "--falsification", default=FALSIFICATION_PATH,
+        help="path to falsification.jsonl (default: .crucible/ledger/falsification.jsonl)",
+    )
+    parser.add_argument(
+        "--out-dir", default=REPORT_DIR,
+        help="output directory for weekly-*.md (default: docs/ledger/)",
+    )
+    args = parser.parse_args(argv)
+
+    # First-time-ever: runs.jsonl MISSING -> notice + exit 0, write nothing.
+    if not os.path.exists(args.ledger):
+        print("no ledger data yet — runs.jsonl not found; nothing to render.")
+        return 0
+
+    entries = load_runs(args.ledger)
+    if not entries:
+        # File exists but is empty / all-malformed. Honest: nothing to render.
+        print("no ledger data yet — runs.jsonl has no readable entries.")
+        return 0
+
+    groups = _group_by_week(entries)
+    if not groups:
+        print("no ledger data yet — no entries with a parseable timestamp.")
+        return 0
+
+    falsified = falsified_count(args.falsification)
+
+    weeks_sorted = sorted(groups.keys(), reverse=True)  # most recent first
+    selected = weeks_sorted[: max(args.weeks, 0)]
+
+    # Deterministic, per-invocation: exactly the earliest selected week in each
+    # calendar month gets the §4a monthly spot-check checklist. Re-rendering the
+    # same corpus reproduces the same placement (no filesystem dependence).
+    first_of_month = first_of_month_weeks(selected)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    written = []
+    for wk in selected:
+        md = render_week(
+            wk, groups[wk],
+            baseline_medians={},  # v1: no forward rolling history yet -> silent
+            falsified=falsified,
+            is_first_of_month=(wk in first_of_month),
+        )
+        out_path = os.path.join(args.out_dir, f"weekly-{wk}.md")
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(md)
+        written.append(out_path)
+
+    for p in written:
+        print(f"[ledger] wrote {p}")
+    print(f"[ledger] rendered {len(written)} week(s); "
+          f"caught(total over rendered weeks)="
+          f"{sum(caught_count(groups[w]) for w in selected)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/ledger/SKILL.md
+++ b/skills/ledger/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ledger
+description: Render the Crucible calibration ledger weekly report — the honest "Crucible caught N silent bugs" headline, verdict breakdown, per-skill severity rates, and the inflation detector. Triggers on "/ledger", "weekly report", "weekly ledger", "caught N", "quality ledger", "calibration report", "render the ledger".
+origin: crucible
+---
+
+<!-- CANONICAL: shared/ledger-reduce.md -->
+
+# Ledger weekly renderer
+
+Renders `docs/ledger/weekly-YYYY-Www.md` from `.crucible/ledger/runs.jsonl`
+(plus `falsification.jsonl` for the cross-link). The SKILL.md is a thin prompt
+wrapper; the source of truth is the testable Python core at
+`scripts/render_ledger.py`.
+
+**Skill type:** Utility — direct execution, no subagent dispatch.
+
+## Trigger
+
+Manual `/ledger [--weeks N]` (default `N=1`, the most recent ISO week).
+
+## What it does
+
+Invoke the renderer directly:
+
+```
+python3 scripts/render_ledger.py --weeks N
+```
+
+That command:
+
+1. Reads `.crucible/ledger/runs.jsonl`. **First-time-ever: if the file is
+   MISSING, print "no ledger data yet" and exit 0 — do NOT write an empty
+   report.**
+2. Groups entries by ISO week (`YYYY-Www`).
+3. For each of the most-recent `N` weeks, writes `docs/ledger/weekly-YYYY-Www.md`.
+
+## Algorithm summary
+
+- **Tolerant load** (`load_runs`): skips blank / malformed / partial-trailing
+  lines, dedups defensively by `(run_id, skill)` latest-position-wins.
+- **Honest "caught N" headline** (`caught_count`): counts entries with
+  `would_have_shipped_without_gate == true`, **EXCLUDING `backfilled == true`**.
+  Backfilled entries carry `severity_histogram: null` ⇒ WHS `null` (the
+  mechanical L-3 rule) and are reported in a SEPARATE "Backfilled historical
+  context" section — never in the headline (L-5). This is what test T-5 asserts.
+- **Per-skill `significant_rate` / `fatal_rate`** (`week_summary`): computed
+  **from forward-captured entries only** (`backfilled == false` AND
+  `severity_histogram != null`). Raw rates are printed from week 1.
+- **Inflation detector (§4a)** (`inflation_alert`): alerts when a skill's
+  `significant_rate` or `fatal_rate` exceeds **3× its 4-week rolling median**.
+  **Silent for a skill until 4 weeks of forward data exist** (the v1 bootstrap
+  — with no forward history yet, the detector is silent, but raw rates still
+  print so a human can eyeball drift).
+- **Falsified cross-link** (`falsified_count`): the all-time count of falsified
+  verdicts via the **L-9 latest-entry-wins reduction** over
+  `falsification.jsonl` (`scripts.ledger_reduce.reduce`, the canonical helper
+  cited above). **Graceful degradation:** if `falsification.jsonl` is absent
+  (Phase 4 reconciler not built yet), the reduction returns `{}` ⇒ count `0`;
+  the renderer never crashes.
+- **Monthly spot-check (§4a)**: on the first `/ledger` run of a calendar month,
+  the report appends an advisory checklist prompting a spot-check of 5 random
+  `would_have_shipped_without_gate: true` entries against
+  `skills/shared/severity-rubric.md`.
+
+## Commit citations
+
+Design §4 calls for "findings with commit citations". The v1 schema has **no
+commit field** (`artifact_hash` is null for backfill). So:
+
+- **Backfilled entries** (`backfill-<PR>-quality-gate`) cite **`PR #<PR>`**,
+  extracted from the deterministic `run_id`.
+- **Forward entries** (UUIDv7 `run_id`) have no commit in v1 ⇒ the citation is
+  omitted gracefully. No SHAs are invented. A future schema rev capturing the
+  gating commit can replace this with a real SHA.
+
+## Honest-count rule (binding)
+
+The headline is `would_have_shipped_without_gate == true` **minus backfilled**.
+Backfilled entries seed the corpus but never inflate the caught-N number; they
+appear only in the separate historical-context section. Inflation drift is
+defended structurally (the 3× detector) and culturally (the monthly spot-check).


### PR DESCRIPTION
## What

Phase 5 of the Epistemics-Stack v1 plan — the **#272 keystone**. Adds the `/ledger` skill that renders the calibration ledger into `docs/ledger/weekly-YYYY-Www.md` with the honest **"Crucible caught N silent bugs"** headline. Consumes the Phase-3 backfill corpus (merged in #322).

Builds on the already-shipped write side (Phase 1, #281: `shared/ledger-append.md`, `ledger_append.py`) and the backfill (Phase 3, #322). Depends only on Phase 1 (soft) — `/calibration-reconcile` (#270, Phase 4) is *not* required; its `falsification.jsonl` cross-link degrades gracefully to 0.

## Files

- **`scripts/render_ledger.py`** — testable render core (pure stdlib). SKILL.md is a thin wrapper; this is the source of truth.
- **`skills/ledger/SKILL.md`** — `/ledger [--weeks N]` (default 1); cites `shared/ledger-reduce.md` (T-10b).
- **`eval/calibration-ledger/test-ledger-headline-t5.py`** — T-5 + 16 supporting tests (17 total).
- **`docs/ledger/weekly-2026-W{14,15,16,20,21,22}.md`** — first reports over the backfill corpus.

## Key behaviors (per design §4 / §4a)

- **Honest "caught N" headline:** counts `would_have_shipped_without_gate == true` entries **excluding `backfilled == true`** (L-3/L-5). Keys on `backfilled` identity, not just WHS-null, so a pathological backfilled-WHS-true entry is still excluded (T-5 asserts this).
- **Per-skill `significant_rate`/`fatal_rate`** from forward-captured entries only (backfilled excluded from the denominator); raw rates printed from week 1.
- **Structural inflation-detector (§4a):** alerts at 3× the 4-week rolling median; **silent until 4 forward weeks** exist per skill (so silent in v1 bootstrap).
- **Monthly spot-check:** deterministic — the chronologically-earliest *selected* week per calendar month carries the checklist. Idempotent across re-renders.
- **Graceful degradation:** missing `falsification.jsonl` → falsified count 0, no crash. Missing `runs.jsonl` → "no ledger data yet", writes nothing.

## First report (W22)

`Crucible caught 0 silent bugs` — correct and honest: all 11 corpus entries are backfilled (→ WHS-null → excluded). They appear in a separate **"Backfilled historical context"** section (PR #320/#318/#314 in W22, etc.), with a "no forward data yet (bootstrap)" rates note — so 0 reads as "no forward catches yet," not "gate broken." The first *real* forward catch will increment the headline once gating skills emit forward entries.

## Decisions flagged for review

- **Committed all 6 weekly reports** (W14–W22) rather than only the current week — gives the complete historical seed the backfill exists to provide. Reports are regenerable from `runs.jsonl` anytime.
- **`falsified_count` semantics:** counts reduced records with `falsified == true` (via the L-9 reduction), not raw lines — other reconciler records may be unfalsifiable/unchecked.
- **Commit citations:** v1 schema has no commit field, so backfilled entries cite `PR #<N>` from the run_id; forward UUID entries omit (no invented SHAs).

## Quality gate

PASS — 2 rounds (#303 cost-cap collapse). Round 1 found **1 Significant** (the monthly spot-check was non-idempotent — it scanned the mutable filesystem and vanished on re-render, dropping §4a's bootstrap drift guard) → **fixed** (deterministic `first_of_month_weeks` over the rendered selection) → round-2 fresh red-team PASS → **look-harder confirmed clean** under the tightened rubric. The gate's own ledger-emit was kill-switched (gating a ledger-feature change shouldn't add a forward entry to the committed corpus mid-PR).

## Tests

17 pass: T-5 (headline excludes backfilled, with a discriminating "sneaky backfilled-WHS-true" sub-assertion), ISO-week grouping, tolerant load, forward-only rates, inflation bootstrap silence, falsified graceful-degradation, deterministic month logic, and **idempotency across re-renders** (the regression the gate caught).

Refs #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)