### PR TITLE
feat(#270): /calibration-reconcile skill (walkback + cross-cut + manual override + Brier classifier; T-2/T-3/T-6/T-11)

### DIFF
--- a/eval/calibration-ledger/test-brier-classifier-t11.py
+++ b/eval/calibration-ledger/test-brier-classifier-t11.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""T-11: Brier verdict-type classifier + polarity.
+
+Fixture A: 1 PASS (not falsified) + 1 FAIL (no predicate) + 1 each of
+  STAGNATION / ESCALATED / ARCHITECTURAL / SUSTAINED_REGRESSION, all
+  confidence:0.9, backfilled:false, cross_cut:false, artifact_type:"code",
+  timestamps >30d before now.
+  Assert: (a) denominator n == 2 (only PASS+FAIL); (b) both have actual=1;
+  (c) brier == (0.9-1)**2 == 0.01 exact.
+
+Fixture B: a single PASS, confidence:0.9, WITH a falsification.jsonl entry
+  (cross_cut:false) marking it falsified within window -> actual=0 ->
+  brier == (0.9-0)**2 == 0.81 exact when it's the only entry.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _entry(run_id, verdict, **kw):
+    base = {
+        "schema_version": 2, "run_id": run_id, "skill": "quality-gate",
+        "artifact_type": "code", "verdict": verdict, "confidence": 0.9,
+        "gated_files": ["src/foo.py"],
+        "timestamp": "2026-01-01T00:00:00Z",  # >30d before 2026-03-01
+        "backfilled": False, "falsified": None, "falsified_by": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_fixture_a_classifier():
+    from scripts.reconcile_ledger import compute_brier
+    entries = [
+        _entry("r-pass", "PASS"),
+        _entry("r-fail", "FAIL"),
+        _entry("r-stag", "STAGNATION"),
+        _entry("r-esc", "ESCALATED"),
+        _entry("r-arch", "ARCHITECTURAL"),
+        _entry("r-reg", "SUSTAINED_REGRESSION"),
+    ]
+    brier = compute_brier(entries, {}, now="2026-03-01T00:00:00Z")
+    qg = brier.get("quality-gate", {})
+    _check("T-11.A1 denominator n == 2 (only PASS+FAIL)",
+           qg.get("n") == 2, f"got {qg}")
+    # actual=1 for both -> brier = (0.9-1)^2 = 0.01
+    _check("T-11.A2 brier == 0.01 exact",
+           qg.get("n") == 2 and abs(qg.get("brier", -1) - 0.01) < 1e-9,
+           f"got {qg.get('brier')}")
+
+
+def test_fixture_b_falsified_pass():
+    from scripts.reconcile_ledger import compute_brier, ledger_entry_hash
+    entries = [_entry("r-onlypass", "PASS")]
+    h = ledger_entry_hash("r-onlypass", "quality-gate")
+    # Reduced falsification map: this PASS was marked falsified, cross_cut false.
+    fmap = {h: {"ledger_entry_hash": h, "falsified": True, "cross_cut": False}}
+    brier = compute_brier(entries, fmap, now="2026-03-01T00:00:00Z")
+    qg = brier.get("quality-gate", {})
+    _check("T-11.B1 denominator n == 1", qg.get("n") == 1, f"got {qg}")
+    # actual=0 -> brier = (0.9-0)^2 = 0.81
+    _check("T-11.B2 brier == 0.81 exact",
+           qg.get("n") == 1 and abs(qg.get("brier", -1) - 0.81) < 1e-9,
+           f"got {qg.get('brier')}")
+
+
+def main():
+    test_fixture_a_classifier()
+    test_fixture_b_falsified_pass()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-brier-grace-failclosed-s1.py
+++ b/eval/calibration-ledger/test-brier-grace-failclosed-s1.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""S-1 regression: Brier grace filter fails CLOSED on unparseable `now`.
+
+When `_parse_iso(now)` cannot parse, age cannot be evaluated, so the falsifiable
+sample is empty — compute_brier returns {} rather than admitting (fail-open)
+verdicts younger than the grace period.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _entry(run_id, verdict="PASS", **kw):
+    base = {
+        "schema_version": 2, "run_id": run_id, "skill": "quality-gate",
+        "artifact_type": "code", "verdict": verdict, "confidence": 0.9,
+        "gated_files": ["src/foo.py"], "timestamp": "2026-01-01T00:00:00Z",
+        "backfilled": False, "falsified": None, "falsified_by": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_unparseable_now_returns_empty():
+    from scripts.reconcile_ledger import compute_brier
+    # These entries WOULD qualify under a valid `now` far in the future.
+    entries = [_entry("r-a", "PASS"), _entry("r-b", "FAIL")]
+    # Sanity: with a valid `now` these are admitted (n==2).
+    valid = compute_brier(entries, {}, now="2026-06-01T00:00:00Z")
+    _check("S-1.0 sanity: valid now admits the sample (n==2)",
+           valid.get("quality-gate", {}).get("n") == 2, f"got {valid}")
+    # Fail-closed: unparseable now -> {}.
+    out = compute_brier(entries, {}, now="not-a-date")
+    _check("S-1.1 unparseable now -> {} (fail-closed)", out == {},
+           f"got {out}")
+    # Other unparseable forms.
+    for bad in ["", "2026-13-99", "yesterday", None]:
+        o = compute_brier(entries, {}, now=bad)
+        _check(f"S-1.2 unparseable now ({bad!r}) -> {{}}", o == {}, f"got {o}")
+
+
+def main():
+    test_unparseable_now_returns_empty()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-cross-cut-bootstrap.py
+++ b/eval/calibration-ledger/test-cross-cut-bootstrap.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Cross-cut detector bootstrap + denominator exclusion.
+
+- cross_cut_threshold_from(sizes) returns 20 when < 30 samples.
+- returns the p90 when >= 30 samples (a known list whose p90 != 20).
+- A candidate with len(touched_files) > threshold is tagged cross_cut: true and
+  is EXCLUDED from the Brier denominator.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def test_bootstrap_under_30():
+    from scripts.reconcile_ledger import cross_cut_threshold_from
+    sizes = [100] * 10  # only 10 samples
+    t = cross_cut_threshold_from(sizes)
+    _check("CC.1 <30 samples -> bootstrap 20", t == 20, f"got {t}")
+    _check("CC.2 empty -> bootstrap 20", cross_cut_threshold_from([]) == 20,
+           f"got {cross_cut_threshold_from([])}")
+
+
+def test_p90_at_or_above_30():
+    from scripts.reconcile_ledger import cross_cut_threshold_from
+    # 30 samples: 1..30. p90 (nearest-rank: ceil(0.9*30)=27th value) = 27.
+    # Whatever the exact percentile convention, it must be != 20 and within range.
+    sizes = list(range(1, 31))
+    t = cross_cut_threshold_from(sizes)
+    _check("CC.3 >=30 samples -> p90 (not the bootstrap 20)", t != 20,
+           f"got {t}")
+    _check("CC.4 p90 in plausible upper range (>=25)", t >= 25, f"got {t}")
+
+
+def test_cross_cut_tag_and_denominator_exclusion():
+    from scripts.reconcile_ledger import reconcile, compute_brier, ledger_entry_hash, load_jsonl
+    tmp = tempfile.mkdtemp(prefix="cc-")
+    try:
+        ledger = os.path.join(tmp, "runs.jsonl")
+        fals = os.path.join(tmp, "falsification.jsonl")
+        manual = os.path.join(tmp, "manual-attribution.jsonl")
+        # A forward PASS verdict, old enough to be falsifiable.
+        entry = {
+            "schema_version": 2, "run_id": "run-CC", "skill": "quality-gate",
+            "artifact_type": "code", "verdict": "PASS", "confidence": 0.9,
+            "gated_files": ["src/foo.py"], "timestamp": "2026-01-01T00:00:00Z",
+            "backfilled": False, "falsified": None, "falsified_by": None,
+        }
+        _write_jsonl(ledger, [entry])
+        threshold = 5
+        # Candidate touching 6 files > threshold 5 -> cross_cut: true
+        candidates = [{
+            "commit": "bigfix",
+            "touched_files": ["src/foo.py", "a", "b", "c", "d", "e"],
+            "merge_time": "2026-01-08T00:00:00Z",
+        }]
+        appended = reconcile(
+            ledger, fals, manual, candidates,
+            cross_cut_threshold=threshold, lookback_days=30,
+            now="2026-03-01T00:00:00Z",
+        )
+        match = [e for e in appended if e.get("ledger_entry_hash") ==
+                 ledger_entry_hash("run-CC", "quality-gate")]
+        _check("CC.5 cross-cut candidate still produces an entry",
+               len(match) == 1, f"got {len(match)}")
+        if match:
+            _check("CC.6 entry tagged cross_cut: true",
+                   match[0].get("cross_cut") is True,
+                   f"got {match[0].get('cross_cut')}")
+
+        # Now Brier: the cross-cut falsification must be excluded from the
+        # denominator -> this skill has n == 0 falsifiable verdicts.
+        from scripts.ledger_reduce import reduce
+        fmap = reduce(fals)
+        entries = load_jsonl(ledger)
+        brier = compute_brier(entries, fmap, now="2026-03-01T00:00:00Z")
+        n = brier.get("quality-gate", {}).get("n", None)
+        _check("CC.7 cross-cut verdict excluded from Brier denominator (n==0)",
+               n == 0 or "quality-gate" not in brier,
+               f"got brier={brier}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    test_bootstrap_under_30()
+    test_p90_at_or_above_30()
+    test_cross_cut_tag_and_denominator_exclusion()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-fix-merge-subject-s4.py
+++ b/eval/calibration-ledger/test-fix-merge-subject-s4.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""S-4 regression: _is_fix_merge_subject anchors on a branch boundary.
+
+True for fix/* and hotfix/* branch refs; False for prefix/, affix/, suffix/
+where the token is mid-word. Pure — no git.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def test_subject_matching():
+    from scripts.reconcile_ledger import _is_fix_merge_subject
+    truthy = [
+        "Merge branch 'fix/auth'",
+        "Merge pull request #3 from o/hotfix/x",
+        "fix/at-start",                       # start-of-string
+        'Merge "fix/quoted"',                 # after a quote
+        "Merge branch 'HOTFIX/Upper'",        # case-insensitive
+    ]
+    falsy = [
+        "Merge ... from o/prefix/thing",      # 'e' before fix
+        ".../feature/affix/x",                # 'f' before fix
+        "Merge branch 'suffix/y'",            # 's' before fix
+        "Merge branch 'feature/auth'",        # no fix at all
+        "",                                   # empty
+    ]
+    for s in truthy:
+        _check(f"S-4.T {s!r} -> True", _is_fix_merge_subject(s) is True,
+               f"got {_is_fix_merge_subject(s)}")
+    for s in falsy:
+        _check(f"S-4.F {s!r} -> False", _is_fix_merge_subject(s) is False,
+               f"got {_is_fix_merge_subject(s)}")
+
+
+def main():
+    test_subject_matching()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-manual-creates-attribution-s3.py
+++ b/eval/calibration-ledger/test-manual-creates-attribution-s3.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""S-3 regression: manual attribution is authoritative and can CREATE a match.
+
+A manual-attribution entry for a hash the algorithm does NOT match (candidate
+touches unrelated files) STILL produces a falsification entry reflecting the
+manual fields. Manual is read FIRST and overrides the algorithm.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def test_manual_creates_attribution():
+    from scripts.reconcile_ledger import reconcile, ledger_entry_hash
+    tmp = tempfile.mkdtemp(prefix="s3-")
+    try:
+        ledger = os.path.join(tmp, "runs.jsonl")
+        fals = os.path.join(tmp, "falsification.jsonl")
+        manual = os.path.join(tmp, "manual-attribution.jsonl")
+        # A ledger entry the algorithm would NOT match (candidate touches an
+        # unrelated file). The entry itself need not even be present in the
+        # ledger — manual attribution is keyed purely by hash.
+        _write_jsonl(ledger, [{
+            "schema_version": 2, "run_id": "rNoMatch", "skill": "quality-gate",
+            "artifact_type": "code", "verdict": "PASS", "confidence": 0.9,
+            "gated_files": ["src/unrelated.py"], "timestamp": "2026-01-01T00:00:00Z",
+            "backfilled": False,
+        }])
+        h = ledger_entry_hash("rNoMatch", "quality-gate")
+        _write_jsonl(manual, [{
+            "ledger_entry_hash": h,
+            "falsified": True,
+            "confidence": "medium",
+            "reasoning": "human spotted a missed false-positive",
+            "cross_cut": False,
+        }])
+        # Candidate touches a file with NO overlap -> algorithm matches nothing.
+        candidates = [{
+            "commit": "deadbeef",
+            "touched_files": ["src/totally_other.py"],
+            "merge_time": "2026-02-01T00:00:00Z",
+        }]
+        appended = reconcile(
+            ledger, fals, manual, candidates,
+            cross_cut_threshold=20, lookback_days=30,
+            now="2026-05-01T00:00:00Z",
+        )
+        match = [e for e in appended if e.get("ledger_entry_hash") == h]
+        _check("S-3.1 manual entry produced despite no algorithm match",
+               len(match) == 1, f"got {len(match)} of {len(appended)}")
+        if match:
+            e = match[0]
+            _check("S-3.2 manual falsified preserved", e.get("falsified") is True,
+                   f"got {e.get('falsified')}")
+            _check("S-3.3 manual confidence preserved",
+                   e.get("confidence") == "medium", f"got {e.get('confidence')}")
+            _check("S-3.4 manual reasoning preserved",
+                   "human spotted" in (e.get("reasoning") or ""),
+                   f"got {e.get('reasoning')}")
+        # No algorithmic entry should have been produced (no overlap).
+        _check("S-3.5 only the manual entry produced", len(appended) == 1,
+               f"got {len(appended)}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    test_manual_creates_attribution()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-manual-override-t6.py
+++ b/eval/calibration-ledger/test-manual-override-t6.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""T-6: manual attribution override.
+
+A manual-attribution.jsonl entry keyed by ledger_entry_hash overrides the
+algorithm's attribution. Here the algorithm would falsify (high confidence)
+but the manual override says NOT falsified (and a different confidence). Manual
+must win.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def _entry(**kw):
+    base = {
+        "schema_version": 2,
+        "run_id": "run-M",
+        "skill": "quality-gate",
+        "artifact_type": "code",
+        "verdict": "PASS",
+        "confidence": 0.9,
+        "gated_files": ["src/foo.py"],
+        "timestamp": "2026-01-01T00:00:00Z",
+        "backfilled": False,
+        "falsified": None,
+        "falsified_by": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_manual_override_wins():
+    from scripts.reconcile_ledger import reconcile, ledger_entry_hash
+    tmp = tempfile.mkdtemp(prefix="t6-")
+    try:
+        ledger = os.path.join(tmp, "runs.jsonl")
+        fals = os.path.join(tmp, "falsification.jsonl")
+        manual = os.path.join(tmp, "manual-attribution.jsonl")
+        h = ledger_entry_hash("run-M", "quality-gate")
+        _write_jsonl(ledger, [_entry(run_id="run-M", skill="quality-gate",
+                                     gated_files=["src/foo.py"])])
+        # Manual override: human reviewed, says this verdict was NOT a false
+        # positive (not falsified), overriding the algorithm.
+        _write_jsonl(manual, [{
+            "ledger_entry_hash": h,
+            "falsified": False,
+            "confidence": "high",
+            "reasoning": "human-reviewed: fix unrelated to gated change",
+            "cross_cut": False,
+        }])
+        # Candidate that WOULD trigger an algorithmic falsification (overlap +
+        # within 14d).
+        candidates = [{
+            "commit": "deadbeef",
+            "touched_files": ["src/foo.py"],
+            "merge_time": "2026-01-08T00:00:00Z",
+        }]
+        appended = reconcile(
+            ledger, fals, manual, candidates,
+            cross_cut_threshold=20, lookback_days=30,
+            now="2026-03-01T00:00:00Z",
+        )
+        # The manual override should be emitted (and win) for this hash.
+        match = [e for e in appended if e.get("ledger_entry_hash") == h]
+        _check("T-6.1 an entry exists for the overridden hash",
+               len(match) == 1, f"got {len(match)}")
+        if match:
+            e = match[0]
+            _check("T-6.2 manual override wins: falsified == False",
+                   e.get("falsified") is False, f"got {e.get('falsified')}")
+            _check("T-6.3 manual confidence wins",
+                   e.get("confidence") == "high", f"got {e.get('confidence')}")
+            _check("T-6.4 manual reasoning preserved",
+                   "human-reviewed" in (e.get("reasoning") or ""),
+                   f"got {e.get('reasoning')}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    test_manual_override_wins()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-reconciler-negative-t3.py
+++ b/eval/calibration-ledger/test-reconciler-negative-t3.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""T-3: reconciler negative case.
+
+An injected candidate touching files with NO overlap with any entry's
+`gated_files` produces NO falsification entry.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def _entry(**kw):
+    base = {
+        "schema_version": 2,
+        "run_id": "run-N",
+        "skill": "quality-gate",
+        "artifact_type": "code",
+        "verdict": "PASS",
+        "confidence": 0.9,
+        "gated_files": ["src/unrelated.py"],
+        "timestamp": "2026-01-01T00:00:00Z",
+        "backfilled": False,
+        "falsified": None,
+        "falsified_by": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_no_overlap_no_falsification():
+    from scripts.reconcile_ledger import reconcile
+    tmp = tempfile.mkdtemp(prefix="t3-")
+    try:
+        ledger = os.path.join(tmp, "runs.jsonl")
+        fals = os.path.join(tmp, "falsification.jsonl")
+        manual = os.path.join(tmp, "manual-attribution.jsonl")
+        _write_jsonl(ledger, [_entry(gated_files=["src/unrelated.py"])])
+        candidates = [{
+            "commit": "cafe1234",
+            "touched_files": ["src/totally_other.py", "docs/readme.md"],
+            "merge_time": "2026-01-05T00:00:00Z",
+        }]
+        appended = reconcile(
+            ledger, fals, manual, candidates,
+            cross_cut_threshold=20, lookback_days=30,
+            now="2026-03-01T00:00:00Z",
+        )
+        _check("T-3.1 no falsification entries appended",
+               len(appended) == 0, f"got {len(appended)}")
+        # falsification file should be empty / absent
+        exists = os.path.exists(fals)
+        lines = []
+        if exists:
+            with open(fals, encoding="utf-8") as f:
+                lines = [ln for ln in f if ln.strip()]
+        _check("T-3.2 falsification.jsonl has no entries", len(lines) == 0,
+               f"got {len(lines)}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    test_no_overlap_no_falsification()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-reconciler-positive-t2.py
+++ b/eval/calibration-ledger/test-reconciler-positive-t2.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""T-2: reconciler positive case.
+
+A forward ledger entry (backfilled:false, artifact_type:code) whose `gated_files`
+intersect an injected candidate's `touched_files`, with the candidate `merge_time`
+within 14 days AFTER the entry's `timestamp`, gets falsified with confidence: high.
+
+Drives the PURE reconcile() with an INJECTED candidate list — no real git.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def _entry(**kw):
+    base = {
+        "schema_version": 2,
+        "run_id": "run-X",
+        "skill": "quality-gate",
+        "tier": "A",
+        "artifact_type": "code",
+        "verdict": "PASS",
+        "confidence": 0.9,
+        "gated_files": ["src/foo.py"],
+        "timestamp": "2026-01-01T00:00:00Z",
+        "backfilled": False,
+        "falsified": None,
+        "falsified_by": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_positive_high_confidence():
+    from scripts.reconcile_ledger import reconcile, ledger_entry_hash
+    tmp = tempfile.mkdtemp(prefix="t2-")
+    try:
+        ledger = os.path.join(tmp, "runs.jsonl")
+        fals = os.path.join(tmp, "falsification.jsonl")
+        manual = os.path.join(tmp, "manual-attribution.jsonl")
+        _write_jsonl(ledger, [_entry(run_id="run-X", skill="quality-gate",
+                                     gated_files=["src/foo.py"],
+                                     timestamp="2026-01-01T00:00:00Z")])
+        candidates = [{
+            "commit": "deadbeef",
+            "touched_files": ["src/foo.py", "src/bar.py"],
+            # 7 days after the verdict -> within 14d -> high
+            "merge_time": "2026-01-08T00:00:00Z",
+        }]
+        appended = reconcile(
+            ledger, fals, manual, candidates,
+            cross_cut_threshold=20, lookback_days=30,
+            now="2026-03-01T00:00:00Z",
+        )
+        _check("T-2.1 exactly one falsification entry appended",
+               len(appended) == 1, f"got {len(appended)}")
+        if appended:
+            e = appended[0]
+            expect_hash = ledger_entry_hash("run-X", "quality-gate")
+            _check("T-2.2 entry hashed by run_id+skill",
+                   e.get("ledger_entry_hash") == expect_hash,
+                   f"got {e.get('ledger_entry_hash')}")
+            _check("T-2.3 falsified == true", e.get("falsified") is True,
+                   f"got {e.get('falsified')}")
+            _check("T-2.4 confidence == high", e.get("confidence") == "high",
+                   f"got {e.get('confidence')}")
+            _check("T-2.5 falsified_by.commit recorded",
+                   (e.get("falsified_by") or {}).get("commit") == "deadbeef",
+                   f"got {e.get('falsified_by')}")
+            _check("T-2.6 cross_cut false", e.get("cross_cut") is False,
+                   f"got {e.get('cross_cut')}")
+        # And it should have been written to the falsification file
+        with open(fals, encoding="utf-8") as f:
+            lines = [ln for ln in f if ln.strip()]
+        _check("T-2.7 falsification.jsonl has one line", len(lines) == 1,
+               f"got {len(lines)}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    test_positive_high_confidence()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/calibration-ledger/test-walkback-multi-verdict-s2.py
+++ b/eval/calibration-ledger/test-walkback-multi-verdict-s2.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""S-2 regression: walkback falls through to next-earliest UNSEEN verdict.
+
+E1(Jan) + E2(Feb), distinct hashes, both gate src/foo.py. candA + candB both
+touch src/foo.py and post-date both. Two distinct falsification entries must be
+produced — one for E1's hash, one for E2's — not just one (which would deflate
+the false-positive count and bias Brier optimistic).
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def _entry(run_id, ts):
+    return {
+        "schema_version": 2, "run_id": run_id, "skill": "quality-gate",
+        "artifact_type": "code", "verdict": "PASS", "confidence": 0.9,
+        "gated_files": ["src/foo.py"], "timestamp": ts,
+        "backfilled": False, "falsified": None, "falsified_by": None,
+    }
+
+
+def test_two_fixes_two_verdicts():
+    from scripts.reconcile_ledger import reconcile, ledger_entry_hash
+    tmp = tempfile.mkdtemp(prefix="s2-")
+    try:
+        ledger = os.path.join(tmp, "runs.jsonl")
+        fals = os.path.join(tmp, "falsification.jsonl")
+        manual = os.path.join(tmp, "manual-attribution.jsonl")
+        _write_jsonl(ledger, [
+            _entry("E1", "2026-01-01T00:00:00Z"),  # earliest
+            _entry("E2", "2026-02-01T00:00:00Z"),
+        ])
+        candidates = [
+            {"commit": "candA", "touched_files": ["src/foo.py"],
+             "merge_time": "2026-03-01T00:00:00Z"},
+            {"commit": "candB", "touched_files": ["src/foo.py"],
+             "merge_time": "2026-03-02T00:00:00Z"},
+        ]
+        appended = reconcile(
+            ledger, fals, manual, candidates,
+            cross_cut_threshold=20, lookback_days=30,
+            now="2026-05-01T00:00:00Z",
+        )
+        hashes = {e["ledger_entry_hash"] for e in appended}
+        hE1 = ledger_entry_hash("E1", "quality-gate")
+        hE2 = ledger_entry_hash("E2", "quality-gate")
+        _check("S-2.1 exactly two falsification entries", len(appended) == 2,
+               f"got {len(appended)}")
+        _check("S-2.2 E1 hash falsified", hE1 in hashes, f"got {hashes}")
+        _check("S-2.3 E2 hash falsified", hE2 in hashes, f"got {hashes}")
+        # candA (earlier merge) should claim E1 (earliest), candB falls through
+        # to E2.
+        by_commit = {e["falsified_by"]["commit"]: e["ledger_entry_hash"]
+                     for e in appended}
+        _check("S-2.4 candA -> E1 (earliest unseen)",
+               by_commit.get("candA") == hE1, f"got {by_commit}")
+        _check("S-2.5 candB -> E2 (next-earliest unseen)",
+               by_commit.get("candB") == hE2, f"got {by_commit}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    test_two_fixes_two_verdicts()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -24,6 +24,7 @@ import hashlib
 import json
 import math
 import os
+import re
 import sys
 from typing import Dict, List, Optional
 
@@ -191,10 +192,38 @@ def reconcile(
     indexed.sort(key=lambda pair: pair[0])
 
     appended: List[dict] = []
-    # Track hashes already falsified in THIS run so one fix doesn't double-count
-    # the same ledger entry across multiple candidates.
+    # Track hashes already attributed in THIS run so one verdict isn't
+    # double-counted. Manual entries claim their hash first (S-3), and the
+    # algorithm pass skips a verdict once attributed, falling through to the
+    # next-earliest UNSEEN overlapping verdict (S-2).
     seen_hashes = set()
 
+    # --- §3.5 manual pass FIRST (authoritative) ---------------------------- #
+    # Manual attribution is read first and overrides the algorithm. A human
+    # asserting a missed falsification (or suppressing a wrong one) is a
+    # first-class entry: we emit one falsification entry for EVERY manual
+    # attribution, regardless of whether the algorithm would have matched its
+    # hash, and reserve that hash so the algorithm pass skips it (S-3).
+    for h, mo in manual.items():
+        entry = {
+            "ledger_entry_hash": h,
+            "falsified": mo.get("falsified", True),
+            "falsified_by": mo.get("falsified_by", {
+                "commit": mo.get("commit"),
+                "reason": mo.get("reasoning", "manual attribution"),
+                "confidence": mo.get("confidence", "low"),
+                "cross_cut": mo.get("cross_cut", False),
+                "manual_override": True,
+            }),
+            "confidence": mo.get("confidence", "low"),
+            "reasoning": mo.get("reasoning", "manual attribution"),
+            "cross_cut": mo.get("cross_cut", False),
+        }
+        seen_hashes.add(h)
+        _ledger_append(falsification_path, entry)
+        appended.append(entry)
+
+    # --- §3.3/§3.4 algorithm pass ----------------------------------------- #
     for cand in candidates:
         touched = set(cand.get("touched_files") or [])
         if not touched:
@@ -202,7 +231,10 @@ def reconcile(
         merge_dt = _parse_iso(cand.get("merge_time"))
         cross_cut = len(touched) > cross_cut_threshold
 
-        # Walkback: earliest ledger entry meeting ALL §3.3 conditions.
+        # Walkback: earliest UNSEEN ledger entry meeting ALL §3.3 conditions.
+        # The seen-check is INSIDE the loop so a candidate whose earliest match
+        # is already attributed falls through to the next-earliest unseen
+        # overlapping verdict rather than being dropped entirely (S-2).
         match = None
         for ts, e in indexed:
             # (c) artifact_type == "code"
@@ -218,18 +250,20 @@ def reconcile(
             # (b) entry timestamp < candidate merge_time
             if merge_dt is not None and not (ts < merge_dt):
                 continue
-            match = (ts, e)
+            run_id = e.get("run_id", "unknown")
+            skill = e.get("skill", "unknown")
+            h = ledger_entry_hash(run_id, skill)
+            # Skip already-attributed verdicts (manual pass or a prior
+            # candidate this run); keep scanning for the next-earliest unseen.
+            if h in seen_hashes:
+                continue
+            match = (ts, e, gated, h)
             break
 
         if match is None:
             continue
 
-        ts, e = match
-        run_id = e.get("run_id", "unknown")
-        skill = e.get("skill", "unknown")
-        h = ledger_entry_hash(run_id, skill)
-        if h in seen_hashes:
-            continue
+        ts, e, gated, h = match
         seen_hashes.add(h)
 
         # §3.4 confidence
@@ -258,27 +292,6 @@ def reconcile(
             "reasoning": reason,
             "cross_cut": cross_cut,
         }
-
-        # §3.5 manual override wins (keyed by ledger_entry_hash).
-        if h in manual:
-            mo = manual[h]
-            # Manual fields override the algorithm's; preserve provenance of the
-            # candidate under falsified_by while letting the human flip verdict /
-            # confidence / cross_cut / reasoning.
-            entry["falsified"] = mo.get("falsified", entry["falsified"])
-            if "confidence" in mo:
-                entry["confidence"] = mo["confidence"]
-            if "cross_cut" in mo:
-                entry["cross_cut"] = mo["cross_cut"]
-            if "reasoning" in mo:
-                entry["reasoning"] = mo["reasoning"]
-            entry["falsified_by"] = mo.get("falsified_by", {
-                "commit": cand.get("commit"),
-                "reason": entry["reasoning"],
-                "confidence": entry["confidence"],
-                "cross_cut": entry["cross_cut"],
-                "manual_override": True,
-            })
 
         # Append-only write (L-1). The append helper honors the kill-switch and
         # the 16 KiB cap; a no-op return does not stop us from reporting the
@@ -314,9 +327,12 @@ def compute_brier(
     Returns {"<skill>": {"n": int, "brier": float, "last_updated": iso}}.
     """
     now_dt = _parse_iso(now)
-    grace_cutoff = None
-    if now_dt is not None:
-        grace_cutoff = now_dt - _dt.timedelta(days=GRACE_DAYS)
+    # Fail-CLOSED: a calibration metric must not admit verdicts whose age it
+    # cannot evaluate. If `now` is unparseable, the 30-day grace filter cannot
+    # be applied, so exclude EVERYTHING rather than fail open (S-1).
+    if now_dt is None:
+        return {}
+    grace_cutoff = now_dt - _dt.timedelta(days=GRACE_DAYS)
 
     # accumulate squared errors per skill
     acc: Dict[str, List[float]] = {}
@@ -387,6 +403,20 @@ def _git(args: List[str], cwd: Optional[str] = None) -> Optional[str]:
     return proc.stdout
 
 
+_FIX_MERGE_RE = re.compile(r"(?:^|[\s/'\"])(?:hot)?fix/", re.I)
+
+
+def _is_fix_merge_subject(subject: str) -> bool:
+    """True iff a merge-commit subject references a fix/* or hotfix/* branch.
+
+    Anchored on a branch boundary (start-of-string / whitespace / slash /
+    quote) so it matches `fix/` and `hotfix/` but NOT `prefix/`, `affix/`,
+    `suffix/` where the token is mid-word (S-4)."""
+    if not subject:
+        return False
+    return _FIX_MERGE_RE.search(subject) is not None
+
+
 def discover_candidates(lookback_days: int = 30) -> List[dict]:
     """Discover fix/* hotfix/* merges within lookback_days, plus regression
     issues with a referenced commit (best-effort).
@@ -411,8 +441,7 @@ def discover_candidates(lookback_days: int = 30) -> List[dict]:
             if len(parts) < 3:
                 continue
             sha, when, subject = parts[0], parts[1], parts[2]
-            low = subject.lower()
-            if "fix/" not in low and "hotfix/" not in low:
+            if not _is_fix_merge_subject(subject):
                 continue
             touched = _touched_files(sha)
             candidates.append({
@@ -460,7 +489,6 @@ def _git_gh_regression_commits() -> List[str]:
         issues = json.loads(proc.stdout)
     except (json.JSONDecodeError, ValueError):
         return []
-    import re
     shas: List[str] = []
     sha_re = re.compile(r"\b([0-9a-f]{7,40})\b")
     for iss in issues:
@@ -488,8 +516,7 @@ def fix_branch_sizes(days: int = 90) -> List[int]:
         if len(parts) < 2:
             continue
         sha, subject = parts[0], parts[1]
-        low = subject.lower()
-        if "fix/" not in low and "hotfix/" not in low:
+        if not _is_fix_merge_subject(subject):
             continue
         sizes.append(len(_touched_files(sha)))
     return sizes

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""`/calibration-reconcile` reconciler (#270, Epistemics Phase 4).
+
+Walks fix branches to falsify originating gating-verdicts, computes per-skill
+Brier calibration scores, and writes a falsification log.
+
+Architecture (binding):
+  - PURE core (no subprocess/git, deterministic, drives off injected data):
+      ledger_entry_hash, reconcile, compute_brier, load_jsonl,
+      read_manual_attribution
+  - GIT layer (subprocess; NOT exercised by unit tests):
+      discover_candidates, fix_branch_sizes, cross_cut_threshold_from, main
+
+Scope: design §3 steps 1-6 ONLY. The predicted-falsifier predicate parser /
+"second pass" is Phase 7 and explicitly OUT OF SCOPE here.
+
+The Brier formula `brier = mean((confidence - actual)^2)` (contract L-10).
+
+Pure stdlib. No third-party deps.
+"""
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import math
+import os
+import sys
+from typing import Dict, List, Optional
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+# L-9 canonical reduction over falsification.jsonl.
+# <!-- CANONICAL: shared/ledger-reduce.md -->
+from scripts.ledger_reduce import reduce as _falsification_reduce  # noqa: E402
+from scripts.ledger_append import (  # noqa: E402
+    append as _ledger_append,
+    default_ledger_dir,
+    default_ledger_path,
+)
+
+# 30-day grace period: a verdict must be older than this before it can be
+# falsified by a fix (so it has had a chance to be falsified) and before it is
+# admitted into the Brier sample.
+GRACE_DAYS = 30
+# Confidence-window cutoffs (design §3.4).
+HIGH_WINDOW_DAYS = 14
+MEDIUM_WINDOW_DAYS = 30
+# Bootstrap cross-cut threshold until >= 30 fix-branch samples exist (§3.2).
+BOOTSTRAP_CROSS_CUT = 20
+MIN_CROSS_CUT_SAMPLES = 30
+# Multi-file fix heuristic (§3.4 'low'): >5 touched files but <= cross-cut.
+MULTI_FILE_LOW = 5
+# Brier sample requires a calibrated verdict.
+MIN_CONFIDENCE = 0.5
+# Verdict-type classifier (T-11): only these count for Brier.
+BRIER_VERDICTS = {"PASS", "FAIL"}
+
+
+# --------------------------------------------------------------------------- #
+# Time helpers                                                                #
+# --------------------------------------------------------------------------- #
+
+def _parse_iso(ts: str) -> Optional[_dt.datetime]:
+    """Parse an ISO8601 timestamp (tolerant of a trailing 'Z'). Returns an
+    aware UTC datetime, or None when unparseable."""
+    if not ts or not isinstance(ts, str):
+        return None
+    s = ts.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = _dt.datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_dt.timezone.utc)
+    return dt.astimezone(_dt.timezone.utc)
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --------------------------------------------------------------------------- #
+# PURE core                                                                   #
+# --------------------------------------------------------------------------- #
+
+def ledger_entry_hash(run_id: str, skill: str) -> str:
+    """Stable hash over only the immutable identity fields (run_id + skill)."""
+    return hashlib.sha256((run_id + ":" + skill).encode()).hexdigest()
+
+
+def load_jsonl(path: str) -> List[dict]:
+    """Tolerant per-line JSONL read.
+
+    Skips blank/malformed lines and a trailing partial line (no terminating
+    newline). Missing file -> []. (Same tolerance as ledger_reduce.reduce.)
+    """
+    if not path or not os.path.exists(path):
+        return []
+    try:
+        with open(path, "rb") as f:
+            raw = f.read()
+    except OSError:
+        return []
+    if not raw:
+        return []
+    parts = raw.split(b"\n")
+    if not raw.endswith(b"\n"):
+        parts = parts[:-1]  # drop the partial trailing line
+    out: List[dict] = []
+    for chunk in parts:
+        if not chunk:
+            continue
+        try:
+            out.append(json.loads(chunk))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+    return out
+
+
+def read_manual_attribution(path: str) -> Dict[str, dict]:
+    """Read manual-attribution.jsonl into a dict keyed by ledger_entry_hash.
+
+    Latest file-position wins per hash (L-9 semantics). Missing file -> {}
+    (no overrides, no error).
+    """
+    out: Dict[str, dict] = {}
+    for obj in load_jsonl(path):
+        key = obj.get("ledger_entry_hash")
+        if key is None:
+            continue
+        out[key] = obj
+    return out
+
+
+def _confidence_label(days_delta: float, n_touched: int, cross_cut: bool) -> str:
+    """Confidence scoring (design §3.4).
+
+    high   : intersection >=1 AND merge within 14d AND cross_cut == False
+    medium : 14-30 days AND cross_cut == False
+    low    : >30 days OR cross_cut == True OR multi-file (>5 files but <= xcut)
+    """
+    if cross_cut:
+        return "low"
+    if days_delta > MEDIUM_WINDOW_DAYS:
+        return "low"
+    # Multi-file fixes (>5 files, but not cross-cut) downgrade to low.
+    if n_touched > MULTI_FILE_LOW:
+        return "low"
+    if days_delta <= HIGH_WINDOW_DAYS:
+        return "high"
+    return "medium"
+
+
+def reconcile(
+    ledger_path: str,
+    falsification_path: str,
+    manual_attribution_path: str,
+    candidates: List[dict],
+    *,
+    cross_cut_threshold: int,
+    lookback_days: int = 30,
+    now: str,
+) -> List[dict]:
+    """Run design §3 steps 2-5 over an INJECTED candidate list.
+
+    For each candidate, walk back to the EARLIEST forward code-verdict whose
+    gated_files intersect the candidate's touched_files and whose timestamp
+    precedes the merge. Records a falsification entry per matched ledger entry,
+    honoring manual overrides. Appends each entry (append-only, L-1/L-9) to
+    falsification_path and also returns the list of appended entries.
+
+    Returns the list of falsification entries appended (in append order).
+    """
+    now_dt = _parse_iso(now)
+    entries = load_jsonl(ledger_path)
+    manual = read_manual_attribution(manual_attribution_path)
+
+    # Pre-sort ledger entries by timestamp ascending so "earliest match" is the
+    # first qualifying entry we encounter per candidate.
+    indexed = []
+    for e in entries:
+        ts = _parse_iso(e.get("timestamp"))
+        if ts is None:
+            continue
+        indexed.append((ts, e))
+    indexed.sort(key=lambda pair: pair[0])
+
+    appended: List[dict] = []
+    # Track hashes already falsified in THIS run so one fix doesn't double-count
+    # the same ledger entry across multiple candidates.
+    seen_hashes = set()
+
+    for cand in candidates:
+        touched = set(cand.get("touched_files") or [])
+        if not touched:
+            continue
+        merge_dt = _parse_iso(cand.get("merge_time"))
+        cross_cut = len(touched) > cross_cut_threshold
+
+        # Walkback: earliest ledger entry meeting ALL §3.3 conditions.
+        match = None
+        for ts, e in indexed:
+            # (c) artifact_type == "code"
+            if e.get("artifact_type") != "code":
+                continue
+            # (d) backfilled == false
+            if e.get("backfilled"):
+                continue
+            # (a) gated_files ∩ touched_files non-empty
+            gated = set(e.get("gated_files") or [])
+            if not (gated & touched):
+                continue
+            # (b) entry timestamp < candidate merge_time
+            if merge_dt is not None and not (ts < merge_dt):
+                continue
+            match = (ts, e)
+            break
+
+        if match is None:
+            continue
+
+        ts, e = match
+        run_id = e.get("run_id", "unknown")
+        skill = e.get("skill", "unknown")
+        h = ledger_entry_hash(run_id, skill)
+        if h in seen_hashes:
+            continue
+        seen_hashes.add(h)
+
+        # §3.4 confidence
+        if merge_dt is not None:
+            days_delta = (merge_dt - ts).total_seconds() / 86400.0
+        else:
+            days_delta = float("inf")
+        confidence = _confidence_label(days_delta, len(touched), cross_cut)
+
+        reason = (
+            f"fix {cand.get('commit', '?')} touched "
+            f"{sorted(gated & touched)} gated by this verdict; merged "
+            f"{days_delta:.1f}d after the verdict"
+        )
+
+        entry = {
+            "ledger_entry_hash": h,
+            "falsified": True,
+            "falsified_by": {
+                "commit": cand.get("commit"),
+                "reason": reason,
+                "confidence": confidence,
+                "cross_cut": cross_cut,
+            },
+            "confidence": confidence,
+            "reasoning": reason,
+            "cross_cut": cross_cut,
+        }
+
+        # §3.5 manual override wins (keyed by ledger_entry_hash).
+        if h in manual:
+            mo = manual[h]
+            # Manual fields override the algorithm's; preserve provenance of the
+            # candidate under falsified_by while letting the human flip verdict /
+            # confidence / cross_cut / reasoning.
+            entry["falsified"] = mo.get("falsified", entry["falsified"])
+            if "confidence" in mo:
+                entry["confidence"] = mo["confidence"]
+            if "cross_cut" in mo:
+                entry["cross_cut"] = mo["cross_cut"]
+            if "reasoning" in mo:
+                entry["reasoning"] = mo["reasoning"]
+            entry["falsified_by"] = mo.get("falsified_by", {
+                "commit": cand.get("commit"),
+                "reason": entry["reasoning"],
+                "confidence": entry["confidence"],
+                "cross_cut": entry["cross_cut"],
+                "manual_override": True,
+            })
+
+        # Append-only write (L-1). The append helper honors the kill-switch and
+        # the 16 KiB cap; a no-op return does not stop us from reporting the
+        # in-memory entry to the caller.
+        _ledger_append(falsification_path, entry)
+        appended.append(entry)
+
+    return appended
+
+
+def compute_brier(
+    ledger_entries: List[dict],
+    falsification_map: Dict[str, dict],
+    *,
+    now: str,
+) -> Dict[str, dict]:
+    """Per-skill Brier score over the falsifiable sample.
+
+    brier = mean((confidence - actual)^2)  (contract L-10).
+
+    Falsifiable sample filters (ALL must hold):
+      - artifact_type == "code"
+      - backfilled == false
+      - verdict in {PASS, FAIL} with confidence >= 0.5  (T-11 classifier)
+      - entry older than the 30-day grace period
+      - if a matching falsification entry exists, its cross_cut must be False
+        (cross-cut excluded from the denominator)
+
+    actual = 1 iff CORRECT: a PASS NOT marked falsified, OR any FAIL (at v1
+      every FAIL => actual=1, since predicates are Phase 7).
+    actual = 0 iff WRONG: a PASS that WAS marked falsified: true.
+
+    Returns {"<skill>": {"n": int, "brier": float, "last_updated": iso}}.
+    """
+    now_dt = _parse_iso(now)
+    grace_cutoff = None
+    if now_dt is not None:
+        grace_cutoff = now_dt - _dt.timedelta(days=GRACE_DAYS)
+
+    # accumulate squared errors per skill
+    acc: Dict[str, List[float]] = {}
+
+    for e in ledger_entries:
+        if e.get("artifact_type") != "code":
+            continue
+        if e.get("backfilled"):
+            continue
+        verdict = e.get("verdict")
+        if verdict not in BRIER_VERDICTS:
+            continue
+        confidence = e.get("confidence")
+        if not isinstance(confidence, (int, float)):
+            continue
+        if confidence < MIN_CONFIDENCE:
+            continue
+        ts = _parse_iso(e.get("timestamp"))
+        if ts is None:
+            continue
+        # Must be older than the grace period.
+        if grace_cutoff is not None and not (ts < grace_cutoff):
+            continue
+
+        run_id = e.get("run_id", "unknown")
+        skill = e.get("skill", "unknown")
+        h = ledger_entry_hash(run_id, skill)
+        fals = falsification_map.get(h)
+
+        # Cross-cut falsifications are excluded from the denominator.
+        if fals is not None and fals.get("cross_cut"):
+            continue
+
+        # Determine actual.
+        if verdict == "FAIL":
+            actual = 1  # v1: every FAIL is correct (predicates are Phase 7)
+        else:  # PASS
+            falsified = bool(fals.get("falsified")) if fals is not None else False
+            actual = 0 if falsified else 1
+
+        sq_err = (float(confidence) - actual) ** 2
+        acc.setdefault(skill, []).append(sq_err)
+
+    out: Dict[str, dict] = {}
+    last = _now_iso() if now_dt is None else now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    for skill, errs in acc.items():
+        n = len(errs)
+        brier = sum(errs) / n if n else 0.0
+        out[skill] = {"n": n, "brier": brier, "last_updated": last}
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# GIT layer (subprocess; NOT exercised by unit tests)                         #
+# --------------------------------------------------------------------------- #
+
+def _git(args: List[str], cwd: Optional[str] = None) -> Optional[str]:
+    """Run a git command; return stdout (stripped) or None on any failure."""
+    import subprocess
+    try:
+        proc = subprocess.run(
+            ["git"] + args, capture_output=True, text=True, timeout=30, cwd=cwd,
+        )
+    except Exception:  # noqa: BLE001 — git is best-effort
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def discover_candidates(lookback_days: int = 30) -> List[dict]:
+    """Discover fix/* hotfix/* merges within lookback_days, plus regression
+    issues with a referenced commit (best-effort).
+
+    Each candidate: {"commit", "touched_files": [...], "merge_time": iso}.
+    """
+    candidates: List[dict] = []
+    since = (
+        _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=lookback_days)
+    ).strftime("%Y-%m-%d")
+
+    # Merge commits whose merged branch matches fix/* or hotfix/*. We look at
+    # merge commits in the lookback window and inspect the merge subject for a
+    # fix/hotfix branch name.
+    log = _git([
+        "log", "--merges", f"--since={since}",
+        "--pretty=format:%H%x1f%cI%x1f%s",
+    ])
+    if log:
+        for line in log.splitlines():
+            parts = line.split("\x1f")
+            if len(parts) < 3:
+                continue
+            sha, when, subject = parts[0], parts[1], parts[2]
+            low = subject.lower()
+            if "fix/" not in low and "hotfix/" not in low:
+                continue
+            touched = _touched_files(sha)
+            candidates.append({
+                "commit": sha,
+                "touched_files": touched,
+                "merge_time": when,
+            })
+
+    # regression-labelled closed issues with a referenced commit (best-effort).
+    gh = _git_gh_regression_commits()
+    for sha in gh:
+        touched = _touched_files(sha)
+        when = _git(["show", "-s", "--format=%cI", sha])
+        candidates.append({
+            "commit": sha,
+            "touched_files": touched,
+            "merge_time": (when or "").strip(),
+        })
+
+    return candidates
+
+
+def _touched_files(sha: str) -> List[str]:
+    out = _git(["show", "--name-only", "--pretty=format:", sha])
+    if not out:
+        return []
+    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+
+
+def _git_gh_regression_commits() -> List[str]:
+    """Best-effort: closed issues labelled `regression` with a referenced
+    commit, via the `gh` CLI. If gh is unavailable, skip silently."""
+    import subprocess
+    try:
+        proc = subprocess.run(
+            ["gh", "issue", "list", "--state", "closed", "--label",
+             "regression", "--json", "body,title", "--limit", "100"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except Exception:  # noqa: BLE001 — gh optional
+        return []
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return []
+    try:
+        issues = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    import re
+    shas: List[str] = []
+    sha_re = re.compile(r"\b([0-9a-f]{7,40})\b")
+    for iss in issues:
+        text = (iss.get("body") or "") + " " + (iss.get("title") or "")
+        for m in sha_re.findall(text):
+            shas.append(m)
+    return shas
+
+
+def fix_branch_sizes(days: int = 90) -> List[int]:
+    """Touched-file counts of fix/hotfix merges over the prior `days` (a
+    DISTINCT 90-day window from the 30-day candidate lookback)."""
+    since = (
+        _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=days)
+    ).strftime("%Y-%m-%d")
+    log = _git([
+        "log", "--merges", f"--since={since}",
+        "--pretty=format:%H%x1f%s",
+    ])
+    sizes: List[int] = []
+    if not log:
+        return sizes
+    for line in log.splitlines():
+        parts = line.split("\x1f")
+        if len(parts) < 2:
+            continue
+        sha, subject = parts[0], parts[1]
+        low = subject.lower()
+        if "fix/" not in low and "hotfix/" not in low:
+            continue
+        sizes.append(len(_touched_files(sha)))
+    return sizes
+
+
+def cross_cut_threshold_from(sizes: List[int]) -> int:
+    """p90 of `sizes` when len(sizes) >= 30, else the bootstrap fixed 20 (§3.2)."""
+    if len(sizes) < MIN_CROSS_CUT_SAMPLES:
+        return BOOTSTRAP_CROSS_CUT
+    ordered = sorted(sizes)
+    # Nearest-rank percentile: rank = ceil(0.9 * N), 1-indexed.
+    rank = max(1, math.ceil(0.9 * len(ordered)))
+    return int(ordered[rank - 1])
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # L-6 kill-switch: graceful no-op exit BEFORE any work.
+    if os.environ.get("CRUCIBLE_CALIBRATION_DISABLED") == "1":
+        print("[calibration-reconcile] calibration disabled; reconcile skipped",
+              file=sys.stderr)
+        return 0
+
+    ledger_dir = default_ledger_dir()
+    parser = argparse.ArgumentParser(description="calibration reconciler (#270)")
+    parser.add_argument("--lookback-days", type=int, default=30)
+    parser.add_argument("--ledger", default=default_ledger_path())
+    parser.add_argument("--falsification",
+                        default=os.path.join(ledger_dir, "falsification.jsonl"))
+    parser.add_argument("--manual-attribution",
+                        default=os.path.join(ledger_dir, "manual-attribution.jsonl"))
+    parser.add_argument("--brier-out",
+                        default=os.path.join(ledger_dir, "brier-rolling.json"))
+    args = parser.parse_args(argv)
+
+    now = _now_iso()
+
+    # §3.1 candidate discovery + §3.2 cross-cut threshold (distinct 90d window).
+    candidates = discover_candidates(lookback_days=args.lookback_days)
+    threshold = cross_cut_threshold_from(fix_branch_sizes(days=90))
+
+    appended = reconcile(
+        args.ledger, args.falsification, args.manual_attribution, candidates,
+        cross_cut_threshold=threshold, lookback_days=args.lookback_days, now=now,
+    )
+
+    # Recompute Brier over the full ledger + reduced falsification map.
+    fmap = _falsification_reduce(args.falsification)
+    entries = load_jsonl(args.ledger)
+    brier = compute_brier(entries, fmap, now=now)
+
+    # Write brier-rolling.json (gitignored).
+    try:
+        os.makedirs(os.path.dirname(args.brier_out) or ".", exist_ok=True)
+        with open(args.brier_out, "w", encoding="utf-8") as f:
+            json.dump(brier, f, indent=2, sort_keys=True)
+            f.write("\n")
+    except OSError as e:
+        print(f"[calibration-reconcile] could not write brier-rolling.json: {e}",
+              file=sys.stderr)
+
+    print(f"[calibration-reconcile] candidates={len(candidates)} "
+          f"cross_cut_threshold={threshold} falsified+={len(appended)} "
+          f"skills_scored={len(brier)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/calibration-reconcile/SKILL.md
+++ b/skills/calibration-reconcile/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: calibration-reconcile
+description: Reconcile the Crucible calibration ledger — walk merged fix/hotfix branches to falsify the originating gating-verdicts, compute per-skill Brier calibration scores, and append a falsification log. Triggers on "/calibration-reconcile", "reconcile ledger", "reconcile calibration", "falsify verdicts", "brier score", "calibration reconcile", "compute brier".
+origin: crucible
+---
+
+<!-- CANONICAL: shared/ledger-reduce.md -->
+
+# Calibration reconciler
+
+Walks fix branches to **falsify** the gating-verdicts that should have caught
+the bug, computes per-skill **Brier calibration scores**, and writes a
+falsification log to the **central ledger** `~/.claude/crucible/ledger/`
+(override `CRUCIBLE_LEDGER_DIR`). The SKILL.md is a thin prompt wrapper; the
+source of truth is the testable Python core at `scripts/reconcile_ledger.py`.
+
+**Skill type:** Utility — direct execution, no subagent dispatch.
+
+## Trigger
+
+Manual `/calibration-reconcile [--lookback-days N]` (default `N=30`).
+
+## Kill-switch
+
+If `CRUCIBLE_CALIBRATION_DISABLED=1`, the CLI **skips entirely** (graceful
+no-op exit 0) before any git or filesystem work. The forward-capture path
+(`scripts/ledger_append.py`) honors the same switch, so the whole calibration
+subsystem can be disabled with one env var.
+
+## What it does
+
+Invoke the reconciler directly. Resolve `scripts/reconcile_ledger.py` by
+**absolute path** from the plugin root (it self-locates its own modules via
+`__file__`, so no `PYTHONPATH` is needed and it runs from any cwd):
+
+```
+python3 <plugin_root>/scripts/reconcile_ledger.py --lookback-days 30
+```
+
+It reads `runs.jsonl` and `manual-attribution.jsonl` from the central store and
+**writes** `falsification.jsonl` (append-only, L-1/L-9) + `brier-rolling.json`
+(gitignored) into that SAME dir.
+
+## Algorithm (design §3 steps 1–6)
+
+> Scope limit: this implements steps 1–6 ONLY. The predicted-falsifier
+> predicate parser / "second pass" is **Phase 7 and explicitly out of scope**.
+
+1. **Candidate set** (git layer, `discover_candidates`): `fix/*` `hotfix/*`
+   branches merged in the last `--lookback-days` (default 30) + `regression`-
+   labelled closed issues with a referenced commit (best-effort; if `gh` is
+   unavailable, skip silently). Each candidate carries `touched_files` (from
+   `git show --name-only <merge-sha>`) and `merge_time`.
+2. **Cross-cut detector** (`cross_cut_threshold_from`): threshold = **p90 of
+   fix-branch sizes over the prior 90 days** (a DISTINCT window from the 30-day
+   candidate lookback); **bootstrap to a fixed 20** until ≥30 samples exist. A
+   candidate with `len(touched_files) > threshold` is tagged `cross_cut: true`.
+   Cross-cut candidates may still get a `confidence: low` attribution but are
+   **EXCLUDED from the Brier denominator**.
+3. **Walkback** (`reconcile`): for each candidate, find the **EARLIEST** ledger
+   entry where ALL of: (a) `gated_files ∩ touched_files` non-empty, (b) entry
+   `timestamp` < candidate `merge_time`, (c) `artifact_type == "code"`, (d)
+   `backfilled == false`. If found, record a falsification entry marking it
+   `falsified: true` with `falsified_by: {commit, reason, confidence, cross_cut}`.
+4. **Confidence scoring:** `high` when intersection ≥1 file AND merge within 14
+   days of the verdict AND `cross_cut == false`; `medium` when 14–30 days AND
+   `cross_cut == false`; `low` when >30 days OR `cross_cut == true` OR
+   multi-file fixes (>5 files but ≤ the cross-cut threshold).
+5. **Manual override** (`read_manual_attribution`): read
+   `manual-attribution.jsonl` **first**; entries there (keyed by
+   `ledger_entry_hash`) override the algorithm's attribution. Missing file ⇒
+   empty overrides (no error).
+6. **Kill-switch:** see above — `CRUCIBLE_CALIBRATION_DISABLED=1` ⇒ no-op exit.
+
+## Brier scoring (contract L-10)
+
+Per-skill calibration is the Brier score over each skill's **falsifiable
+sample**:
+
+```
+brier = mean((confidence - actual)^2)
+```
+
+- **actual = 1** iff the verdict was CORRECT: a `PASS` NOT marked falsified, OR
+  any `FAIL` (at v1 every FAIL ⇒ actual=1, since predicted-falsifier predicates
+  are Phase 7).
+- **actual = 0** iff WRONG: a `PASS` that WAS marked `falsified: true` (looked
+  up in the **L-9 latest-entry-wins reduction** over `falsification.jsonl` via
+  `scripts.ledger_reduce.reduce`, the canonical helper cited above).
+- **Falsifiable sample filters (ALL must hold):** `artifact_type == "code"`;
+  `backfilled == false`; `verdict ∈ {PASS, FAIL}` with `confidence >= 0.5`;
+  entry older than the 30-day grace period; AND if a matching falsification
+  entry exists, its `cross_cut` must be `false`.
+- **Verdict-type classifier (T-11):** only `PASS`/`FAIL` count. `STAGNATION`,
+  `ESCALATED`, `ARCHITECTURAL`, `SUSTAINED_REGRESSION` are excluded from both
+  numerator AND denominator.
+- Skills with **<5 falsifiable verdicts** are excluded from the advisory (we
+  still compute `n`; just don't gate). The advisory threshold is `brier > 0.25`
+  (consumed in Phase 6 — here we only compute and store).
+
+## Outputs
+
+- **`falsification.jsonl`** — APPEND-ONLY (L-1/L-9). Each entry:
+  `{ledger_entry_hash, falsified, falsified_by, confidence, reasoning, cross_cut}`.
+- **`brier-rolling.json`** (gitignored) —
+  `{"<skill>": {"n": int, "brier": float, "last_updated": "<iso>"}, ...}`.


### PR DESCRIPTION
## Epistemics Phase 4 — `/calibration-reconcile` (#270)

Implements the reconciler that closes the calibration loop: walks fix branches to falsify originating gating-verdicts, computes per-skill Brier calibration scores, and writes an append-only falsification log. This lights up `/ledger`'s falsified cross-link (which has degraded to 0 since Phase 5 shipped without a reconciler).

Follows the finalized, pre-gated design §3 (steps 1–6) + Brier formal definition / contract L-9, L-10. **Scope: steps 1–6 only** — the §3a predicted-falsifier second pass is Phase 7 and explicitly out of scope.

### What it does
- **`scripts/reconcile_ledger.py`** — pure-stdlib reconciler. PURE core (deterministic, injected-data) + git-discovery layer + CLI.
  - **Candidate set:** `fix/*`/`hotfix/*` merges in last `--lookback-days` (default 30) + regression-labelled issues (best-effort `gh`).
  - **Cross-cut detector:** p90 of fix-branch sizes over the prior **90 days** (distinct window), bootstrap to fixed 20 until ≥30 samples; cross-cut candidates excluded from the Brier denominator.
  - **Walkback:** earliest *unseen* ledger entry where gated∩touched ≠ ∅, `timestamp < merge_time`, `artifact_type=="code"`, `backfilled==false`.
  - **Confidence:** high/medium/low per §3.4.
  - **Manual override:** `manual-attribution.jsonl` is a first-class FIRST pass — authoritative even when the algorithm matched nothing.
  - **Brier:** `mean((confidence − actual)^2)` with the L-10 polarity (actual=1 iff CORRECT); verdict-type classifier counts only PASS/FAIL (escalation verdicts excluded); fail-closed on unparseable `now`.
  - **Kill-switch:** `CRUCIBLE_CALIBRATION_DISABLED=1` → graceful no-op.
- **`skills/calibration-reconcile/SKILL.md`** — thin wrapper (mirrors Phase 5's `/ledger` over `render_ledger.py`); cites the L-9 CANONICAL helper and the Brier formula.

### Central store
Reads `runs.jsonl`/`manual-attribution.jsonl` and writes `falsification.jsonl` (append-only, L-9) + `brier-rolling.json` (gitignored) to `default_ledger_dir()` (`~/.claude/crucible/ledger/`), matching the `render_ledger.py` precedent from #326. Live ledger data is never committed; the in-repo `.crucible/ledger/runs.jsonl` stays a fixed 11-row test fixture.

### Tests (TDD)
T-2 (positive falsify), T-3 (negative no-overlap), T-6 (manual override), cross-cut bootstrap, T-11 (Brier classifier — denominator==2 + numeric 0.01/0.81). Plus 4 review-driven regression tests (fail-closed grace, walkback multi-verdict fall-through, manual-creates-attribution, anchored fix-branch match). T-10a regression holds. Full 17-file calibration-ledger suite green; fixture intact at 11 rows.

### Review
Adversarial review → 0 Fatal (append()/L-9 reuse confirmed clean) → 4 Significant fixed → clean fresh-eyes re-review.

Refs #270