### PR TITLE
feat(#334): wire delve/temper/audit to harness-adapter dispatch

### DIFF
--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -104,8 +104,6 @@ Operationally: when `--drift intent=<path>` is passed, the orchestrator reads th
 
 **Invocation contract (pinned by construction):** audit invokes `/delve` with **`effort=high`** and **`scope` = the full audited subsystem** (the same subsystem audit reports on). audit MUST drive delve at `high`, not delve's unstated default (which could be `medium`). The `/audit` API has no effort param of its own; `--bugs` always pins high + full-subsystem, so the suppress-and-cite scope/effort precondition holds by construction.
 
-> **Dispatch marker (forward reference).** audit reaches `delve-engine` only **transitively**, through the `/delve` skill — it does **not** dispatch the engine directly and so does **not** carry the engine marker `dispatch: delve-engine` (out of scope for the I2 allowlist grep, whose set is exactly `{delve, temper}`). audit carries a separate `dispatch: delve` (skill) marker; that canonical column-0 marker line is added to this skill's body when the harness-adapter dispatch wiring lands (**#334**) — it is **not** present yet. This sentence references the marker phrase inline only.
-
 **Output — a SEPARATE section.** delve's findings are appended under a clearly-headed **"Instance Bugs (via delve)"** section using delve's own eight-field schema (`{file, line, summary, failure_scenario, severity, verdict, scope, effort}`) — **never inline-merged** into audit's systemic findings.
 
 ### Suppress-and-cite gate
@@ -176,6 +174,12 @@ When auditing non-code artifacts, the blind-spots agent hunts for document-level
 - Scope boundary gaps (what's just outside scope that could cause problems?)
 - Silent dependencies (external factors assumed to remain true)
 - Logical leaps (conclusions not supported by the preceding argument)
+
+## Dispatch
+
+On the opt-in `--bugs` path, audit invokes the **`/delve` skill** — not `delve-engine` directly — at `effort=high` over the full audited subsystem; `/delve` is the file that dispatches the engine. audit therefore carries a **separate skill marker** (`dispatch: delve`), **not** the engine marker `dispatch: delve-engine`, and is **out of scope** for the I2 engine-marker allowlist grep (whose anchored `^dispatch: delve-engine` set is exactly `{delve, temper}`). The `/delve` skill it invokes itself fans out through the harness-adapter mechanism (with the sequential fallback applying inside delve's engine fan-out where no parallel-subagent primitive exists), so audit issues a single skill call rather than driving the fan-out itself. When `/delve` is not installed, the `/delve`-absent fallback above keeps single-reproduction findings visible rather than dropping them.
+
+dispatch: delve
 
 ## Why This Exists
 
@@ -766,7 +770,7 @@ Each analysis template includes:
 | `crucible:recon` | Subsystem-manifest module | Phase 1 Code Path (subsystem scoping via structured manifest). Fallback: dispatch scoping agent via `audit-scoping-prompt.md`. |
 | `crucible:cartographer-skill` | Consult mode | Phase 1 (subsystem scoping and conventions) |
 | `crucible:cartographer-skill` | Record mode | Phase 4 (Phase 1 manifest only) |
-| `crucible:delve` | Instance-bug sweep | Code path, opt-in `--bugs`: invoked as a SKILL at `effort=high` over the full subsystem; feeds the suppress-and-cite gate. (audit reaches `delve-engine` only transitively through `/delve`; the `dispatch: delve` marker lands at #334.) |
+| `crucible:delve` | Instance-bug sweep | Code path, opt-in `--bugs`: invoked as a SKILL at `effort=high` over the full subsystem; feeds the suppress-and-cite gate. (audit reaches `delve-engine` only transitively through `/delve`; it carries the separate `dispatch: delve` skill marker — see the Dispatch section.) |
 | `crucible:prospector` | Maintainability / complexity / hotspot depth | Code path, on request — audit delegates rather than re-deriving git-churn friction |
 | `crucible:test-coverage` | Test **staleness** | Code path — Test-health routes staleness here (Test-health itself only diagnoses systemic coverage gaps) |
 

--- a/skills/delve/SKILL.md
+++ b/skills/delve/SKILL.md
@@ -107,8 +107,6 @@ Drive `shared/delve-engine.md` a **single** time with:
 
 The fan-out (finder angles) and the per-candidate verify gate run as parallel subagents **through the harness-adapter dispatch mechanism** — delve issues **no harness-specific call inline** (I1). On a harness with no parallel-subagent primitive, the adapter's **sequential fallback** runs the angles as multiple sequential passes (one per angle), never collapsed into a single in-context pass; it warns once that recall may drop.
 
-> **Dispatch marker (forward reference).** The canonical column-0 `dispatch: delve-engine` marker line that the I2 allowlist grep keys on is added to this skill's body when the harness-adapter wiring lands (#334) — it is **not** present yet. This sentence references the marker phrase inline only; per the marker grammar no file may start a line with the bare marker phrase before wiring.
-
 delve runs the engine **once**. There is no fix-verification loop and no second round — that cadence belongs to `temper`.
 
 ### Step 3: Report (always)
@@ -155,6 +153,14 @@ delve first writes the Step 3 formatted report body to a `findings.md` file, whi
 | PR merged or deleted | Do **not** offer paste-mode; surface locally: "The PR is no longer postable (merged / deleted). Findings remain in your session." |
 
 The findings are complete after Step 3 regardless of whether `--comment` succeeds.
+
+## Dispatch
+
+delve drives `shared/delve-engine.md` through the harness-adapter **fan-out mechanism** (`shared/harness-adapter.md` §4, §7) — never a harness-specific call inline (I1). Where a harness has no parallel-subagent primitive, the adapter's **sequential fallback** (§5) runs the angles as multiple sequential passes, warning once that recall may drop.
+
+delve is one of the **exactly two** files that dispatch `delve-engine` directly (the other is `temper`). The canonical engine-dispatch marker line follows; the I2 allowlist test keys on it with the anchored pattern `grep -rn '^dispatch: delve-engine'`:
+
+dispatch: delve-engine
 
 ## Example
 

--- a/skills/shared/delve-engine.md
+++ b/skills/shared/delve-engine.md
@@ -199,11 +199,9 @@ primitive, the angles run as *multiple sequential passes* — one pass per angle
 into a single in-context pass (the single-pass mode is the recall-poor failure this engine exists to
 fix; the adapter warns once that recall may drop under the sequential fallback).
 
-Until #334 lands, treat dispatch as a placeholder and the sequential fallback as acceptable.
-
 This engine is the thing **dispatched**; it does not dispatch itself. The canonical
 `dispatch: delve-engine` marker that the I2 allowlist greps for lives in the BODY of the two direct
-dispatchers (`/delve`, `temper`) — added in #334 — never in this engine file.
+dispatchers (`/delve`, `temper`) — added at wiring time (#334) — never in this engine file.
 
 ## 8. Worked example (illustrative)
 

--- a/skills/temper/SKILL.md
+++ b/skills/temper/SKILL.md
@@ -166,8 +166,6 @@ If the C/I count is strictly below `cap` on the first run, no gating finding was
 
 **Per-invocation dispatch-id** (concurrency isolation). Every `/temper` invocation generates a unique dispatch-id at Step 1: `temper-YYYYMMDDTHHmmss-<6-char-nonce>`. Generate via a cryptographic RNG (e.g., `python -c 'import secrets; print(secrets.token_hex(3))'` for 6 hex chars). If a dispatch file path already exists on disk, regenerate the nonce and retry — never overwrite. The dispatch file path and the `metadata.dispatch_id` field both include this id, so concurrent invocations (e.g., user-initiated overlapping with build's Phase 4) cannot collide. Round numbering remains per-invocation; the dispatch-id disambiguates `(skill, round)` traceability tuples in the external_review MCP and in any session-log consumers. (The R2+ Track-B per-member dispatches extend this stem with a `-m<NN>` member suffix — see Step 4.) Dispatches are disk-mediated per `shared/dispatch-convention.md`: write the filled prompt/inputs to a dispatch file (one file per dispatch-id), then dispatch a Task subagent that reads that file — never paste inputs directly into the Task tool prompt.
 
-> **Dispatch marker (forward reference).** The canonical column-0 `dispatch: delve-engine` marker line that the I2 allowlist grep keys on is added to temper's body when the harness-adapter wiring lands (#334) — it is **not** present yet. This sentence references the marker phrase inline only; per the marker grammar no temper file may start a line with the bare marker phrase before that wiring.
-
 #### Freshness Boundary
 
 Temper's core principle ("fresh agent every round, no anchoring beyond the enumerated `T`") is convention-plus-mechanism. Each round uses a **fresh agent** — no reviewer reuse — with one deliberate, documented exception: the R2+ per-member re-verifier (Track B) **must receive `T`** (the enumerated tracked set is its input — that *is* fix-verification). The exception is scoped to `T` only.
@@ -317,6 +315,14 @@ If the user explicitly asks ("post this to the PR", "leave a review comment"), p
 | PR merged or deleted | Do **not** offer paste-mode. Surface the findings locally: "The PR is no longer postable (merged / deleted). Findings remain in your session for reference." |
 
 Never post without an explicit user instruction. Findings live in the user's session by default.
+
+## Dispatch
+
+temper drives `shared/delve-engine.md` through the harness-adapter **fan-out mechanism** (`shared/harness-adapter.md` §4, §7), disk-mediated per `shared/dispatch-convention.md` — never a harness-specific call inline (I1). Round 1 drives the engine (high effort, bug-angle subset) to enumerate the tracked set `T`; Rounds 2+ re-hunt the changed range the same way. Where a harness has no parallel-subagent primitive, the adapter's **sequential fallback** (§5) runs the angles as multiple sequential passes, warning once that recall may drop.
+
+temper is one of the **exactly two** files that dispatch `delve-engine` directly (the other is `delve`). The canonical engine-dispatch marker line follows; the I2 allowlist test keys on it with the anchored pattern `grep -rn '^dispatch: delve-engine'`:
+
+dispatch: delve-engine
 
 ## Severity / Verdict Vocabulary
 


### PR DESCRIPTION
## What

Wire `delve` / `temper` / `audit` to harness-adapter dispatch (epic #338, design §7 / Issue #7). The dispatch **mechanism** prose was already authored in #329–#333; this PR flips the three "forward-reference" placeholders into real, machine-detectable dispatch markers.

- **`delve`, `temper`** — new `## Dispatch` section ending in a column-0 `dispatch: delve-engine` marker line. These are the **exactly two** files that dispatch the engine directly.
- **`audit`** — new `## Dispatch` section with a **separate** column-0 `dispatch: delve` **skill** marker (audit reaches the engine only transitively via the `/delve` skill); out of scope for the engine grep. Routing-table parenthetical updated.
- **`delve-engine`** — dropped the now-false "Until #334 lands, treat dispatch as a placeholder" sentence; it carries **no** marker (it is dispatched, not a dispatcher).

## Invariant (I1 + I2)

The set of files with a column-0 `^dispatch: delve-engine` line is **exactly `{delve, temper}`**; `audit`'s `dispatch: delve` is a separate skill marker that does not match the engine anchor; `harness-adapter` carries **no** marker (it is the fan-out mechanism delve-engine invokes, not a dispatcher). The anchored grep that **#336** will codify (`grep -rn '^dispatch: delve-engine'`) passes over every inline / backtick-wrapped prose mention. Verified:

```
$ grep -rn '^dispatch: delve-engine' . --include='*.md'
skills/delve/SKILL.md:163:dispatch: delve-engine
skills/temper/SKILL.md:325:dispatch: delve-engine
$ grep -rn '^dispatch:' . --include='*.md'   # + audit's separate skill marker
skills/audit/SKILL.md:182:dispatch: delve
```

## Gates

- **`/quality-gate` PASS** — 1 round, 0 Fatal / 0 Significant, look-harder-confirmed under the tightened rubric (two independent Opus red-teams each re-ran the greps). One Minor (audit fallback-attribution wording) fixed in the quick-fix pass. Central-ledger run_id `2026-06-03T21-21-53`.
- **`/temper` Clean** — `main..HEAD`, R1 bug-angle fan-out (line-by-line / removed-behavior / cross-file tracer) found no gating findings; empty-`T` short-circuit satisfied (C/I kept-count 0 < cap, un-truncated). One non-gating Suggestion noted (a `(§4, §7)` citation is loosely placed — defensible, left as-is).

Note for the **#336** author (surfaced by both gates, not a defect here): the engine test must use the longer `^dispatch: delve-engine` anchor — `^dispatch: delve` prefix-matches the engine lines too (skill-marker set is `{audit, delve, temper}`; engine-marker set is `{delve, temper}`).

Refs #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
