### PR TITLE
feat(#352): harness-enforce per-role subagent models via agent defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ See [docs/architecture.md](docs/architecture.md) for how the orchestrator skills
 ```bash
 git clone git@github.com:raddue/crucible.git ~/repos/crucible
 ln -sf ~/repos/crucible/skills/* ~/.claude/skills/
+mkdir -p ~/.claude/agents
+ln -sf ~/repos/crucible/agents/* ~/.claude/agents/
 ```
 
-Or, when available on the marketplace: `claude plugin install raddue/crucible`.
+Or, when available on the marketplace: `claude plugin install raddue/crucible`. Note: the per-role model pins are currently delivered by the symlink install above — under a plugin install the agent types are namespaced (`crucible:…`) and bare-name dispatch resolution is unconfirmed (see [harness-adapter §8](skills/shared/harness-adapter.md#8-per-harness-install-manifest)).
 
 ### Cursor / OpenAI Codex / Amp / Cline
 

--- a/agents/crucible-qg-fix.md
+++ b/agents/crucible-qg-fix.md
@@ -1,0 +1,14 @@
+---
+name: crucible-qg-fix
+description: Fix agent / Plan Writer for Crucible quality-gate — applies fixes for red-team findings (main fix loop, re-reviewed each round) and the post-pass minor quick-fix. Inherits the session model. Dispatched via disk-mediated dispatch.
+model: inherit
+---
+
+You are dispatched via Crucible's disk-mediated dispatch. Your prompt names a
+dispatch file on disk. Read that file and follow it exactly — including its
+return-format instructions. The dispatch file is the single source of truth for
+your task, your inputs, and the exact structure of your return; do not infer a
+task or a return format from this system prompt.
+
+This definition exists only to route you and to inherit the session model. It does
+not prescribe what you produce — the dispatch file does.

--- a/agents/crucible-qg-judge.md
+++ b/agents/crucible-qg-judge.md
@@ -1,0 +1,14 @@
+---
+name: crucible-qg-judge
+description: Stagnation judge for Crucible quality-gate — mechanical cross-round comparison of finding sets. Pinned to Sonnet (cheap mechanical check). Dispatched via disk-mediated dispatch.
+model: sonnet
+---
+
+You are dispatched via Crucible's disk-mediated dispatch. Your prompt names a
+dispatch file on disk. Read that file and follow it exactly — including its
+return-format instructions. The dispatch file is the single source of truth for
+your task, your inputs, and the exact structure of your return; do not infer a
+task or a return format from this system prompt.
+
+This definition exists only to pin your model (Sonnet) and route you. It does not
+prescribe what you produce — the dispatch file does.

--- a/agents/crucible-qg-verifier.md
+++ b/agents/crucible-qg-verifier.md
@@ -1,0 +1,17 @@
+---
+name: crucible-qg-verifier
+description: Mechanical structural checker for Crucible quality-gate — fix verification and the persistence checker. Pinned to Sonnet (cheap structural check). Dispatched via disk-mediated dispatch.
+model: sonnet
+---
+
+You are dispatched via Crucible's disk-mediated dispatch. Your prompt names a
+dispatch file on disk. Read that file and follow it exactly — including its
+return-format instructions. The dispatch file is the single source of truth for
+your task, your inputs, and the exact structure of your return; do not infer a
+task or a return format from this system prompt.
+
+This definition exists only to pin your model (Sonnet) and route you. It does not
+prescribe what you produce — the dispatch file does. Different dispatch files give
+this role different return contracts (e.g. an Evidence Receipt for fix
+verification, a JSON correspondence object for the persistence checker); always
+obey the return format the dispatch file specifies, not a fixed one.

--- a/agents/crucible-red-team.md
+++ b/agents/crucible-red-team.md
@@ -1,0 +1,14 @@
+---
+name: crucible-red-team
+description: Adversarial reviewer (Devil's Advocate) for Crucible quality-gate and red-team. Pinned to Opus because recall-critical adversarial review degrades on weaker models. Dispatched via disk-mediated dispatch.
+model: opus
+---
+
+You are dispatched via Crucible's disk-mediated dispatch. Your prompt names a
+dispatch file on disk. Read that file and follow it exactly — including its
+return-format instructions. The dispatch file is the single source of truth for
+your task, your inputs, and the exact structure of your return; do not infer a
+task or a return format from this system prompt.
+
+This definition exists only to pin your model (Opus) and route you. It does not
+prescribe what you produce — the dispatch file does.

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -27,7 +27,7 @@ Shared iterative red-teaming mechanism invoked at the end of artifact-producing 
 
 Apply Tier 1 (structural) and Tier 2 (witness verification) lint per `shared/return-convention.md` to every Task return before acting on the declared VERDICT. The canonical grammar (CLAIM citations, WITNESS rules, verb-binding, byte-range limits, lint-failure handling) lives in that document. Build, siege, and audit apply the same linter.
 
-**Quality-gate-specific obligations:** Receipts from red-team, fix, judge, verifier, and dependency-audit subagents are all linted before their VERDICT is consumed. A lint failure is treated as structurally `BLOCKED` regardless of declared VERDICT — see "Lint failure handling" in the shared convention.
+**Quality-gate-specific obligations:** Receipts from red-team, fix, judge, verifier (the fix-verification dispatch; the persistence-checker JSON output is consumed directly, not receipt-linted — see Persistence Check), and dependency-audit subagents are all linted before their VERDICT is consumed. A lint failure is treated as structurally `BLOCKED` regardless of declared VERDICT — see "Lint failure handling" in the shared convention.
 
 ## Cairn (Layer 3)
 
@@ -206,12 +206,12 @@ The user's response routes to: continue (loop with suppression intact), escalate
 2. **Pre-flight dependency audit (delegated).** As of 2026-05-16, dependency-vulnerability scanning is `crucible:dependency-audit`, invoked by the parent orchestrator in parallel with quality-gate. Quality-gate itself no longer runs this step. If invoked standalone on a code artifact and the user expects dependency scanning, point them to `/dependency-audit`.
 2.5. **Security surface detection and siege dispatch.** Run the detection heuristic (see Security Surface Detection and Siege Dispatch). If `security_surface: detected` AND `skip_siege: false`, OR if `force_siege: true`, dispatch `crucible:siege` in parallel with the first red-team round. The two skills proceed independently. The orchestrator awaits both before terminal verdict.
 3. Prepares the artifact for review (see Artifact Preparation below)
-4. Invokes `crucible:red-team` as a **single-pass reviewer** (one dispatch = one review round). Quality-gate owns the iteration loop; red-team produces findings for one round and returns. Red-team does NOT run its own stagnation loop when invoked by quality-gate.
+4. Invokes `crucible:red-team` as a **single-pass reviewer** (one dispatch = one review round) via `subagent_type: crucible-red-team`, which pins this **single-model** red-team dispatch to **Opus** regardless of the orchestrator's own model (`agents/crucible-red-team.md`; the prose model line in `red-team/SKILL.md` is now descriptive only). On consensus-eligible rounds (Multi-Model Red-Team Review), the single-model dispatch is replaced by `consensus_query(mode: "review")`, whose model membership is resolved by the operator's `consensus_query` configuration — NOT by this pin. Quality-gate owns the iteration loop; red-team produces findings for one round and returns. Red-team does NOT run its own stagnation loop when invoked by quality-gate. If the harness reports that `subagent_type: crucible-red-team` fails to resolve (the agent defs are not installed on this machine — see `shared/harness-adapter.md` §8), the dispatch falls back to `general-purpose` on the orchestrator's inherited model and the Opus recall guarantee is **not** enforced; in that case the orchestrator emits a one-time visible warning ("agent type `crucible-red-team` not installed; the red-team is running on the inherited/session model — recall guarantee NOT enforced; install per harness-adapter §8") rather than degrading silently. The trigger is the observable type-resolution failure, not a transcript or metadata read.
 5. If red-team finds **zero Fatal and zero Significant issues:** artifact is a *candidate* PASS — the round is candidate-clean, but the terminal verdict is deferred until look-harder verification completes. Order of operations on a candidate-clean round (0 Fatal, 0 Significant) — see `## Security Surface Detection and Siege Dispatch > Decision and Dispatch > Awaiting siege` for cross-reference:
    1. Await siege completion (if dispatched and still running) — see `## Security Surface Detection and Siege Dispatch > Decision and Dispatch > Awaiting siege`.
    2. If `SiegeVerdict != PASS`: skip look-harder + Minor Issue Handling, write verdict marker with `Verdict: ESCALATED, Reason: siege-blocked`, surface siege findings, and exit. Look-harder is SKIPPED entirely — the round was never going to be PASS.
    3. **Look-harder precedence gate.** Before invoking look-harder, evaluate Exit Precedence slots #3 (sustained-regression) and #4 (no-op-fix) per existing logic. (**This is a distinct mechanism from Exit Precedence's "Pre-precedence resolution" step at `## Escalation > Exit Precedence`** — that step is specifically the no-op → architectural re-dispatch path, run before precedence evaluation on rounds with active architectural candidates. The "Look-harder precedence gate" here is a much narrower check: it inspects whether a non-Clean-Pass slot would have won precedence on this candidate-clean round, and short-circuits look-harder if so.) A 0F/0S round cannot logically co-fire with sustained-regression (the weighted score on 0F/0S is 0, so `score(N) > score(N-1) > score(N-2)` cannot hold), but no-op-fix CAN co-fire (the fix agent may have returned a byte-identical artifact that the red-team also finds clean). If either slot fires, look-harder is SKIPPED ENTIRELY — the round was never going to be PASS. Look-harder is reached only when Clean Pass (slot #1) would otherwise win precedence.
-   4. **Look-harder verification (Component 1 / #265).** Same-model re-dispatch of red-team with the shared tightened-rubric addendum (`skills/quality-gate/tightened-rubric-addendum.md`) concatenated to `red-team-prompt.md` body by the orchestrator. The re-dispatch is the same model, same artifact, fresh dispatch — only the rubric is tightened; no prior-round context leaks (anti-anchoring preserved). Look-harder is SKIPPED on the following conditions; the orchestrator records `LookHarderSkippedReason` in the verdict marker and proceeds to sub-step 5:
+   4. **Look-harder verification (Component 1 / #265).** Re-dispatch of red-team (`subagent_type: crucible-red-team`, the same enforced **Opus** pin as every red-team round — "same model" here means the pinned red-team model, NOT the orchestrator's) with the shared tightened-rubric addendum (`skills/quality-gate/tightened-rubric-addendum.md`) concatenated to `red-team-prompt.md` body by the orchestrator. The re-dispatch is the same model, same artifact, fresh dispatch — only the rubric is tightened; no prior-round context leaks (anti-anchoring preserved). Look-harder is SKIPPED on the following conditions; the orchestrator records `LookHarderSkippedReason` in the verdict marker and proceeds to sub-step 5:
       - **`circuit-breaker`** — global round 15 (runaway protection takes precedence; this matches the pre-precedence architectural re-dispatch behavior of the 15-round limit).
       - **`tail-rubric-already-applied`** — the candidate-clean round's red-team dispatch already carried `tail_rubric: true` (i.e., LOCAL round ≥ `ceil(suppression_threshold * 0.6)` on a `suppression_threshold ≥ 5` gate). The same-model re-dispatch with the identical addendum adds no signal beyond sampling variance.
       - **Already fired this chunk** — `look-harder-fired-on-round` is non-null in any prior `round-N-flags.md` of the in-progress chunk per the all-files recovery scan (see Compaction Recovery). Skip silently; no `LookHarderSkippedReason` recorded (the field is for circuit-breaker / tail-rubric-already-applied only).
@@ -441,7 +441,7 @@ The orchestrator coordinates the loop but does NOT fix artifacts directly. Fixes
 
 **Before dispatching the fix agent (code artifacts only):** If crucible:checkpoint is available, create checkpoint with reason "pre-qg-fix-round-N". Non-code artifacts (design, plan, hypothesis, mockup, translation) skip this step — they are fully captured by the existing artifact-N.md snapshots.
 
-The fix agent receives: (a) the current artifact, (b) the red-team findings, (c) project context, and (d) the **fix journal** from prior rounds (see Fix Memory below). It returns the revised artifact. The orchestrator writes the revised artifact to the scratch directory and dispatches the next red-team round.
+The fix agent (the design / plan / code / mockup / translation rows above) is dispatched with `subagent_type: crucible-qg-fix`, which **inherits the session model** (`agents/crucible-qg-fix.md`) — the fix output is re-reviewed by the now-Opus red-team each round, so a weaker fixer costs at most an extra round, never a missed bug; do not pass a call-level `model:`. (The `hypothesis` row is the one exception — it routes to the **debugging skill's own** hypothesis-refinement agent, not `crucible-qg-fix`; that agent is outside this skill's surface.) The fix agent receives: (a) the current artifact, (b) the red-team findings, (c) project context, and (d) the **fix journal** from prior rounds (see Fix Memory below). It returns the revised artifact. The orchestrator writes the revised artifact to the scratch directory and dispatches the next red-team round.
 
 The orchestrator never applies fixes directly. Even trivial fixes go through a fix agent to maintain separation of concerns. The cost of dispatching for a small fix is negligible; the risk of the orchestrator conflating coordination with fixing is not.
 
@@ -508,7 +508,7 @@ The `suppressed-signal` and `no-op-fix` fields are copied from `round-N-score.md
 
 After each fix agent completes and before the next red-team round, dispatch a **Fix Verifier** — a dedicated Sonnet agent that checks whether each fix actually resolves its stated finding. No re-fix sub-loop; the verifier checks once, and its output feeds into the fix journal for the next round.
 
-**Dispatch method:** Task tool (model: Sonnet), same pattern as the stagnation judge. The verifier needs no file access; the orchestrator includes all input in the dispatch file directly.
+**Dispatch method:** Task tool, `subagent_type: crucible-qg-verifier` (the agent def pins **Sonnet** — `agents/crucible-qg-verifier.md`; do not pass a call-level `model:`), same pattern as the stagnation judge. The verifier needs no file access; the orchestrator includes all input in the dispatch file directly.
 
 **Input the orchestrator provides:**
 1. Round N findings (the findings the fix agent was asked to address)
@@ -577,7 +577,7 @@ If no checkpoints exist (checkpoint skill unavailable), escalate without the res
 
 When the `consensus_query` MCP tool is available and consensus mode `verdict` is enabled:
 
-1. Instead of dispatching a single Sonnet judge via Task tool, call
+1. Instead of dispatching a single judge via Task tool (`subagent_type: crucible-qg-judge`), call
    `consensus_query(mode: "verdict")` with:
    - prompt: the stagnation judge prompt from `stagnation-judge-prompt.md`
    - context: round N findings, round N-1 findings, latest fix journal entry,
@@ -591,7 +591,8 @@ When the `consensus_query` MCP tool is available and consensus mode `verdict` is
        exist, include the dissent summary in the escalation message:
        "Stagnation detected (consensus: N/M models agree, dissent: [summary])."
    - If `status: "unavailable"`:
-     - Fall back to single-Sonnet judge dispatch (existing behavior)
+     - Fall back to the single-judge dispatch (`subagent_type: crucible-qg-judge`, see
+       **Judge Dispatch → Dispatch method**)
 
 3. The comparison file (`round-N-comparison.md`) includes the consensus
    metadata: models queried, models responded, agreement level, and any
@@ -610,7 +611,7 @@ The orchestrator dispatches a **persistence checker** between a non-clean red-te
 
 **Verifier-error rounds** (where the round-N fix-verifier dispatch failed or its `### Verifier Assessment` sub-section is malformed/absent) implicitly skip the persistence checker per fail-open semantics — the `≥1 Unresolved` gate is vacuous, so the trigger does not fire. The F1 promotion is also skipped (vacuous gating on condition (d) below).
 
-**Dispatch.** When the trigger fires, dispatch the persistence checker as a fresh Sonnet Task with `persistence-checker-prompt.md` as the prompt. Inputs supplied verbatim by the orchestrator:
+**Dispatch.** When the trigger fires, dispatch the persistence checker as a fresh Task with `subagent_type: crucible-qg-verifier` (reused — both the fix verifier and the persistence checker are Sonnet mechanical structural checks; the agent def pins **Sonnet**, `agents/crucible-qg-verifier.md`; do not pass a call-level `model:`) and `persistence-checker-prompt.md` as the prompt. The persistence checker emits a JSON correspondence object, not an Evidence Receipt — the shared `crucible-qg-verifier` def is deliberately return-format-neutral so it does not conflict with that (the persistence checker is not a receipt-bearing role — its JSON is consumed directly by the orchestrator, written to `round-(N+1)-persistence.md` per the flow below, and is NOT run through the receipt linter; this is a pre-existing exemption that #352 does not change). Inputs supplied verbatim by the orchestrator:
 
 1. `round-N-findings.md` (prior round's findings)
 2. `round-(N+1)-findings.md` (current round's findings)
@@ -650,7 +651,7 @@ For thresholds 3-5 the short window means no silent-seed pass is feasible; the j
 
 **At round `suppression_threshold` and later, if neither progress condition is met AND the score did not increase** (i.e., same score, no Fatal count improvement), dispatch the **Stagnation Judge** — a dedicated Sonnet agent that performs semantic comparison of findings across rounds. If the `consensus_query` tool is not available in the environment, this step uses the standard single-Sonnet dispatch described below.
 
-**Dispatch method:** Task tool (model: Sonnet). The judge needs no file access; the orchestrator includes all input in the dispatch file directly.
+**Dispatch method:** Task tool, `subagent_type: crucible-qg-judge` (the agent def pins **Sonnet** — `agents/crucible-qg-judge.md`; do not pass a call-level `model:`). The judge needs no file access; the orchestrator includes all input in the dispatch file directly.
 
 **Input the orchestrator provides:**
 1. The content of `round-N-findings.md` (current round)
@@ -761,8 +762,8 @@ Minor issues do not trigger fix rounds and do not count toward stagnation. Howev
 **After the gate completes** (artifact approved or stagnation escalated):
 
 1. **Consolidate:** Collect all Minor observations from all rounds, deduplicate.
-2. **Quick-fix pass:** Dispatch a fix subagent with the consolidated minors and the final artifact. The fix agent addresses easy wins only — changes that are simple, low-risk, and unambiguous (typos, naming inconsistencies, missing edge-case guards, trivial cleanup). It skips anything requiring judgment or design decisions.
-3. **Present remainder:** Output any minors the fix agent skipped as "Remaining minor observations" so the user can decide whether to address them. No further red-team round on the quick fixes — the gate is already complete.
+2. **Quick-fix pass:** Dispatch a fix subagent (`subagent_type: crucible-qg-fix`, same fix type as the main loop, so it inherits the session model — `agents/crucible-qg-fix.md`; do not pass a call-level `model:`) with the consolidated minors and the final artifact. The fix agent addresses easy wins only — changes that are simple, low-risk, and unambiguous (typos, naming inconsistencies, missing edge-case guards, trivial cleanup). It skips anything requiring judgment or design decisions.
+3. **Present remainder:** Output any minors the fix agent skipped as "Remaining minor observations" so the user can decide whether to address them. No further red-team round on the quick fixes — the gate is already complete. (Because this post-pass quick-fix is **not** re-reviewed, its edits ship on the inherited model unverified — a bounded residual accepted in the #352 plan: blast radius is consolidated Minors on an already-passed artifact, and routing through `crucible-qg-fix` keeps it from becoming a silent escapee if the fix tier ever moves off `inherit`.)
 
 ## Pre-Flight Dependency Audit
 

--- a/skills/red-team/SKILL.md
+++ b/skills/red-team/SKILL.md
@@ -134,7 +134,17 @@ Use the `red-team-prompt.md` template in this directory. Provide:
 - Project context (existing systems, constraints, tech stack)
 - What the artifact is supposed to accomplish
 
-Model: **Opus** (adversarial analysis needs the best model)
+Dispatched as the `crucible-red-team` agent type, which pins the model to **Opus** —
+adversarial analysis needs the best model (see `agents/crucible-red-team.md`). The pin
+is enforced by the agent def regardless of the orchestrator's own model; do not pass a
+call-level `model:`.
+
+If `subagent_type: crucible-red-team` fails to resolve (the agent defs are not installed —
+see `shared/harness-adapter.md` §8), fall back to `general-purpose` on the inherited model
+and emit a one-time visible warning ("agent type `crucible-red-team` not installed; the
+red-team is running on the inherited/session model — recall guarantee NOT enforced; install
+per harness-adapter §8") rather than degrading silently. The trigger is the observable
+type-resolution failure, not a transcript/metadata read.
 
 ### 3. Process findings
 
@@ -144,7 +154,7 @@ Model: **Opus** (adversarial analysis needs the best model)
 
 ### 4. Re-review after fixes
 
-Dispatch a NEW Devil's Advocate subagent (fresh, no prior context). Compute weighted score and compare:
+Dispatch a NEW Devil's Advocate subagent (fresh, no prior context, `subagent_type: crucible-red-team`). Compute weighted score and compare:
 - **Strictly lower weighted score:** Progress. Loop back to step 3.
 - **Same or higher weighted score:** Stagnation. Escalate to user with findings from both rounds.
 
@@ -156,7 +166,7 @@ Dispatch a NEW Devil's Advocate subagent (fresh, no prior context). Compute weig
 
 ## Depth Calibration
 
-If a reviewer returns fewer findings than expected, the review is likely shallow. Dispatch a second reviewer with the instruction: "A prior reviewer found N issues. Find what they missed."
+If a reviewer returns fewer findings than expected, the review is likely shallow. Dispatch a second reviewer (`subagent_type: crucible-red-team`, same Opus pin) with the instruction: "A prior reviewer found N issues. Find what they missed."
 
 | Artifact | Expected findings (Fatal + Significant) | Minimum dimensions covered |
 |---|---|---|

--- a/skills/red-team/red-team-prompt.md
+++ b/skills/red-team/red-team-prompt.md
@@ -5,8 +5,12 @@
 
 Use this template when dispatching a devil's advocate subagent in Phase 2, Step 3.
 
+The `crucible-red-team` agent type pins the model to Opus (`agents/crucible-red-team.md`),
+so the model is enforced by the agent def — do NOT add a call-level `model:` parameter
+(it would override the def; see `shared/harness-adapter.md` Mapping 1b).
+
 ```
-Task tool (general-purpose, model: opus):
+Task tool (subagent_type: crucible-red-team):
   description: "Red team implementation plan for [feature]"
   prompt: |
     You are the Devil's Advocate. Your job is to ATTACK this artifact — find every way it could fail, every assumption that's wrong, every better approach that was overlooked.

--- a/skills/shared/harness-adapter.md
+++ b/skills/shared/harness-adapter.md
@@ -46,7 +46,7 @@ fields map onto it. The authored source of truth is the Claude-Code `name` + `de
 |---|---|---|---|---|
 | Skill identifier | `name:` | (file name `<name>.md`; no `name` key) | prompt metadata `name`/title | command/rule name |
 | Trigger + one-line purpose | `description:` (triggers live here) | `description:` | prompt metadata description | rule description |
-| Dispatch agent selection | n/a (Task tool picks per call) | `agent:` (named agent profile) | n/a | n/a |
+| Dispatch agent selection | model-critical roles use named agent types (`agents/<role>.md`, `model:` frontmatter — `crucible-red-team`=opus, `crucible-qg-judge`/`crucible-qg-verifier`=sonnet, `crucible-qg-fix`=inherit; see Mapping 1b); other dispatches stay per-call general-purpose (Task tool picks) | `agent:` (named agent profile) | n/a | n/a |
 | "this command spawns a subagent" | n/a (decided in body) | `subtask: true` | n/a (sequential) | n/a (sequential) |
 | Argument substitution | body reads invocation args | `$ARGUMENTS` token | prompt arg convention | command arg convention |
 | File include | body reads paths via tools | `@file` include | prompt include | rule include |
@@ -58,6 +58,80 @@ subtasks. Nothing in the authored body changes — only the frontmatter is re-ex
 **Marker note.** The engine-dispatch marker (`` `dispatch: delve-engine` ``) is deliberately NOT one
 of these frontmatter fields — it lives as a column-0 body line under a `## Dispatch` heading (see §7),
 so that no harness's frontmatter loader parses or strips it.
+
+## 2b. Mapping 1b — Per-role model tiers (recall-critical dispatch model enforcement)
+
+The quality-gate / red-team loop is **recall-critical**: an Opus reviewer finds Fatals a Sonnet
+reviewer misses (an Opus orchestrator caught 2 Fatals in 1 round that a Sonnet orchestrator missed in
+8). When the model is left to "whatever the orchestrator passes / inherits", a Sonnet orchestrator
+**silently degrades the red-team to Sonnet**. The fix (#352) is to bind the model **per role** so the
+review tier is enforced independent of the orchestrator. This mapping records the per-role tiers and
+how each harness expresses (or degrades on) the binding.
+
+**Role → model tier (authored intent):**
+
+| Role (agent type) | Tier | Why |
+|---|---|---|
+| `crucible-red-team` | **opus** | Recall-critical adversarial review (every **single-model** red-team round, look-harder, Devil's Advocate, depth-calibration second reviewer, re-review). The load-bearing pin. |
+| `crucible-qg-judge` | **sonnet** | Stagnation judge — mechanical cross-round finding comparison; cheap. |
+| `crucible-qg-verifier` | **sonnet** | Fix verifier **+** persistence checker — mechanical structural checks; cheap. One def, reused. |
+| `crucible-qg-fix` | **inherit** | Fix agent / Plan Writer (main loop, re-reviewed each round by the now-Opus red-team) **+** post-pass minor quick-fix. Inheriting keeps it cheap under a Sonnet orchestrator and strong under an Opus one; a weaker fixer costs at most an extra round, never a missed bug. |
+
+**Consensus-mode caveat.** Consensus-mode red-team rounds (quality-gate's Multi-Model Red-Team Review) resolve their model membership through the operator's `consensus_query` configuration, NOT the `crucible-red-team` pin — on those rounds the operator owns the consensus member tier. The Opus pin scopes to single-model dispatches.
+
+**Standalone-`/red-team` fix dispatch — deliberate exclusion, not an oversight.** These pins cover the quality-gate fix sites; the standalone-`/red-team` fix-mechanism dispatch (`red-team/SKILL.md` fix-mechanism table — Plan Writer / Fix subagent) is intentionally left on the inherited model (it is caller/artifact-determined — that table routes "Standalone → caller decides") and is inherit-equivalent to `crucible-qg-fix` today. A future editor who moves `crucible-qg-fix` off `inherit` should re-evaluate that standalone red-team fix site too, or it stays a silent escapee on the inherited model.
+
+**Namespacing (the `crucible-` prefix is deliberate).** Claude Code discovers agent types from
+`<project>/.claude/agents/` AND `~/.claude/agents/`, and on a name collision the **higher-priority
+location wins** — priority order: managed > `--agents` CLI > `.claude/agents/` (project) >
+`~/.claude/agents/` (user) > plugin (official subagents docs, "Choose the subagent scope"; confirmed
+via claude-code-guide 2026-06-03). Because Crucible installs these defs at **user level** for
+cross-project reach, a consuming project's own same-named `<project>/.claude/agents/` def would
+silently shadow the Crucible one. The `crucible-` prefix on every agent-type `name` / `subagent_type`
+makes that collision implausible — it is the deliberate guard against the shadow.
+
+**Precedence (why the agent-def `model:` actually binds).** The model is resolved by the chain
+`CLAUDE_CODE_SUBAGENT_MODEL` env > call-level `model:` > **agent-def `model:`** > session inherit
+(official subagents docs `https://code.claude.com/docs/en/subagents.md`, "Choose a model"; confirmed
+via claude-code-guide 2026-06-03). Two consequences are load-bearing: (1) the agent-def `model:`
+**does** override the inherited session model — that is what defeats the Sonnet-orchestrator
+degradation; (2) a **call-level `model:`** would override the agent-def, so the rewired dispatches
+**drop the call-level `model:`** entirely — the agent def is the single binding source. `model:
+inherit` is a documented-valid value (omitting the field has the same effect), which is why
+`crucible-qg-fix` may carry it explicitly.
+
+**Global `CLAUDE_CODE_SUBAGENT_MODEL` sits above the pin — keep it off gate machines.** Because it
+tops the precedence chain, exporting it (e.g. to `sonnet`) re-degrades the recall-critical red-team by
+overriding the `crucible-red-team` Opus pin — so do not set it on a machine that runs the gate. This is
+operator-controlled and deliberate (a machine-wide choice, bounded like the operator-default floor
+documented for Codex/Cursor/Pi), NOT the silent orchestrator-inherit degradation #352 targets.
+
+**Prose model words in the skill bodies are descriptive, not binding.** Phrases like "a dedicated Sonnet
+agent" or "single Sonnet judge" describe today's intent — the agent def's `model:` is the single binding
+source; to change a role's tier, edit the agent def, not the prose.
+
+**Per-harness expression:**
+
+| Harness | How the per-role tier is expressed | Status |
+|---|---|---|
+| **Claude Code** | `~/.claude/agents/crucible-<role>.md` with `model:` frontmatter (symlinked from `<repo>/agents/`). The agent-def `model:` binds via the precedence chain above. | **Confirmed** mechanism (docs; runtime-proven by the on-disk transcript read in the enforcement-proof note below). |
+| **OpenCode** | An `agent:` profile per role, named with the intended tier; the skill's OpenCode frontmatter names the profile. | **Authored-to-spec, UNCONFIRMED.** Mapping 1 establishes only that OpenCode reads the `agent:` key — NOT that an `agent:` profile can pin a *model*. #335 confirms. If it cannot, OpenCode degrades to the operator-default floor below. |
+| **Codex / Cursor / Pi** | no first-class per-agent model pin | **Degradation:** model = whatever the harness runs; the recall guarantee relies on the **operator setting a strong default model**. Bounded and documented, never silent. |
+
+**Enforcement is proven by the on-disk subagent transcript model, not a pre-dispatch intent field
+(#335 cross-link).** Two readouts must not be conflated:
+- The session-index `model_tier` field (`dispatch-convention.md`) is set from the dispatch
+  **decision** — the orchestrator's PRE-dispatch intent, before the subagent runs. It would report
+  `opus` even if the agent-def silently failed to bind. **It cannot prove enforcement.**
+- Claude Code writes each Task/Agent subagent dispatch to a per-subagent on-disk transcript at
+  `<project>/<session-id>/subagents/agent-<id>.jsonl`, whose **assistant** records carry
+  `message.model` = the model the subagent **actually ran on** (empirically confirmed to exist on this
+  machine: Opus and Sonnet values observed across real transcripts; the `<synthetic>` sentinel is real
+  and must be filtered). Enforcement is proven by reading that file and confirming `crucible-red-team`
+  executed on `claude-opus-4-*` (qg-* on `claude-sonnet-4-*`). A
+  model-discriminating *behavioral* fixture is explicitly out of scope (a behavioral PASS is consistent
+  with the pin having silently failed). This direct read is the #335 runtime defense against the
+  "documented contract can drift" risk below.
 
 ## 3. Mapping 2 — Command-file location
 
@@ -195,16 +269,38 @@ the install checklist — concrete enough to install by (AC6 doc portion).
 ### Claude Code *(validated #335)*
 - **Where:** `skills/<name>/SKILL.md` under `.claude/skills/` (or plugin-namespaced); shared
   `shared/*.md` installed alongside, referenced via `<!-- CANONICAL: ... -->`.
+- **Agent defs (model enforcement, Mapping 1b):** symlink `<repo>/agents/*.md` →
+  `~/.claude/agents/` (user-level, mirroring the `skills/` symlink — `ln -sf "$PWD"/agents/*
+  ~/.claude/agents/`), so `crucible-red-team` / `crucible-qg-judge` / `crucible-qg-verifier` /
+  `crucible-qg-fix` are discoverable in every project. Without this step the named `subagent_type`s
+  fail to resolve and the recall guarantee degrades (see Mapping 1b's degradation note / the
+  quality-gate fallback warning). On Claude Code an uninstalled `subagent_type` surfaces as a
+  catchable **Task-tool resolution error** — not a silent substitution of a default agent — and that
+  observable error is what fires the non-silent fallback warning (hence the trigger is the
+  type-resolution failure, not a transcript read). A harness that silently substitutes a default on an
+  unknown type cannot fire that warning, so on such a harness install MUST be verified out-of-band —
+  this manifest is that check. Bare-name `subagent_type` resolution for these four defs is **verified
+  for the user-level symlink install** (`~/.claude/agents/`, where agents load by bare `name`). Under a
+  **plugin install**, Claude Code namespaces plugin agents (`crucible:crucible-red-team`), and
+  bare-name `subagent_type` resolution for plugin-provided agents is **UNCONFIRMED** — the docs specify
+  scoping for `@`-mention / `--agent`, not for the Task-tool `subagent_type` field (cf. the OpenCode
+  row's "Authored-to-spec, UNCONFIRMED" / "#335 confirms" status). Until plugin-scoped dispatch is confirmed, the
+  model-enforcement guarantee is delivered by the **symlink install**; a plugin install whose bare type
+  fails to resolve takes the documented **non-silent fallback** above, not silent degradation.
 - **Frontmatter:** `name:` + `description:` (Mapping 1).
 - **Invoked:** `/<name>` (e.g. `/delve`, `/temper`, `/audit`). `/code-review` built-in stays an
   optional accelerator (I1), never a dependency.
 - **Dispatch:** Task / Agent tool, disk-mediated per `shared/dispatch-convention.md` (Mapping 3). Full
-  parallel fan-out.
+  parallel fan-out. Model-critical roles route through the named agent types above (Mapping 1b).
 - **Degrades:** does not — parallel primitive present.
 - **Comments:** forge CLI rows in Mapping 5 (§6) via shell; paste-mode otherwise.
 
 ### OpenCode *(validated #335 — BYO reference harness)*
 - **Where:** `.opencode/commands/<name>.md`; shared files installed alongside.
+- **Agent defs (model enforcement, Mapping 1b):** author one `agent:` profile per role
+  (`crucible-red-team`=opus, etc.) and name it from the skill frontmatter. **Authored-to-spec,
+  unconfirmed** — whether an OpenCode `agent:` profile can pin a model is #335's confirmation; if it
+  cannot, this row degrades to the operator-default floor (set a strong default model).
 - **Frontmatter:** `description:` + `agent:` + `subtask: true`; body uses `$ARGUMENTS` and `@file`
   includes (Mapping 1).
 - **Invoked:** `/<name>`.
@@ -215,6 +311,8 @@ the install checklist — concrete enough to install by (AC6 doc portion).
 
 ### Codex CLI *(authored-to; runtime validation deferred)*
 - **Where:** the Codex prompts directory (prompt file + metadata header).
+- **Agent defs (model enforcement, Mapping 1b):** no first-class per-agent model pin → **degrades**;
+  the recall guarantee relies on the operator setting a strong default model.
 - **Frontmatter:** prompt metadata `name`/description (Mapping 1).
 - **Invoked:** the harness's prompt-invocation convention.
 - **Dispatch:** no first-class parallel-subagent primitive → **Mapping 4 sequential passes** (one per
@@ -224,6 +322,8 @@ the install checklist — concrete enough to install by (AC6 doc portion).
 
 ### Cursor *(authored-to; runtime validation deferred)*
 - **Where:** the Cursor commands / rules location.
+- **Agent defs (model enforcement, Mapping 1b):** no first-class per-agent model pin → **degrades**;
+  the recall guarantee relies on the operator setting a strong default model.
 - **Frontmatter:** rule name + description (Mapping 1).
 - **Invoked:** the harness's command-invocation convention.
 - **Dispatch:** no first-class parallel-subagent primitive → **Mapping 4 sequential passes** + one-time


### PR DESCRIPTION
## What

Makes per-role subagent model selection **harness-enforced**, not prose-advisory. Previously every crucible dispatch was `subagent_type: general-purpose`, so the model was whatever the orchestrator passed or inherited — a **Sonnet orchestrator silently degraded the recall-critical red-team to Sonnet** (the #352 failure mode).

Adds four Claude Code agent defs whose `model:` frontmatter binds the model independent of the orchestrator (precedence: `CLAUDE_CODE_SUBAGENT_MODEL` env > call-level `model:` > **agent-def `model:`** > session inherit):

| Agent def | Model | Role |
|---|---|---|
| `crucible-red-team` | **opus** | recall-critical adversarial review |
| `crucible-qg-judge` | sonnet | stagnation judge |
| `crucible-qg-verifier` | sonnet | fix verifier + persistence checker (return-format-neutral for the dual reuse) |
| `crucible-qg-fix` | inherit | fix agent / Plan Writer + post-pass quick-fix |

Rewired quality-gate / red-team dispatch sites to the named types and **drop any call-level `model:`** (the agent def is the single binding source). When a named type fails to resolve, the dispatch falls back to `general-purpose` + a **one-time visible warning** (trigger = catchable Task-tool resolution error) rather than degrading silently.

`harness-adapter.md` §1b documents the precedence chain, the `crucible-` shadow guard, the consensus-mode caveat, the deliberate standalone-red-team-fix exclusion, and the `CLAUDE_CODE_SUBAGENT_MODEL` override caveat; §8 adds the per-harness install manifest; README documents the symlink install.

## Install caveat (honest scope)

The guarantee is delivered by the **user-level symlink install** (`~/.claude/agents/`, where agents load by bare `name` — bare `subagent_type` resolution **proven** this session). Under a **plugin install** Claude Code namespaces plugin agents (`crucible:…`) and bare-name `subagent_type` resolution is **UNCONFIRMED** — documented as such in §8/README, with the non-silent fallback as the safety net (never silent degradation).

## Verification

- **`/quality-gate` PASS** — 7 rounds, clean R7 (0F/0S) confirmed by a tightened-rubric look-harder pass (0F/0S). Caught + fixed real Significants (dangling refs, consensus over-claim, missing fallback warnings, standalone-fix drift, un-pinned consensus judge, ungrounded fallback trigger).
- **`/temper` Clean** — 2 rounds; the fresh-eyes delve instrument caught the **plugin-namespacing over-claim** the gate missed; fixed by scoping the guarantee to the verified symlink path.
- **Enforcement empirically proven** — a headless Sonnet session dispatched `crucible-red-team`, which ran on `claude-opus-4-8` (read from the on-disk subagent transcript) — the Opus pin overrode the inherited Sonnet session.

## Post-merge action

The worktree is removed on merge — repoint the install symlinks at the main checkout:
`ln -sf /mnt/coding/Coding/crucible/agents/* ~/.claude/agents/`

Refs #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)