### PR TITLE
docs(review-feedback): align H1 with frontmatter name

### DIFF
--- a/skills/review-feedback/SKILL.md
+++ b/skills/review-feedback/SKILL.md
@@ -3,7 +3,7 @@ name: review-feedback
 description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
 ---
 
-# Code Review Reception
+# Review Feedback
 
 ## Overview
 


### PR DESCRIPTION
One-line cosmetic fix surfaced by `/stocktake`: the skill's H1 read **"Code Review Reception"** while its frontmatter `name:` is `review-feedback`. Aligned the H1 to **"Review Feedback"** for consistency.

No behavior change. Part of the 2026-05-31 skill-health audit (all 49 skills `Keep`; this was the only actionable polish item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)