### PR TITLE
feat(#341,#342,#343): calibration ledger v1.1 follow-ups

### DIFF
--- a/eval/calibration-ledger/test-predicted-falsifier-t13.py
+++ b/eval/calibration-ledger/test-predicted-falsifier-t13.py
@@ -143,28 +143,31 @@ def test_ledger_unparseable_rate():
 
 
 def test_referencing_form_uncheckable_not_in_hitrate():
-    """Regression (adversarial Finding 2): `referencing`/`hash` forms parse but
-    aren't auto-checkable at v1. They must NOT sit in the hit-rate denominator
-    (which would structurally drag siege's rate to 0 — siege is steered toward
-    `referencing`). They still count in total_non_null (unparseable_rate denom)
-    but are NOT unparseable."""
+    """v1.1 (#343): `touching`, `referencing`, and `revert`-verb `hash` are ALL
+    auto-checkable and sit in the hit-rate denominator. Only a NON-revert `hash`
+    predicate (e.g. `fix of artifact_hash=…`) stays `uncheckable` — it has no
+    candidate population, so it must NOT drag the hit-rate to 0. Original
+    adversarial Finding 2 (uncheckable forms excluded from the denominator) still
+    holds for that residual case. All count in total_non_null; none unparseable."""
     from scripts.render_ledger import predicate_rates
     entries = [
         _entry(run_id="t1", skill="siege",
-               predicted_falsifier="fix touching src/foo.py within 30d"),   # touching -> hit-rate denom
+               predicted_falsifier="fix touching src/foo.py within 30d"),       # checkable
         _entry(run_id="t2", skill="siege",
-               predicted_falsifier="CVE referencing token-refresh within 90d"),  # uncheckable
+               predicted_falsifier="CVE referencing token-refresh within 90d"),  # checkable (v1.1)
         _entry(run_id="t3", skill="siege",
-               predicted_falsifier="revert of artifact_hash=deadbeef within 30d"),  # uncheckable
+               predicted_falsifier="revert of artifact_hash=deadbeef within 30d"),  # checkable (v1.1)
+        _entry(run_id="t4", skill="siege",
+               predicted_falsifier="fix of artifact_hash=deadbeef within 30d"),  # non-revert hash -> uncheckable
     ]
     rates = predicate_rates(entries, {}, now="2026-03-01T00:00:00Z")
     sg = rates.get("siege", {})
