### PR TITLE
fix(#358): repair canonical-drift checker + document the two quality vocabularies as deliberately separate

### DIFF
--- a/scripts/check_canonical_drift.py
+++ b/scripts/check_canonical_drift.py
@@ -5,16 +5,24 @@ vs build-reviewer paraphrase.
 Invocation (from repo root):
     python3 scripts/check_canonical_drift.py
 
-Compares the `### Targeted Lenses` block AND the new Tenancy/Rollback
-discipline sections + AI-Slop counter-rule in `skills/shared/reviewer-common.md`
-(canonical) against their paraphrased counterparts in
-`skills/build/build-reviewer-prompt.md`.
+Compares the `### Targeted Lenses` block AND the Tenancy/Rollback discipline
+sections + AI-Slop counter-rule + Pre-flight section in
+`skills/shared/reviewer-common.md` (canonical) against their paraphrased
+counterparts in `skills/build/build-reviewer-prompt.md`.
 
-Asserts both files contain: the 4 lens subsection headings, the 6 co-fire
-data-row conditions, the 4 pinned severity-ceiling sentences, the Tenancy
-and Rollback discipline headings + Category values, and the AI-Slop
-counter-rule paraphrase-resistant pins. Exits 0 if aligned, 1 with a
-diff summary otherwise. Stdlib only.
+`skills/temper/temper-reviewer.md` is intentionally NOT checked. The #333
+Review-Trio reshape turned it into a per-member fix-verification adjudicator
+whose only canonical dependency is the Verification Principle — it no longer
+paraphrases the Targeted Lenses or the Tenancy/Rollback/Pre-flight
+disciplines, and asserting them against it encoded a pre-reshape consumer
+graph that failed spuriously (#358). Do not re-add a temper-reviewer
+discipline assertion: a per-member adjudicator is not a holistic reviewer.
+
+Asserts canonical + build-paraphrase both contain: the 4 lens subsection
+headings, the 6 co-fire data-row conditions, the pinned severity-ceiling
+sentences, the Tenancy and Rollback discipline headings + Category values,
+the AI-Slop counter-rule, and the Pre-flight pins. Exits 0 if aligned, 1
+with a diff summary otherwise. Stdlib only.
 """
 from __future__ import annotations
 import pathlib, re, sys
@@ -22,7 +30,6 @@ import pathlib, re, sys
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 CANON = ROOT / "skills/shared/reviewer-common.md"
 BUILD = ROOT / "skills/build/build-reviewer-prompt.md"
-TEMPER = ROOT / "skills/temper/temper-reviewer.md"
 
 LENS_HEADINGS = ["#### Surgical Changes", "#### DRY", "#### SRP", "#### OCP"]
 COFIRE_ROWS = [
@@ -110,7 +117,6 @@ def check_disciplines(name: str, text: str) -> list[str]:
 def main() -> int:
     canon_text = CANON.read_text(encoding="utf-8")
     build_text = BUILD.read_text(encoding="utf-8")
-    temper_text = TEMPER.read_text(encoding="utf-8")
     canon_block = extract_canon(canon_text)
     build_block = extract_build(build_text)
     errs = (
@@ -118,14 +124,13 @@ def main() -> int:
         + check("build-paraphrase", build_block)
         + check_disciplines("canonical", canon_text)
         + check_disciplines("build-paraphrase", build_text)
-        + check_disciplines("temper-reviewer", temper_text)
     )
     if errs:
         print("DRIFT DETECTED:")
         for e in errs:
             print(f"  - {e}")
         return 1
-    print("OK — canonical, build paraphrase, and temper reviewer are aligned (lenses + disciplines).")
+    print("OK — canonical and build paraphrase are aligned (lenses + disciplines).")
     return 0
 
 if __name__ == "__main__":

--- a/skills/shared/delve-engine.md
+++ b/skills/shared/delve-engine.md
@@ -103,6 +103,17 @@ Critical/Important is a **bug-angle** finding and is re-attributed to the owning
 Correctness/Architecture concern), exactly as `reviewer-common.md`'s DRY re-attribution does — it is
 never emitted as a Critical "quality" finding.
 
+> **Parallel taxonomy — intentional, not a duplicate (#358).** These angles overlap by intuition
+> with the prompt-reviewer *Targeted Lenses* in `shared/reviewer-common.md` but are a deliberately
+> separate vocabulary: `Reuse` mirrors the `DRY` lens; `Altitude` is adjacent to — but distinct
+> from — `SRP` (abstraction *placement* vs. unit *cohesion*); the lenses' `Surgical Changes` and
+> `OCP` have no angle counterpart. The angles lack a precedence / co-fire resolution table (the
+> lenses' Surgical-wins, SRP-contains-DRY, co-fire rules) and are capped *by construction*; but both
+> share a re-attribution mechanism — a genuinely Critical/Important concern is re-attributed to the
+> owning bug angle (mirroring the lenses' DRY escape hatch) rather than emitted as a capped quality
+> finding — because the two serve different machines: this portable engine vs. a live gating
+> reviewer. Synced by intent, never by shared text.
+
 **4.4 Reuse.** New code that duplicates an existing helper/utility instead of calling it, or two
 near-identical blocks introduced in the same diff that would predictably need the same future fix.
 

--- a/skills/shared/reviewer-common.md
+++ b/skills/shared/reviewer-common.md
@@ -33,6 +33,17 @@
 
 > Four named lenses focus the review on disciplines code-review agents reliably drift on. Each lens emits findings tagged with the lens name (`Lens: <name>`) in addition to the standard finding fields. **Every finding emitted from any lens MUST include a `File:` line in the exact format `File: <path>:<line>` or `File: <path>:<lo>-<hi>` (e.g., `File: src/foo.py:42` or `File: src/foo.py:42-58`). Function names, class names, or parenthetical locators (e.g., `src/foo.py (render_banner)` or `src/foo.py:get_timeout_seconds`) are INVALID — use the actual line number from the diff's `@@` hunks. Findings without a numeric `File:` line are invalid and MUST be dropped before emit.** Prose-only suggestions ("consider being more DRY") are not findings.
 
+> **Parallel taxonomy — intentional, not a duplicate (#358).** The delve-engine
+> (`shared/delve-engine.md`) carries its own *quality angles* (Reuse / Simplification /
+> Efficiency / Altitude) for the instance-bug fan-out. They overlap by intuition but are
+> deliberately separate: `Reuse` mirrors the `DRY` lens; `Altitude` is adjacent to — but distinct
+> from — `SRP` (abstraction *placement* vs. unit *cohesion*); `Surgical Changes` and `OCP` have no
+> angle counterpart. The angles are capped non-gating *by construction* and lack a precedence /
+> co-fire resolution table (the lenses' Surgical-wins, SRP-contains-DRY, co-fire rules); but they
+> share a re-attribution mechanism — a genuinely Critical/Important concern is re-attributed to the
+> owning bug angle (mirroring DRY's escape hatch here) rather than emitted as a capped quality
+> finding. The two vocabularies are kept in sync by *intent*, never by shared text.
+
 #### Surgical Changes (precedence: highest)
 
 > Every changed line should trace to what the user asked for. Drive-by reformatting and adjacent-code "improvements" muddy diffs and increase review burden disproportionately.


### PR DESCRIPTION
## #358 — repair the canonical-drift checker + document the two quality vocabularies as deliberately separate

**This PR is deliberately *smaller* than #358 was filed for.** I filed #358 on a "merge the two code-review quality vocabularies into one" framing. Investigation (two parallel investigators + an adversarial challenger, via `/design`) refuted that framing — see #358 for the full write-up. The surgical fix below is the correct outcome.

### Why not the merge
- **No runtime double-coverage.** `temper` drives `delve-engine` with the **bug-angle subset only** — it never runs the quality angles. So reviewer-common's lenses (build Phase 3 + external review) and delve-engine's angles (standalone `/delve`, `/audit --bugs`) almost never review the same diff in the same run. The "double-count" the issue feared doesn't occur in the pipeline.
- **A merge would damage conceptual integrity.** Only DRY≈Reuse is genuinely the same concept; SRP≠Altitude (cohesion vs placement); Surgical/OCP are lens-only; Simplification/Efficiency angle-only. The lenses carry a precedence/co-fire resolution table + re-attribution machinery the angles deliberately lack. Forcing one vocabulary would either strip load-bearing rules or impose lens machinery on the portable engine.
- **A shared glossary / YAML pipeline is the over-engineering #289 was right to defer.** The reference mechanism can't even reduce duplication (external-review can't use includes; delve-engine must stay harness-portable).

### What's here
- **`scripts/check_canonical_drift.py`** — remove the **stale `temper-reviewer` discipline assertion**. The #333 reshape turned `temper-reviewer.md` into a per-member fix-verification adjudicator whose only canonical dependency is the Verification Principle; it no longer paraphrases the Targeted Lenses or the Tenancy/Rollback/Pre-flight disciplines, so the checker had been **failing spuriously since #333**. Removes the orphaned `TEMPER` constant + read; updates docstring (with a do-not-re-add note) + success message. **Canonical↔build coverage untouched; the checker now exits 0.**
- **`skills/shared/reviewer-common.md` + `skills/shared/delve-engine.md`** — one mutually-consistent blockquote note in each, documenting the two taxonomies as a deliberately-separate parallel pair so the parallelism is explained, not accidental.

### Disposition of #289
Likely **subsumed** (its YAML extraction is the same over-engineering, now doubly disproven). Ruling deferred to #358's close-out — not closed in this PR.

### Gate (green)
- **`/quality-gate` PASS** — 2 rounds, score **1→0**. Look-harder fired on the round-1 candidate-clean round and correctly **demoted a Minor doc-note inaccuracy to Significant** (the reviewer-common note claimed the angles have "no re-attribution machinery" — false per delve-engine body lines 100-104), driving the fix. Round 2 clean-confirmed. Central-ledger entry emitted.
- `check_canonical_drift.py` **and** `check_i2_marker.py` both exit 0 on the branch.

Refs #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