-    _check("T-13.9 parseable (hit-rate denom) == 1 (touching only)",
-           sg.get("parseable") == 1, f"got {sg}")
-    _check("T-13.10 uncheckable == 2 (referencing + hash)",
-           sg.get("uncheckable") == 2, f"got {sg}")
-    _check("T-13.11 total_non_null == 3, unparseable == 0",
-           sg.get("total_non_null") == 3 and sg.get("unparseable") == 0,
+    _check("T-13.9 parseable (hit-rate denom) == 3 (touching + referencing + revert-hash)",
+           sg.get("parseable") == 3, f"got {sg}")
+    _check("T-13.10 uncheckable == 1 (non-revert hash only)",
+           sg.get("uncheckable") == 1, f"got {sg}")
+    _check("T-13.11 total_non_null == 4, unparseable == 0",
+           sg.get("total_non_null") == 4 and sg.get("unparseable") == 0,
            f"got {sg}")
     _check("T-13.12 unparseable_rate == 0.0 (none are free-form prose)",
            sg.get("unparseable_rate") == 0.0, f"got {sg}")

--- a/eval/calibration-ledger/test-v11-followups.py
+++ b/eval/calibration-ledger/test-v11-followups.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""v1.1 follow-ups (#341 / #342 / #343).
+
+#343 — auto-check the `hash` (verb-gated revert-only) and `referencing`
+       predicted_falsifier forms; both move out of `uncheckable` into the
+       hit-rate denominator. Pure matchers `_hash_fired` / `_referencing_fired`
+       + shared `predicate_checkable`.
+#342 — `signal_type: bad_implementation` non-code calibration signal: threaded
+       through the manual-attribution pass and admitted into `compute_brier`.
+#341 — Tier B stub emission wiring in verify / test-coverage / review-feedback
+       (prose lint).
+
+Mirrors eval/calibration-ledger style: pure functions, synthetic fixtures.
+"""
+import os
+import re
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+_results = []
+
+
+def _check(label, cond, detail=""):
+    tag = "[PASS]" if cond else "[FAIL]"
+    msg = f"{tag} {label}"
+    if detail and not cond:
+        msg += f"  -- {detail}"
+    print(msg)
+    _results.append(cond)
+
+
+def _entry(**kw):
+    base = {
+        "schema_version": 2,
+        "run_id": "run-X",
+        "skill": "quality-gate",
+        "tier": "A",
+        "artifact_type": "code",
+        "verdict": "PASS",
+        "confidence": 0.9,
+        "artifact_hash": "deadbeefcafe0000",
+        "gated_files": ["src/auth.py"],
+        "timestamp": "2026-01-01T00:00:00Z",
+        "backfilled": False,
+        "falsified": None,
+        "falsified_by": None,
+        "predicted_falsifier": None,
+    }
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# #343 hash — verb-gated revert-only (V-1)                                     #
+# --------------------------------------------------------------------------- #
+
+def test_hash_fired():
+    from scripts.reconcile_ledger import (
+        _hash_fired, _parse_iso, parse_predicate, reconcile_predicates,
+        ledger_entry_hash, load_jsonl,
+    )
+    edt = _parse_iso("2026-01-01T00:00:00Z")
+    gated = ["src/auth.py"]
+
+    # V-1a fires: revert of the verdict's artifact, touching a gated file, in-window.
+    p = parse_predicate("revert of artifact_hash=deadbeef within 30d")
+    rc = [{"commit": "rev1", "touched_files": ["src/auth.py"],
+           "merge_time": "2026-01-11T00:00:00Z", "message": 'Revert "x"'}]
+    _check("V-1a hash revert in-window touching gated file fires",
+           _hash_fired(p, edt, rc, gated, "deadbeefcafe0000") is not None)
+
+    # V-1b verb gate: a non-revert verb never fires even with a matching candidate.
+    pf = parse_predicate("fix of artifact_hash=deadbeef within 30d")
+    _check("V-1b non-revert verb (fix) does NOT fire",
+           _hash_fired(pf, edt, rc, gated, "deadbeefcafe0000") is None)
+
+    # hash-bind: a predicate naming a DIFFERENT artifact than its verdict cannot fire.
+    pother = parse_predicate("revert of artifact_hash=feedface within 30d")
+    _check("V-1b' hash naming a different artifact does NOT fire (bind)",
+           _hash_fired(pother, edt, rc, gated, "deadbeefcafe0000") is None)
+    _check("V-1b'' null entry artifact_hash → bind fails → no fire",
+           _hash_fired(p, edt, rc, gated, None) is None)
+
+    # V-1c `without touching` exclusion.
+    pw = parse_predicate("revert of artifact_hash=deadbeef without touching src/tests/* within 30d")
+    rc_tests = [{"commit": "rev2", "touched_files": ["src/tests/x.py", "src/auth.py"],
+                 "merge_time": "2026-01-11T00:00:00Z", "message": 'Revert "x"'}]
+    _check("V-1c without-touching: candidate touching an excluded path does NOT fire",
+           _hash_fired(pw, edt, rc_tests, gated, "deadbeefcafe0000") is None)
+    rc_clean = [{"commit": "rev3", "touched_files": ["src/auth.py"],
+                 "merge_time": "2026-01-11T00:00:00Z", "message": 'Revert "x"'}]
+    _check("V-1c' without-touching: candidate touching only gated (not excluded) fires",
+           _hash_fired(pw, edt, rc_clean, gated, "deadbeefcafe0000") is not None)
+
+    # V-1d out-of-window revert candidate → no fire.
+    rc_old = [{"commit": "rev4", "touched_files": ["src/auth.py"],
+               "merge_time": "2026-03-01T00:00:00Z", "message": 'Revert "x"'}]
+    _check("V-1d out-of-window revert does NOT fire",
+           _hash_fired(p, edt, rc_old, gated, "deadbeefcafe0000") is None)
+
+    # V-1e end-to-end: reconcile_predicates with revert_candidates appends via:predicate.
+    tmp = tempfile.mkdtemp(prefix="v1-hash-")
+    try:
+        fals = os.path.join(tmp, "falsification.jsonl")
+        entries = [_entry(run_id="r-hash", artifact_hash="deadbeefcafe0000",
+                          gated_files=["src/auth.py"],
+                          predicted_falsifier="revert of artifact_hash=deadbeef within 30d")]
+        _, appended = reconcile_predicates(
+            entries, [], fals, now="2026-03-01T00:00:00Z", revert_candidates=rc)
+        ok = len(appended) == 1 and appended[0].get("via") == "predicate" \
+            and appended[0].get("confidence") == "high"
+        _check("V-1e end-to-end revert-hash → via:predicate, high", ok, f"got {appended}")
+    finally:
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# #343 referencing — word-boundary (V-2)                                       #
+# --------------------------------------------------------------------------- #
+
+def test_referencing_fired():
+    from scripts.reconcile_ledger import (
+        _referencing_fired, _parse_iso, parse_predicate, reconcile_predicates,
+    )
+    edt = _parse_iso("2026-01-01T00:00:00Z")
+
+    # V-2a token matches message in-window → fired.
+    p = parse_predicate("cve referencing token-refresh within 90d")
+    rc = [{"commit": "c1", "message": "hotfix token-refresh leak",
+           "merge_time": "2026-01-20T00:00:00Z"}]
+    _check("V-2a referencing token in message fires",
+           _referencing_fired(p, edt, rc) is not None)
+
+    # V-2b token absent / out-of-window → no fire.
+    rc_absent = [{"commit": "c2", "message": "unrelated change",
+                  "merge_time": "2026-01-20T00:00:00Z"}]
+    _check("V-2b token absent → no fire", _referencing_fired(p, edt, rc_absent) is None)
+    rc_late = [{"commit": "c3", "message": "token-refresh", "merge_time": "2026-09-01T00:00:00Z"}]
+    _check("V-2b' out-of-window → no fire", _referencing_fired(p, edt, rc_late) is None)
+
+    # V-2c word-boundary: `auth` must not match `authentication`.
+    pa = parse_predicate("fix referencing auth within 30d")
+    _check("V-2c `auth` does NOT fire on 'refactor authentication'",
+           _referencing_fired(pa, edt, [{"commit": "c4", "message": "refactor authentication",
+                                         "merge_time": "2026-01-10T00:00:00Z"}]) is None)
+    _check("V-2c' `auth` fires on 'fix auth bug'",
+           _referencing_fired(pa, edt, [{"commit": "c5", "message": "fix auth bug",
+                                        "merge_time": "2026-01-10T00:00:00Z"}]) is not None)
+
+    # issue/PR tokens that start with a non-word char (the \b defect).
+    ph = parse_predicate("fix referencing #341 within 30d")
+    _check("V-2c'' `#341` fires on 'closes #341' but not '#3419'",
+           _referencing_fired(ph, edt, [{"commit": "c6", "message": "closes #341",
+                                        "merge_time": "2026-01-10T00:00:00Z"}]) is not None
+           and _referencing_fired(ph, edt, [{"commit": "c7", "message": "ref #3419",
+                                            "merge_time": "2026-01-10T00:00:00Z"}]) is None)
+
+    # V-2d case-insensitivity.
+    pt = parse_predicate("cve referencing Token-Refresh within 90d")
+    _check("V-2d case-insensitive token match",
+           _referencing_fired(pt, edt, [{"commit": "c8", "message": "patch token-refresh",
+                                        "merge_time": "2026-01-10T00:00:00Z"}]) is not None)
+
+    # V-2e end-to-end via reconcile_predicates(reference_candidates=...).
+    tmp = tempfile.mkdtemp(prefix="v2-ref-")
+    try:
+        fals = os.path.join(tmp, "falsification.jsonl")
+        entries = [_entry(run_id="r-ref",
+                          predicted_falsifier="cve referencing token-refresh within 90d")]
+        _, appended = reconcile_predicates(
+            entries, [], fals, now="2026-06-01T00:00:00Z", reference_candidates=rc)
+        _check("V-2e end-to-end referencing → via:predicate",
+               len(appended) == 1 and appended[0].get("via") == "predicate", f"got {appended}")
+    finally:
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# #343 dispatch + render (V-3)                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_dispatch_and_render():
+    from scripts.reconcile_ledger import (
+        parse_predicate, predicate_checkable, reconcile_predicates,
+    )
+    from scripts.render_ledger import predicate_rates
+
+    # V-3a predicate_checkable.
+    _check("V-3a touching checkable",
+           predicate_checkable(parse_predicate("fix touching a.py within 30d")) is True)
+    _check("V-3a referencing checkable",
+           predicate_checkable(parse_predicate("cve referencing tok within 30d")) is True)
+    _check("V-3a revert-hash checkable",
+           predicate_checkable(parse_predicate("revert of artifact_hash=deadbeef within 30d")) is True)
+    _check("V-3a fix-hash NOT checkable",
+           predicate_checkable(parse_predicate("fix of artifact_hash=deadbeef within 30d")) is False)
+
+    # V-3b predicate_rates: touching+referencing+revert-hash count in `parseable`,
+    # a fix-hash counts `uncheckable`. (Entries old enough to be outside grace.)
+    entries = [
+        _entry(run_id="t", skill="quality-gate",
+               predicted_falsifier="fix touching src/auth.py within 30d"),
+        _entry(run_id="r", skill="quality-gate",
+               predicted_falsifier="cve referencing token-refresh within 90d"),
+        _entry(run_id="h", skill="quality-gate",
+               predicted_falsifier="revert of artifact_hash=deadbeef within 30d"),
+        _entry(run_id="fh", skill="quality-gate",
+               predicted_falsifier="fix of artifact_hash=deadbeef within 30d"),
+    ]
+    rates = predicate_rates(entries, {}, now="2026-06-01T00:00:00Z")
+    qg = rates.get("quality-gate", {})
+    _check("V-3b touching+referencing+revert-hash → parseable=3",
+           qg.get("parseable") == 3, f"got {qg}")
+    _check("V-3b fix-hash → uncheckable=1", qg.get("uncheckable") == 1, f"got {qg}")
+
+    # V-3c keyword-only threading: the old positional call shape is untouched.
+    tmp = tempfile.mkdtemp(prefix="v3-thread-")
+    try:
+        fals = os.path.join(tmp, "falsification.jsonl")
+        te = [_entry(run_id="r-t", gated_files=["src/auth.py"],
+                     predicted_falsifier="fix touching src/auth.py within 30d")]
+        cands = [{"commit": "c", "touched_files": ["src/auth.py"],
+                  "merge_time": "2026-01-11T00:00:00Z"}]
+        _, appended = reconcile_predicates(te, cands, fals, now="2026-03-01T00:00:00Z")
+        _check("V-3c positional touching call unchanged (fires)",
+               len(appended) == 1 and appended[0].get("via") == "predicate", f"got {appended}")
+    finally:
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# #342 signal_type + scoped Brier (V-4)                                        #
+# --------------------------------------------------------------------------- #
+
+def test_bad_implementation_signal():
+    from scripts.reconcile_ledger import (
+        reconcile, compute_brier, ledger_entry_hash, load_jsonl,
+    )
+
+    # V-4a/b manual attribution threads signal_type top-level + into falsified_by.
+    tmp = tempfile.mkdtemp(prefix="v4-sig-")
+    try:
+        ledger = os.path.join(tmp, "runs.jsonl")
+        fals = os.path.join(tmp, "falsification.jsonl")
+        manual = os.path.join(tmp, "manual-attribution.jsonl")
+        h = ledger_entry_hash("r-design", "quality-gate")
+        with open(manual, "w") as f:
+            import json
+            f.write(json.dumps({"ledger_entry_hash": h, "falsified": True,
+                                "confidence": "high", "signal_type": "bad_implementation",
+                                "reasoning": "design call led to downstream rework"}) + "\n")
+        with open(ledger, "w") as f:
+            pass
+        appended = reconcile(ledger, fals, manual, [], cross_cut_threshold=20,
+                             now="2026-03-01T00:00:00Z")
+        e = appended[0] if appended else {}
+        _check("V-4a signal_type at top level of falsification entry",
+               e.get("signal_type") == "bad_implementation", f"got {e}")
+        _check("V-4a' signal_type injected into falsified_by",
+               (e.get("falsified_by") or {}).get("signal_type") == "bad_implementation", f"got {e}")
+
+        # V-4b default signal_type is manual_override; user-supplied falsified_by gets it too.
+        manual2 = os.path.join(tmp, "manual2.jsonl")
+        fals2 = os.path.join(tmp, "fals2.jsonl")
+        with open(manual2, "w") as f:
+            import json
+            f.write(json.dumps({"ledger_entry_hash": h, "falsified": True,
+                                "falsified_by": {"commit": "abc", "reason": "x"}}) + "\n")
+        appended2 = reconcile(ledger, fals2, manual2, [], cross_cut_threshold=20,
+                             now="2026-03-01T00:00:00Z")
+        e2 = appended2[0] if appended2 else {}
+        _check("V-4b default signal_type is manual_override",
+               e2.get("signal_type") == "manual_override", f"got {e2}")
+        _check("V-4b' user-supplied falsified_by gets signal_type injected",
+               (e2.get("falsified_by") or {}).get("signal_type") == "manual_override", f"got {e2}")
+    finally:
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    # V-4c scoped Brier: a NON-CODE design PASS WITH a bad_implementation attribution
+    # is admitted with actual=0 → sq_err (0.9-0)^2 = 0.81.
+    h = ledger_entry_hash("r-d", "design")
+    entries = [_entry(run_id="r-d", skill="design", artifact_type="design",
+                      verdict="PASS", confidence=0.9, predicted_falsifier=None)]
+    fmap = {h: {"ledger_entry_hash": h, "falsified": True, "cross_cut": False,
+                "signal_type": "bad_implementation"}}
+    b = compute_brier(entries, fmap, now="2026-03-01T00:00:00Z")
+    _check("V-4c non-code PASS + bad_implementation → brier 0.81",
+           abs(b.get("design", {}).get("brier", -1) - 0.81) < 1e-9, f"got {b}")
+
+    # V-4d a non-code verdict WITHOUT a bad_implementation attribution stays EXCLUDED.
+    b0 = compute_brier(entries, {}, now="2026-03-01T00:00:00Z")
+    _check("V-4d non-code PASS, no attribution → excluded (no design score)",
+           "design" not in b0, f"got {b0}")
+
+    # V-4e a non-code Tier B verdict (confidence null) + bad_implementation → NOT Brier-scored.
+    eb = [_entry(run_id="r-b", skill="audit", artifact_type="design", tier="B",
+                 verdict="PASS", confidence=None, predicted_falsifier=None)]
+    hb = ledger_entry_hash("r-b", "audit")
+    fmapb = {hb: {"ledger_entry_hash": hb, "falsified": True, "cross_cut": False,
+                  "signal_type": "bad_implementation"}}
+    bb = compute_brier(eb, fmapb, now="2026-03-01T00:00:00Z")
+    _check("V-4e non-code Tier B (confidence null) → NOT Brier-scored",
+           "audit" not in bb, f"got {bb}")
+
+    # V-4g (gate S1): bad_implementation is PASS-side. A NON-code FAIL carrying it
+    # is out-of-contract → must NOT be admitted (would otherwise score actual=1
+    # and improve Brier for free).
+    hf = ledger_entry_hash("r-df", "design")
+    ef = [_entry(run_id="r-df", skill="design", artifact_type="design",
+                 verdict="FAIL", confidence=0.9, predicted_falsifier=None)]
+    fmapf = {hf: {"ledger_entry_hash": hf, "falsified": True, "cross_cut": False,
+                  "signal_type": "bad_implementation"}}
+    bf = compute_brier(ef, fmapf, now="2026-03-01T00:00:00Z")
+    _check("V-4g non-code FAIL + bad_implementation → excluded (PASS-side only)",
+           "design" not in bf, f"got {bf}")
+
+
+def test_render_breakdown():
+    # V-4f render breakdown counts bad_implementation separately.
+    from scripts.render_ledger import falsified_breakdown
+    tmp = tempfile.mkdtemp(prefix="v4f-")
+    try:
+        import json
+        fals = os.path.join(tmp, "falsification.jsonl")
+        rows = [
+            {"ledger_entry_hash": "a", "falsified": True, "via": "walkback"},
+            {"ledger_entry_hash": "b", "falsified": True, "via": "predicate"},
+            {"ledger_entry_hash": "c", "falsified": True,
+             "falsified_by": {"manual_override": True}},
+            {"ledger_entry_hash": "d", "falsified": True, "signal_type": "bad_implementation",
+             "falsified_by": {"manual_override": True, "signal_type": "bad_implementation"}},
+        ]
+        with open(fals, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+        bd = falsified_breakdown(fals)
+        ok = (bd.get("walkback") == 1 and bd.get("predicate") == 1
+              and bd.get("manual_override") == 1 and bd.get("bad_implementation") == 1)
+        _check("V-4f breakdown: walkback/predicate/manual_override/bad_implementation each 1",
+               ok, f"got {bd}")
+    finally:
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# #341 wiring lint (V-5)                                                       #
+# --------------------------------------------------------------------------- #
+
+def test_wiring_lint():
+    skills = ["verify", "test-coverage", "review-feedback"]
+    for name in skills:
+        path = os.path.join(REPO_ROOT, "skills", name, "SKILL.md")
+        try:
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+        except OSError:
+            _check(f"V-5 {name}: SKILL.md present", False, path)
+            continue
+        _check(f"V-5 {name}: emits via ledger_append.py",
+               "ledger_append.py" in text, "missing emit invocation")
+        _check(f"V-5 {name}: Tier B stub",
+               re.search(r'"tier"\s*:\s*"B"|tier["\s:]+B', text) is not None,
+               "missing tier B marker")
+        _check(f"V-5 {name}: standalone-only precondition",
+               "standalone" in text.lower(), "missing standalone-only gate")
+        _check(f"V-5 {name}: kill-switch mention",
+               "CRUCIBLE_CALIBRATION_DISABLED" in text, "missing kill-switch")
+        _check(f"V-5 {name}: never-block clause",
+               re.search(r"never block|must never block|does not block|not block the",
+                         text, re.I) is not None, "missing never-block clause")
+
+
+def main():
+    test_hash_fired()
+    test_referencing_fired()
+    test_dispatch_and_render()
+    test_bad_implementation_signal()
+    test_render_breakdown()
+    test_wiring_lint()
+    failures = sum(1 for r in _results if not r)
+    if failures:
+        print(f"\n{failures} assertion(s) FAILED")
+        return 1
+    print(f"\nALL {len(_results)} assertions PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -213,19 +213,30 @@ def reconcile(
     # attribution, regardless of whether the algorithm would have matched its
     # hash, and reserve that hash so the algorithm pass skips it (S-3).
     for h, mo in manual.items():
-        entry = {
-            "ledger_entry_hash": h,
-            "falsified": mo.get("falsified", True),
-            "falsified_by": mo.get("falsified_by", {
+        # #342: signal_type distinguishes a plain manual override from a
+        # `bad_implementation` signal ("a verdict accepted as PASS led to a bad
+        # implementation"). Default `manual_override` (back-compat). Inject it
+        # into falsified_by on BOTH construction paths — the default-built dict
+        # AND a user-supplied falsified_by (which would otherwise miss it).
+        signal_type = mo.get("signal_type", "manual_override")
+        falsified_by = mo.get("falsified_by")
+        if falsified_by is None:
+            falsified_by = {
                 "commit": mo.get("commit"),
                 "reason": mo.get("reasoning", "manual attribution"),
                 "confidence": mo.get("confidence", "low"),
                 "cross_cut": mo.get("cross_cut", False),
                 "manual_override": True,
-            }),
+            }
+        falsified_by = {**falsified_by, "signal_type": signal_type}
+        entry = {
+            "ledger_entry_hash": h,
+            "falsified": mo.get("falsified", True),
+            "falsified_by": falsified_by,
             "confidence": mo.get("confidence", "low"),
             "reasoning": mo.get("reasoning", "manual attribution"),
             "cross_cut": mo.get("cross_cut", False),
+            "signal_type": signal_type,
         }
         seen_hashes.add(h)
         _ledger_append(falsification_path, entry)
@@ -358,8 +369,31 @@ def compute_brier(
     acc: Dict[str, List[float]] = {}
 
     for e in ledger_entries:
+        # Hoist the falsification lookup ABOVE the artifact_type gate so the
+        # #342 non-code admission can consult it.
+        run_id = e.get("run_id", "unknown")
+        skill = e.get("skill", "unknown")
+        h = ledger_entry_hash(run_id, skill)
+        fals = falsification_map.get(h)
+
+        # #342 scoped relaxation: a NON-code verdict is admitted into the Brier
+        # sample ONLY when a human has supplied a definitive `bad_implementation`
+        # outcome (⇒ actual=0). Absent that, a non-code verdict's outcome is
+        # unknown (auto-falsification can never reach it) and it stays excluded —
+        # we never assume a non-code PASS was correct just because nothing
+        # falsified it. Code verdicts are unaffected.
         if e.get("artifact_type") != "code":
-            continue
+            # `bad_implementation` is a PASS-side marker ("a verdict accepted as
+            # PASS led to a bad implementation"). On a non-code FAIL it is
+            # out-of-contract — NOT admitted (its outcome is undefined and
+            # auto-falsification can never reach it), so we require verdict==PASS
+            # here. Absent a PASS-side bad_implementation attribution, a non-code
+            # verdict's outcome is unknown and stays excluded.
+            sig = (fals or {}).get("signal_type") \
+                or ((fals or {}).get("falsified_by") or {}).get("signal_type")
+            if not (fals and bool(fals.get("falsified"))
+                    and sig == "bad_implementation" and e.get("verdict") == "PASS"):
+                continue
         if e.get("backfilled"):
             continue
         verdict = e.get("verdict")
@@ -376,11 +410,6 @@ def compute_brier(
         # Must be older than the grace period.
         if grace_cutoff is not None and not (ts < grace_cutoff):
             continue
-
-        run_id = e.get("run_id", "unknown")
-        skill = e.get("skill", "unknown")
-        h = ledger_entry_hash(run_id, skill)
-        fals = falsification_map.get(h)
 
         # Cross-cut falsifications are excluded from the denominator.
         if fals is not None and fals.get("cross_cut"):
@@ -542,12 +571,103 @@ def _predicate_fired(parsed: dict, entry_dt, candidates: List[dict]):
     return None
 
 
+def predicate_checkable(parsed: Optional[dict]) -> bool:
+    """Single source of truth (used by BOTH the reconciler and render_ledger):
+    is this parsed predicate auto-checkable at v1.1?
+
+      touching    -> True  (file-intersection walk)
+      referencing -> True  (commit-message token scan)
+      hash        -> True ONLY when verb == "revert" (verb-gated revert-only;
+                     a `fix of artifact_hash=…` stays uncheckable — there is no
+                     candidate population for it without exact-hash matching)
+      else / None -> False
+    """
+    if not parsed:
+        return False
+    form = parsed.get("form")
+    if form in ("touching", "referencing"):
+        return True
+    if form == "hash":
+        return parsed.get("verb") == "revert"
+    return False
+
+
+def _hash_fired(parsed: dict, entry_dt, revert_candidates: List[dict],
+                gated_files: List[str], entry_artifact_hash):
+    """`hash` form — verb-gated revert-only matcher (design #343).
+
+    A `revert of artifact_hash=<hex> [without touching <files>] within Nd`
+    predicate FIRES when an actual revert commit lands strictly after the verdict
+    and within the window, touches at least one of the verdict's `gated_files`,
+    and touches NONE of the `without_files` exclusion patterns.
+
+    Hash bind: the parsed `artifact_hash` must be a case-insensitive prefix of
+    (or equal to) the LEDGER ENTRY's own `artifact_hash` — hashes may be
+    abbreviated. A predicate naming a different artifact than the verdict it is
+    attached to is malformed and does NOT fire; a null/empty entry hash also
+    fails the bind (older rows) → no fire (safe). This makes the parsed hash
+    load-bearing, not decorative.
+    """
+    if not parsed or entry_dt is None or parsed.get("form") != "hash":
+        return None
+    if parsed.get("verb") != "revert":
+        return None
+    # Hash bind — the predicate must name THIS verdict's artifact.
+    pred_hash = (parsed.get("artifact_hash") or "").lower()
+    entry_hash = (entry_artifact_hash or "").lower()
+    if not pred_hash or not entry_hash or not entry_hash.startswith(pred_hash):
+        return None
+    gated = set(gated_files or [])
+    without = parsed.get("without_files") or []
+    window_end = entry_dt + _dt.timedelta(days=parsed["within_days"])
+    for cand in revert_candidates or []:
+        merge_dt = _parse_iso(cand.get("merge_time"))
+        if merge_dt is None or not (entry_dt < merge_dt <= window_end):
+            continue
+        touched = cand.get("touched_files") or []
+        # Disqualify if the revert touches any excluded path (path-aware glob).
+        if any(_glob_match(tf, pat) for tf in touched for pat in without):
+            continue
+        # Must touch at least one gated file.
+        if any(tf in gated for tf in touched):
+            return cand
+    return None
+
+
+def _referencing_fired(parsed: dict, entry_dt, reference_candidates: List[dict]):
+    """`referencing` form — commit-message token scan matcher (design #343).
+
+    A `<verb> referencing <token> within Nd` predicate FIRES when a candidate
+    commit lands strictly after the verdict and within the window AND mentions
+    the token as a DELIMITED unit. The non-word lookarounds `(?<!\\w)…(?!\\w)`
+    (NOT raw substring, NOT `\\b…\\b`) correctly match `closes #341` / `ping
+    @handle` while rejecting `#3419` and `authentication` — `\\b` would silently
+    fail on tokens that begin/end with a non-word char (`#341`, `@handle`).
+    """
+    if not parsed or entry_dt is None or parsed.get("form") != "referencing":
+        return None
+    token = parsed.get("token") or ""
+    if not token:
+        return None
+    pat = re.compile(rf"(?<!\w){re.escape(token)}(?!\w)", re.I)
+    window_end = entry_dt + _dt.timedelta(days=parsed["within_days"])
+    for cand in reference_candidates or []:
+        merge_dt = _parse_iso(cand.get("merge_time"))
+        if merge_dt is None or not (entry_dt < merge_dt <= window_end):
+            continue
+        if pat.search(cand.get("message") or ""):
+            return cand
+    return None
+
+
 def reconcile_predicates(
     ledger_entries: List[dict],
     candidates: List[dict],
     falsification_path: str,
     *,
     now: str,
+    revert_candidates: Optional[List[dict]] = None,
+    reference_candidates: Optional[List[dict]] = None,
 ) -> "tuple[List[dict], List[dict]]":
     """Phase 7 second pass (design §3a). Runs AFTER the file-intersection walkback.
 
@@ -565,8 +685,14 @@ def reconcile_predicates(
 
     Returns (classifications, appended). `classifications` has one record per
     non-null predicate — {ledger_entry_hash, skill, sentinel, parseable, fired,
-    unparseable} — for tests; /ledger derives its own rates from runs.jsonl.
+    unparseable, uncheckable} — for tests; /ledger derives its own rates from
+    runs.jsonl. Dispatch by form: touching→`_predicate_fired`, hash→`_hash_fired`
+    (verb-gated revert-only), referencing→`_referencing_fired`. A parseable but
+    not-`predicate_checkable` predicate is classified `uncheckable` and appends
+    nothing.
     """
+    revert_candidates = revert_candidates or []
+    reference_candidates = reference_candidates or []
     classifications: List[dict] = []
     appended: List[dict] = []
     for e in ledger_entries:
@@ -580,7 +706,8 @@ def reconcile_predicates(
         if pf == PREDICATE_SENTINEL:
             classifications.append({
                 "ledger_entry_hash": h, "skill": skill, "sentinel": True,
-                "parseable": False, "fired": False, "unparseable": False})
+                "parseable": False, "fired": False, "unparseable": False,
+                "uncheckable": False})
             continue
 
         # Predicates are only defined for code artifacts (emit rule). A stray
@@ -592,20 +719,43 @@ def reconcile_predicates(
         if parsed is None:
             classifications.append({
                 "ledger_entry_hash": h, "skill": skill, "sentinel": False,
-                "parseable": False, "fired": False, "unparseable": True})
+                "parseable": False, "fired": False, "unparseable": True,
+                "uncheckable": False})
+            continue
+
+        # Parseable but not auto-checkable (e.g. a non-revert `hash` predicate):
+        # classified `uncheckable`, excluded from the hit-rate denominator.
+        if not predicate_checkable(parsed):
+            classifications.append({
+                "ledger_entry_hash": h, "skill": skill, "sentinel": False,
+                "parseable": False, "fired": False, "unparseable": False,
+                "uncheckable": True})
             continue
 
         entry_dt = _parse_iso(e.get("timestamp"))
-        cand = _predicate_fired(parsed, entry_dt, candidates)
+        form = parsed.get("form")
+        if form == "touching":
+            cand = _predicate_fired(parsed, entry_dt, candidates)
+        elif form == "hash":
+            cand = _hash_fired(parsed, entry_dt, revert_candidates,
+                               e.get("gated_files") or [], e.get("artifact_hash"))
+        else:  # referencing
+            cand = _referencing_fired(parsed, entry_dt, reference_candidates)
         fired = cand is not None
         classifications.append({
             "ledger_entry_hash": h, "skill": skill, "sentinel": False,
-            "parseable": True, "fired": fired, "unparseable": False})
+            "parseable": True, "fired": fired, "unparseable": False,
+            "uncheckable": False})
 
         if fired:
+            _how = {
+                "touching": "touched a predicted file",
+                "hash": "reverted the predicted artifact",
+                "referencing": "referenced the predicted token",
+            }.get(form, "matched the predicate")
             reason = (
                 f"predicted_falsifier {pf!r} fired: {parsed['verb']} "
-                f"{cand.get('commit', '?')} touched a predicted file within the "
+                f"{cand.get('commit', '?')} {_how} within the "
                 f"{parsed['within_days']}d window"
             )
             entry = {
@@ -742,6 +892,98 @@ def _git_gh_regression_commits() -> List[str]:
     return shas
 
 
+_REVERT_BRANCH_RE = re.compile(r"(?:^|[\s/'\"])revert/", re.I)
+
+
+def discover_revert_candidates(lookback_days: int = 30) -> List[dict]:
+    """Discover revert commits within lookback_days (#343 `hash` form).
+
+    `git revert` writes subject `Revert "<orig>"`, so `^Revert` anchors the
+    canonical form deterministically; we ALSO include merge commits of a
+    `revert/*` branch. Each: {"commit", "touched_files", "merge_time",
+    "message"}. Deterministic over a local clone (same class as the existing
+    `touching` discovery). NOT exercised by unit tests.
+    """
+    since = (
+        _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=lookback_days)
+    ).strftime("%Y-%m-%d")
+    out: List[dict] = []
+    seen: set = set()
+
+    # (a) canonical `git revert` commits: subject begins with `Revert`.
+    log = _git([
+        "log", f"--since={since}", "--grep=^Revert",
+        "--pretty=format:%H%x1f%cI%x1f%s",
+    ])
+    if log:
+        for line in log.splitlines():
+            parts = line.split("\x1f")
+            if len(parts) < 3:
+                continue
+            sha, when, subject = parts[0], parts[1], parts[2]
+            if sha in seen:
+                continue
+            seen.add(sha)
+            out.append({"commit": sha, "touched_files": _touched_files(sha),
+                        "merge_time": when, "message": subject})
+
+    # (b) merges of a revert/* branch.
+    mlog = _git([
+        "log", "--merges", f"--since={since}",
+        "--pretty=format:%H%x1f%cI%x1f%s",
+    ])
+    if mlog:
+        for line in mlog.splitlines():
+            parts = line.split("\x1f")
+            if len(parts) < 3:
+                continue
+            sha, when, subject = parts[0], parts[1], parts[2]
+            if sha in seen or not _REVERT_BRANCH_RE.search(subject or ""):
+                continue
+            seen.add(sha)
+            out.append({"commit": sha, "touched_files": _touched_files(sha),
+                        "merge_time": when, "message": subject})
+    return out
+
+
+def discover_reference_commits(tokens: List[str], lookback_days: int = 30) -> List[dict]:
+    """Discover commits whose message mentions any of `tokens` (#343 `referencing`).
+
+    A coarse `git log -i --grep=<token>` pre-filter over ALL commits in the
+    window (referencing is about any mention, not just fix-merges); the pure
+    `_referencing_fired` matcher then applies the exact word-boundary check.
+    Each: {"commit", "merge_time", "message"} (full subject+body). NO `gh` PR
+    scan — PR search is non-deterministic/mutable and would make a shared-ledger
+    Brier depend on which machine/when reconcile ran (determinism invariant).
+    NOT exercised by unit tests.
+    """
+    since = (
+        _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=lookback_days)
+    ).strftime("%Y-%m-%d")
+    out: List[dict] = []
+    seen: set = set()
+    for token in {t for t in tokens if t}:
+        log = _git([
+            "log", "-i", f"--grep={token}", f"--since={since}",
+            "--pretty=format:%H%x1f%cI%x1f%B%x1e",
+        ])
+        if not log:
+            continue
+        for rec in log.split("\x1e"):
+            rec = rec.strip("\n")
+            if not rec.strip():
+                continue
+            parts = rec.split("\x1f")
+            if len(parts) < 3:
+                continue
+            sha, when, message = parts[0].strip(), parts[1].strip(), parts[2]
+            if sha in seen:
+                continue
+            seen.add(sha)
+            out.append({"commit": sha, "merge_time": when, "message": message})
+    return out
+
+
 def fix_branch_sizes(days: int = 90) -> List[int]:
     """Touched-file counts of fix/hotfix merges over the prior `days` (a
     DISTINCT 90-day window from the 30-day candidate lookback)."""
@@ -812,8 +1054,26 @@ def main(argv: Optional[List[str]] = None) -> int:
     # §3a Phase 7 second pass: pre-registered predicate walk. Runs AFTER the
     # walkback so a fired predicate wins precedence under L-9 (latest-wins).
     entries = load_jsonl(args.ledger)
+    # #343: per-form candidate populations (SEPARATE lists, not added to
+    # `candidates`, so walkback/touching is unregressed). Reference tokens are
+    # extracted once from the referencing predicates present in the ledger.
+    revert_candidates = discover_revert_candidates(lookback_days=args.lookback_days)
+    ref_tokens: List[str] = []
+    for e in entries:
+        pf = e.get("predicted_falsifier")
+        if not pf or pf == PREDICATE_SENTINEL:
+            continue
+        parsed = parse_predicate(pf)
+        if parsed and parsed.get("form") == "referencing":
+            ref_tokens.append(parsed["token"])
+    reference_candidates = (
+        discover_reference_commits(ref_tokens, lookback_days=args.lookback_days)
+        if ref_tokens else []
+    )
     classifications, predicate_appended = reconcile_predicates(
         entries, candidates, args.falsification, now=now,
+        revert_candidates=revert_candidates,
+        reference_candidates=reference_candidates,
     )
     parseable = sum(1 for c in classifications if c.get("parseable"))
     unparseable = sum(1 for c in classifications if c.get("unparseable"))

--- a/scripts/render_ledger.py
+++ b/scripts/render_ledger.py
@@ -31,6 +31,7 @@ from scripts.ledger_reduce import reduce as _falsification_reduce  # noqa: E402
 from scripts.ledger_append import default_ledger_dir  # noqa: E402
 from scripts.reconcile_ledger import (  # noqa: E402
     parse_predicate,
+    predicate_checkable,
     ledger_entry_hash,
     PREDICATE_SENTINEL,
     GRACE_DAYS,
@@ -278,6 +279,45 @@ def falsified_count(falsification_path: str) -> int:
     return sum(1 for rec in reduced.values() if rec.get("falsified") is True)
 
 
+def falsified_breakdown(falsification_path: str) -> dict:
+    """Per-source counts of falsified entries (#342), via the L-9 reduction.
+
+    Source derivation: walkback/predicate entries carry a top-level `via`;
+    manual entries do NOT — they carry `falsified_by.manual_override == true`
+    and no `via`. A `bad_implementation` signal (top-level or nested
+    `signal_type`) is counted as its own source. Precedence:
+      via=="walkback"        -> walkback
+      via=="predicate"       -> predicate
+      signal_type=="bad_implementation" -> bad_implementation
+      else (manual_override) -> manual_override
+    The four counts sum to `falsified_count` (each falsified entry hits exactly
+    one bucket).
+    """
+    return _breakdown_from_reduced(_falsification_reduce(falsification_path))
+
+
+def _breakdown_from_reduced(reduced: dict) -> dict:
+    """Core of `falsified_breakdown` over an already-reduced map (so the renderer
+    doesn't re-read falsification.jsonl)."""
+    out = {"walkback": 0, "predicate": 0, "manual_override": 0,
+           "bad_implementation": 0}
+    for rec in reduced.values():
+        if rec.get("falsified") is not True:
+            continue
+        via = rec.get("via") or (rec.get("falsified_by") or {}).get("via")
+        sig = rec.get("signal_type") \
+            or (rec.get("falsified_by") or {}).get("signal_type")
+        if via == "walkback":
+            out["walkback"] += 1
+        elif via == "predicate":
+            out["predicate"] += 1
+        elif sig == "bad_implementation":
+            out["bad_implementation"] += 1
+        else:
+            out["manual_override"] += 1
+    return out
+
+
 # --------------------------------------------------------------------------- #
 # Predicate calibration (predicted_falsifier — design §3a, Phase 7)           #
 # --------------------------------------------------------------------------- #
@@ -337,12 +377,12 @@ def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
         if parsed is None:
             slot["unparseable"] += 1
             continue
-        # v1 only auto-checks the `touching` form (reconciler limitation). The
-        # `hash` / `referencing` forms parse but cannot fire yet, so counting
-        # them in the hit-rate DENOMINATOR would structurally drag the rate to 0
-        # (siege is steered toward `referencing`). Track them as `uncheckable`,
-        # excluded from hit_rate until v1.1 wires their walks.
-        if parsed.get("form") != "touching":
+        # v1.1 auto-checks touching, referencing, and revert-verb `hash` forms
+        # (single source of truth: `predicate_checkable`). A non-revert `hash`
+        # predicate has no candidate population, so counting it in the hit-rate
+        # DENOMINATOR would structurally drag the rate to 0. Track it as
+        # `uncheckable`, excluded from hit_rate.
+        if not predicate_checkable(parsed):
             slot["uncheckable"] += 1
             continue
         # Parseable + auto-checkable: counts toward the hit-rate denominator once
@@ -545,6 +585,14 @@ def render_week(week: str, entries: list, *, baseline_medians=None,
         f"Falsified ledger entries (all-time, via the L-9 reduction over "
         f"`falsification.jsonl`): **{falsified}**."
     )
+    if falsified > 0:
+        bd = _breakdown_from_reduced(falsification_reduced or {})
+        parts = [f"{k.replace('_', ' ')} {bd[k]}"
+                 for k in ("walkback", "predicate", "manual_override",
+                           "bad_implementation") if bd[k]]
+        if parts:
+            lines.append("")
+            lines.append(f"_By source: {', '.join(parts)}._")
     if falsified == 0:
         lines.append("")
         lines.append(
@@ -587,14 +635,15 @@ def render_week(week: str, entries: list, *, baseline_medians=None,
                     f"unparseable (> {_fmt_pct(VAGUENESS_RATE_THRESHOLD)}). Tighten "
                     f"the emit prompt before relying on the hit-rate."
                 )
-            # Transparency: `hash`/`referencing` predicates parse but aren't
-            # auto-checkable at v1, so they're excluded from the hit-rate.
+            # Transparency: a non-revert `hash` predicate parses but has no
+            # candidate population, so it's excluded from the hit-rate.
+            # Self-suppresses when uncheckable == 0.
             if r.get("uncheckable"):
                 lines.append(
                     f"_{r['uncheckable']} `{skill}` predicate"
-                    f"{'' if r['uncheckable'] == 1 else 's'} use the "
-                    f"`hash`/`referencing` form — parseable but not auto-checkable "
-                    f"at v1, so excluded from the hit-rate denominator._"
+                    f"{'' if r['uncheckable'] == 1 else 's'} use the non-revert "
+                    f"`hash` form — parseable but not auto-checkable, so excluded "
+                    f"from the hit-rate denominator._"
                 )
         lines.append("")
     else:

--- a/skills/calibration-reconcile/SKILL.md
+++ b/skills/calibration-reconcile/SKILL.md
@@ -69,7 +69,9 @@ It reads `runs.jsonl` and `manual-attribution.jsonl` from the central store and
 5. **Manual override** (`read_manual_attribution`): read
    `manual-attribution.jsonl` **first**; entries there (keyed by
    `ledger_entry_hash`) override the algorithm's attribution. Missing file ⇒
-   empty overrides (no error).
+   empty overrides (no error). An entry may carry an optional `signal_type`
+   (`manual_override` (default) | `bad_implementation`) — see
+   [Non-code `bad_implementation` signal](#non-code-bad_implementation-signal).
 6. **Kill-switch:** see above — `CRUCIBLE_CALIBRATION_DISABLED=1` ⇒ no-op exit.
 
 ## Brier scoring (contract L-10)
@@ -87,10 +89,11 @@ brier = mean((confidence - actual)^2)
 - **actual = 0** iff WRONG: a `PASS` that WAS marked `falsified: true` (looked
   up in the **L-9 latest-entry-wins reduction** over `falsification.jsonl` via
   `scripts.ledger_reduce.reduce`, the canonical helper cited above).
-- **Falsifiable sample filters (ALL must hold):** `artifact_type == "code"`;
-  `backfilled == false`; `verdict ∈ {PASS, FAIL}` with `confidence >= 0.5`;
-  entry older than the 30-day grace period; AND if a matching falsification
-  entry exists, its `cross_cut` must be `false`.
+- **Falsifiable sample filters (ALL must hold):** `artifact_type == "code"`
+  **OR** a non-code verdict carrying a `bad_implementation` falsification (see
+  below); `backfilled == false`; `verdict ∈ {PASS, FAIL}` with
+  `confidence >= 0.5`; entry older than the 30-day grace period; AND if a
+  matching falsification entry exists, its `cross_cut` must be `false`.
 - **Verdict-type classifier (T-11):** only `PASS`/`FAIL` count. `STAGNATION`,
   `ESCALATED`, `ARCHITECTURAL`, `SUSTAINED_REGRESSION` are excluded from both
   numerator AND denominator.
@@ -98,9 +101,44 @@ brier = mean((confidence - actual)^2)
   still compute `n`; just don't gate). The advisory threshold is `brier > 0.25`
   (consumed in Phase 6 — here we only compute and store).
 
+## Non-code `bad_implementation` signal
+
+Auto-falsification (walkback + predicted_falsifier) is code-artifact-centric: a
+verdict is only falsified when a later fix/revert touches a gated path or fires a
+predicate. That can **never reach a non-code verdict** (a design-doc or plan
+`PASS`), and it misses the case where a `PASS` was accepted but the resulting
+implementation later proved bad for reasons no path-touching fix captures — a
+design-level wrong call, downstream rework, or an abandoned approach.
+
+To score those, a human adds a `manual-attribution.jsonl` entry with
+`signal_type: "bad_implementation"`:
+
+```json
+{"ledger_entry_hash": "<sha256(run_id:skill)>", "falsified": true,
+ "confidence": "high", "signal_type": "bad_implementation",
+ "reasoning": "design PASS led to a full rework of the persistence layer"}
+```
+
+- It is a **PASS-side marker**: "a verdict accepted as PASS led to a bad
+  implementation." On a `PASS` it sets `actual = 0` (the verdict was
+  overconfident); on a `FAIL` it is out-of-contract and silently ignored.
+- It works for **non-code** artifacts (`design`/`plan`/…): such a verdict is
+  admitted into the Brier sample **only** when it carries this signal — absent it,
+  a non-code verdict's outcome is unknown and stays excluded (we never assume a
+  non-code PASS was correct just because nothing falsified it). The usual filters
+  still apply (PASS/FAIL, `confidence >= 0.5`, outside grace, non-cross-cut), so a
+  Tier-B `confidence: null` verdict is render-counted but not Brier-scored.
+- It also works on a **code** PASS (downstream rework that no path-touching fix
+  caught), flipping `actual` like any other PASS falsification.
+
+`/ledger` breaks the falsified count down by source (`walkback` / `predicate` /
+`manual_override` / `bad_implementation`).
+
 ## Outputs
 
 - **`falsification.jsonl`** — APPEND-ONLY (L-1/L-9). Each entry:
-  `{ledger_entry_hash, falsified, falsified_by, confidence, reasoning, cross_cut}`.
+  `{ledger_entry_hash, falsified, falsified_by, confidence, reasoning, cross_cut}`
+  — plus an optional `signal_type` (`manual_override` | `bad_implementation`) on
+  manual-attribution-sourced entries.
 - **`brier-rolling.json`** (gitignored) —
   `{"<skill>": {"n": int, "brier": float, "last_updated": "<iso>"}, ...}`.

--- a/skills/review-feedback/SKILL.md
+++ b/skills/review-feedback/SKILL.md
@@ -204,6 +204,20 @@ You understand 1,2,3,6. Unclear on 4,5.
 
 When replying to inline review comments on GitHub, reply in the comment thread (`gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies`), not as a top-level PR comment.
 
+## Calibration ledger emit (Tier B stub — standalone only)
+
+<!-- CANONICAL: shared/ledger-append.md -->
+
+**Standalone top-level invocation ONLY.** Emit a ledger row IFF `review-feedback` was invoked as its own top-level feedback-evaluation session (a user `/review-feedback`, or an orchestrator dispatching it as a discrete step that owns a run). When this skill's discipline is applied **inline** inside another skill's flow, emit **nothing** — that host skill owns its own ledger row. There is no run lifecycle for an inline application, so there is no `run_id` to mint and nothing to emit.
+
+When (and only when) running standalone, at the terminal conclusion emit ONE **Tier B STUB** JSONL line to the **central ledger** (`~/.claude/crucible/ledger/runs.jsonl`) via the `emit` CLI per `skills/shared/ledger-append.md` — resolve `scripts/ledger_append.py` by absolute path from the plugin root and run `python3 <script> emit - '<json>'`.
+
+- Mint exactly ONE UUIDv7 (`scripts/uuid7.py`) at the start of the standalone session and reuse it for the single emit at the terminal conclusion (not mid-flow). `(run_id, skill="review-feedback")` dedup (L-2) guarantees idempotency.
+- The `emit` CLI owns the mechanics: graceful skip on `CRUCIBLE_CALIBRATION_DISABLED=1` (L-6), and auto-fill of `repo` + `schema_version`. If the script can't be resolved, warn to stderr and skip — a missing emit must **never block** the skill.
+- Populate ONLY meaningful values: `schema_version: 2`, `run_id`, `skill: "review-feedback"`, `tier: "B"`, `verdict` (feedback evaluated and resolved → `PASS`; feedback disputed / routed to the user → `ESCALATED`), `timestamp` (ISO-8601 UTC), `gated_files` (the reviewed artifact's files, repo-relative), `artifact_type` (per the reviewed artifact; default `code`).
+- Set ALL calibration fields EXPLICITLY null per "Tier-B null semantics": `severity_histogram`, `highest_finding`, `would_have_shipped_without_gate`, `findings_count`, `confidence`, `chunk_hash`, `rounds`, `predicted_falsifier` — all `null`. Also `gated_files_truncated: 0`, `comment: null`, `backfilled: false`, `falsified: null`, `falsified_by: null`.
+- **No advisory wiring.** review-feedback produces no confidence-weighted verdict, so Brier is not viable and no `brier_advisory` is read here by design.
+
 ## The Bottom Line
 
 **External feedback = suggestions to evaluate, not orders to follow.**

--- a/skills/shared/ledger-append.md
+++ b/skills/shared/ledger-append.md
@@ -220,6 +220,24 @@ The reconciler and `/ledger` early-return on it (`if predicted_falsifier ==
 parseable nor unparseable. New emits MUST NOT write the sentinel — write a real
 predicate or `null` per the rules above.
 
+## Manual-attribution `signal_type` (reconcile-side; NOT a runs field)
+
+`signal_type` is an **optional field on `manual-attribution.jsonl` entries** (and
+the `falsification.jsonl` entry the reconciler derives from them) — it is **not** a
+`runs.jsonl` field, so the `emit` CLI never writes it. Enum:
+
+- `manual_override` (default when omitted) — a plain human override of the
+  algorithm's attribution.
+- `bad_implementation` — "a verdict accepted as PASS led to a bad implementation"
+  (a design-level wrong call, downstream rework, or an abandoned approach that no
+  path-touching fix captures). This is the seam that lets a **non-code** verdict be
+  Brier-scored: `compute_brier` admits a non-code verdict into the sample only when
+  it carries a `bad_implementation` falsification. PASS-side only. Full semantics +
+  JSONL shape live in `skills/calibration-reconcile/SKILL.md`.
+
+The reconciler threads `signal_type` onto both the top level of the derived
+falsification entry and into its `falsified_by`.
+
 ## L-2 uniqueness clarification
 
 Uniqueness is on `(run_id, skill)` regardless of `run_id` format.

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -182,6 +182,20 @@ Invoke crucible:test-coverage with:
 - Context: [description of changes]
 ```
 
+## Calibration ledger emit (Tier B stub — standalone only)
+
+<!-- CANONICAL: shared/ledger-append.md -->
+
+**Standalone top-level invocation ONLY.** Emit a ledger row IFF `test-coverage` was invoked as its own top-level run (a user `/test-coverage`, or the Standalone caller-integration path above). When dispatched **inline** by a host skill (`debugging` Phase 5, `build` Phase 3, `finish` Step 2.5), emit **nothing** — that host owns its own ledger row. The terminal "Test Alignment Audit Report" is the single emit point; emit once there, not mid-audit.
+
+When (and only when) running standalone, emit ONE **Tier B STUB** JSONL line to the **central ledger** (`~/.claude/crucible/ledger/runs.jsonl`) via the `emit` CLI per `skills/shared/ledger-append.md` — resolve `scripts/ledger_append.py` by absolute path from the plugin root and run `python3 <script> emit - '<json>'`.
+
+- Mint exactly ONE UUIDv7 (`scripts/uuid7.py`) at the start of the standalone run and reuse it for the single emit. `(run_id, skill="test-coverage")` dedup (L-2) guarantees idempotency.
+- The `emit` CLI owns the mechanics: graceful skip on `CRUCIBLE_CALIBRATION_DISABLED=1` (L-6), and auto-fill of `repo` + `schema_version`. If the script can't be resolved, warn to stderr and skip — a missing emit must **never block** the skill.
+- Populate ONLY meaningful values: `schema_version: 2`, `run_id`, `skill: "test-coverage"`, `tier: "B"`, `verdict` (all affected tests pass post-alignment with no coincidence flags and no fix failures → `PASS`; coincidence tests flagged or fix failures needing caller judgment → `ESCALATED`), `timestamp` (ISO-8601 UTC), `gated_files` (the audited test files, repo-relative), `artifact_type: "code"`.
+- Set ALL calibration fields EXPLICITLY null per "Tier-B null semantics": `severity_histogram`, `highest_finding`, `would_have_shipped_without_gate`, `findings_count`, `confidence`, `chunk_hash`, `rounds`, `predicted_falsifier` — all `null`. Also `gated_files_truncated: 0`, `comment: null`, `backfilled: false`, `falsified: null`, `falsified_by: null`.
+- **No advisory wiring.** test-coverage emits PASS/FAIL but no probability, so Brier is not viable and no `brier_advisory` is read here by design.
+
 ## Guardrails
 
 **The audit agent must NOT:**

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -130,6 +130,20 @@ From 24 failure memories:
 - Implications of success
 - ANY communication suggesting completion/correctness
 
+## Calibration ledger emit (Tier B stub — standalone only)
+
+<!-- CANONICAL: shared/ledger-append.md -->
+
+**Standalone top-level invocation ONLY.** Emit a ledger row IFF `verify` was invoked as its own top-level run (a user `/verify`, or an orchestrator dispatching it as a discrete step that owns a run). When this skill's discipline is applied **inline** before another skill's completion claim — the common case — emit **nothing**; that host skill owns its own ledger row. Verify has no run lifecycle of its own when applied inline, so there is no `run_id` to mint and nothing to emit. This precondition is non-negotiable: a naive per-application emit would flood the ledger.
+
+When (and only when) running standalone, at the terminal verdict emit ONE **Tier B STUB** JSONL line to the **central ledger** (`~/.claude/crucible/ledger/runs.jsonl`) via the `emit` CLI per `skills/shared/ledger-append.md` — resolve `scripts/ledger_append.py` by absolute path from the plugin root and run `python3 <script> emit - '<json>'`.
+
+- Mint exactly ONE UUIDv7 (`scripts/uuid7.py`) at the start of the standalone run and reuse it for the single emit at the terminal verdict (not mid-flow). `(run_id, skill="verify")` dedup (L-2) guarantees idempotency.
+- The `emit` CLI owns the mechanics: graceful skip on `CRUCIBLE_CALIBRATION_DISABLED=1` (L-6), and auto-fill of `repo` + `schema_version`. If the script can't be resolved, warn to stderr and skip — a missing emit must **never block** the skill.
+- Populate ONLY meaningful values: `schema_version: 2`, `run_id`, `skill: "verify"`, `tier: "B"`, `verdict` (claim verified by fresh evidence → `PASS`; claim falsified by evidence → `FAIL`; could not verify → `ESCALATED`), `timestamp` (ISO-8601 UTC), `gated_files` (what was verified, repo-relative), `artifact_type` (per what was verified; default `code`).
+- Set ALL calibration fields EXPLICITLY null per "Tier-B null semantics": `severity_histogram`, `highest_finding`, `would_have_shipped_without_gate`, `findings_count`, `confidence`, `chunk_hash`, `rounds`, `predicted_falsifier` — all `null`. Also `gated_files_truncated: 0`, `comment: null`, `backfilled: false`, `falsified: null`, `falsified_by: null`.
+- **No advisory wiring.** Verify produces no confidence-weighted verdict, so Brier is not viable and there is no `brier_advisory` read here by design.
+
 ## The Bottom Line
 
 **No shortcuts for verification.**


### PR DESCRIPTION
Closes the three v1.1 follow-ups in the **Epistemics Stack: Calibration + Quality Ledger** milestone, one PR. Design-gated (prior session) + implementation-gated (one Opus adversarial pass → 1 Significant fixed → clean re-review: 0 Fatal / 0 Significant).

## #343 — auto-check `hash` + `referencing` predicted_falsifier forms
Both forms parsed-but-uncheckable at v1; now wired and moved out of `uncheckable` into the hit-rate denominator.
- New PURE matchers `_hash_fired` (verb-gated **revert-only**, hash-bound to the verdict's own `artifact_hash`, `without touching` exclusion) and `_referencing_fired` (word-boundary `(?<!\w)token(?!\w)` commit-message scan — correctly handles `#341`/`@handle`, rejects `#3419`/`authentication`).
- Shared `predicate_checkable()` is the single source of truth for both the reconciler and `render_ledger.predicate_rates`. Only a **non-revert** `hash` predicate stays `uncheckable`.
- Per-form candidate populations (`revert_candidates`/`reference_candidates`) are **separate** lists (keyword-only, after the existing `*`) so walkback/`touching` is unregressed. No `gh` PR scan (determinism on a shared ledger).

## #342 — `verdict-led-to-bad-implementation` non-code calibration signal
- A `signal_type` (`manual_override` (default) | `bad_implementation`) on manual-attribution entries, threaded onto the derived falsification entry top-level **and** into `falsified_by` (both default-built and user-supplied paths).
- `compute_brier` admits a **non-code** verdict into the sample **only** when it carries a PASS-side `bad_implementation` falsification (`actual=0`). Un-attributed non-code verdicts stay excluded (outcome unknown); a non-code FAIL carrying the marker is out-of-contract → excluded (gate finding S1).
- `/ledger` breaks the falsified count down by source (walkback / predicate / manual_override / bad_implementation).

## #341 — Tier B stub emission for verify / test-coverage / review-feedback
- Verdict-only Tier-B stubs (all calibration fields `null`), mirroring red-team/audit/inquisitor.
- Gated **standalone-top-level-only** (never inline — verify/review-feedback are behavioral mandates with no inline run lifecycle). No advisory wiring (no confidence-weighted verdict ⇒ Brier not viable).

## Tests
`eval/calibration-ledger/test-v11-followups.py` — 47 assertions (V-1 hash, V-2 referencing, V-3 dispatch/render, V-4 signal_type+scoped-Brier incl. V-4g FAIL-exclusion, V-5 wiring lint). `test-predicted-falsifier-t13.py` updated for the v1.1 checkable-forms contract. Full `eval/calibration-ledger/` suite green.

Refs #341 #342 #343