### PR TITLE
feat(#260): make quality-gate stagnation judge Minor-aware (judge-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ Notable changes to the Crucible skill library. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); entries are grouped by
 milestone since skills ship as a library rather than a versioned binary.
 
+## QG Stagnation-Score Cleanup — 2026-06-05
+
+Makes the quality-gate stagnation *judge* (not the weighted score) Minor-aware,
+reconciles the contradicting Minor prose, documents siege-once-on-full-artifact
+for chunked gates, and adds a `DR-Cause` telemetry discriminator. The weighted
+score (`Fatal=3, Significant=1, Minor=0`) is unchanged. Tickets #260, #258.
+
+### Changed
+
+- **Stagnation judge is Minor-aware.** A new Step-3 Mixed-branch rule in
+  `stagnation-judge-prompt.md` classifies `DIMINISHING_RETURNS` when Minors
+  recur/accumulate at a flat score with **zero recurring Fatals/Significants**,
+  corroborated over 2 rounds via a persisted "Consecutive recurring-Minor rounds"
+  counter (analogous to the existing all-Structural counter); fail-open to
+  PROGRESS. Reconciled the `## Minor Issue Handling` prose accordingly — Minors
+  still never enter the weighted score and never trigger fix rounds, but the
+  judge may weigh sustained Minor accumulation at round ≥ threshold. The weighted
+  score is unchanged. (#260)
+- **Chunked-gate siege scope** is now documented as dispatched **once on the full
+  artifact**, not per-chunk, with the acknowledged chunk-local sink tradeoff. (#258)
+
+### Added
+
+- **`DR-Cause` judge discriminator** — a `DR-Cause: minor-accumulation |
+  structural-saturation | none` Output-Format line emitted per DIMINISHING_RETURNS
+  path (parsed like `Verdict:`), plus a convergence-log-only `dr_cause` field
+  (`minor-accumulation | structural-saturation | consensus | null`,
+  key-presence-versioned, **no `marker_version` bump**, no verdict-marker field),
+  with the canonical denominator rule reconciled to filter on `dr_cause`
+  key-presence. The orchestrator composes a distinct minor-accumulation
+  DIMINISHING_RETURNS user message at both escalation sites. (#260)
+- **`scripts/check_qg_stagnation_minor.py`** — a stdlib structural checker (path-
+  pinned to the judge prompt + `quality-gate/SKILL.md`) guarding the Minor-aware
+  rule, the counter line, the `DR-Cause` enum, the reconciled Minor prose, and the
+  convergence-log `dr_cause` value set; wired into `/stocktake`. (#260)
+
+Disposition: #258(1) fixed (siege-once doc); #258(2) closed accepted/inherent for
+short thresholds; #258(3) (`diminishing-returns` rename) closed won't-fix
+(contract-risk-exceeds-benefit).
+
 ## Review-Trio Reshape — 2026-06-03
 
 Splits the code-review trio on an **instance-vs-systemic** axis. `delve` (new)

--- a/scripts/check_qg_stagnation_minor.py
+++ b/scripts/check_qg_stagnation_minor.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Structural check: Minor-aware stagnation judge + DR-Cause discriminator (#260).
+
+Invocation (from repo root):
+    python3 scripts/check_qg_stagnation_minor.py
+
+Path-pinned to exactly two target files — the quality-gate stagnation judge
+prompt and the quality-gate SKILL.md. This checker NEVER rglobs; the path
+pinning is what prevents a self-match (a checker that never globs cannot read
+itself), so the pinned phrases need NOT be obfuscated/split.
+
+Path-pinning to `quality-gate/SKILL.md` is load-bearing: the checker must NOT
+scan `red-team/SKILL.md`, whose "Only Fatal and Significant count" /
+external-findings "do NOT count toward stagnation scoring" lines are
+deliberately retained per the #358 two-vocabulary separation (design D2). It
+is therefore intentionally scoped away from those intentionally-retained lines.
+
+Asserts:
+  Group A (JUDGE prompt):
+    - the Minor-accumulation Mixed-branch rule, signature phrase scoped WITHIN
+      the Step-3 `Mixed (some recurring, some new):` block (after that anchor,
+      before `### Step 4`) — guards against drift back into the unreachable
+      All-new / Step-4 placement;
+    - the persisted `Consecutive recurring-Minor rounds` counter line;
+    - the bold-safe `DR-Cause:` label AND the bare enum value
+      `minor-accumulation | structural-saturation | none` (two separate pins —
+      never the combined `**DR-Cause:** value` substring that straddles `**`).
+  Group B (SKILL Minor prose, literal/path-pinned):
+    - the un-reconciled `do not trigger fix rounds and do not count toward
+      stagnation` clause is GONE;
+    - the reworded anchor `stagnation judge may weigh sustained Minor
+      accumulation` is present.
+    (Literal match — does NOT catch an arbitrary paraphrase that re-introduces
+    the claim in different words.)
+  Group C (SKILL convergence-log `dr_cause` schema), TWO-STAGE scoped:
+    - Stage 1: locate the `**Field semantics for the new entries:**` section
+      (skips any orchestrator-prose `dr_cause` mention ABOVE it);
+    - Stage 2: locate the `dr_cause` field bullet within that section;
+    - within that block require the quoted/literal enum forms
+      `"minor-accumulation"`, `"structural-saturation"`, `"consensus"`, and the
+      `| null` value-set token (enumeration form, not incidental prose; the
+      `consensus` sentinel is the load-bearing pin — absent from the judge
+      prompt's 3-value enum).
+
+Every pin lies strictly INTERIOR to any `**…**` bold span (bare labels /
+values, never a substring that includes or straddles a `**`). Exits 0 when
+aligned, 1 with a `- <error>` list otherwise. Stdlib only.
+"""
+from __future__ import annotations
+import pathlib, re, sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+JUDGE = ROOT / "skills/quality-gate/stagnation-judge-prompt.md"
+SKILL = ROOT / "skills/quality-gate/SKILL.md"
+
+
+def check_judge(text: str) -> list[str]:
+    errs: list[str] = []
+
+    # Group A: persisted counter line (bare phrase, interior to bold) + the rule.
+    if "Consecutive recurring-Minor rounds" not in text:
+        errs.append(
+            "JUDGE: missing 'Consecutive recurring-Minor rounds' counter line"
+        )
+
+    rule_sig = "zero recurring Fatals and zero recurring Significants"
+    if rule_sig not in text:
+        errs.append(
+            f"JUDGE: missing Minor-accumulation rule signature '{rule_sig}'"
+        )
+
+    # Section-anchored placement: the signature phrase must occur WITHIN the
+    # Step-3 Mixed branch (after its anchor, before `### Step 4`) — block-scoping
+    # idiom mirrored from check_canonical_drift.py.
+    m = re.search(
+        r"Mixed \(some recurring, some new\):(.*?)(?=### Step 4)",
+        text, re.DOTALL,
+    )
+    if m is None:
+        errs.append(
+            "JUDGE: Step-3 'Mixed (some recurring, some new):' block not found "
+            "(before '### Step 4')"
+        )
+    elif rule_sig not in m.group(1):
+        errs.append(
+            "JUDGE: Minor-accumulation signature phrase not inside the Step-3 "
+            "Mixed block (drifted toward the unreachable All-new/Step-4 placement)"
+        )
+
+    # DR-Cause: bold-safe two-pin (bare label + bare enum value).
+    if "DR-Cause:" not in text:
+        errs.append("JUDGE: missing 'DR-Cause:' label")
+    if "minor-accumulation | structural-saturation | none" not in text:
+        errs.append(
+            "JUDGE: missing DR-Cause enum value "
+            "'minor-accumulation | structural-saturation | none'"
+        )
+
+    return errs
+
+
+def check_skill(text: str) -> list[str]:
+    errs: list[str] = []
+
+    # Group B: Minor prose reconciliation (literal, path-pinned).
+    stale = "do not trigger fix rounds and do not count toward stagnation"
+    if stale in text:
+        errs.append(
+            f"SKILL: un-reconciled Minor clause still present: '{stale}'"
+        )
+    reworded = "stagnation judge may weigh sustained Minor accumulation"
+    if reworded not in text:
+        errs.append(
+            f"SKILL: missing reworded Minor anchor phrase: '{reworded}'"
+        )
+
+    # Group C: convergence-log dr_cause schema — TWO-STAGE scope.
+    sec = re.search(
+        r"\*\*Field semantics for the new entries:\*\*(.*?)(?=\n\*\*Version-aware|\Z)",
+        text, re.DOTALL,
+    )
+    if sec is None:
+        errs.append(
+            "SKILL: '**Field semantics for the new entries:**' section not found"
+        )
+        return errs
+
+    field_block = re.search(
+        r"`dr_cause`(.*?)(?=\n- `|\n\*\*|\Z)",
+        sec.group(1), re.DOTALL,
+    )
+    if field_block is None:
+        errs.append(
+            "SKILL: `dr_cause` field bullet not found in the field-semantics section"
+        )
+        return errs
+
+    block = field_block.group(1)
+    for quoted in ('"minor-accumulation"', '"structural-saturation"', '"consensus"'):
+        if quoted not in block:
+            errs.append(
+                f"SKILL: dr_cause field block missing quoted enum value {quoted}"
+            )
+    # Strengthened: require `null` as a value-set token (enumeration form
+    # `... | "consensus" | null`), not incidental prose like "null ambiguity".
+    if "| null" not in block:
+        errs.append(
+            "SKILL: dr_cause field block missing the `| null` value-set token"
+        )
+
+    return errs
+
+
+def _read(path: pathlib.Path, errs: list[str]) -> str | None:
+    """Read a pinned target file; on failure append a clean error (no crash)."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except (FileNotFoundError, UnicodeDecodeError, OSError) as err:
+        errs.append(f"{path} missing or unreadable: {err}")
+        return None
+
+
+def main() -> int:
+    errs: list[str] = []
+    judge_text = _read(JUDGE, errs)
+    skill_text = _read(SKILL, errs)
+    if judge_text is not None:
+        errs += check_judge(judge_text)
+    if skill_text is not None:
+        errs += check_skill(skill_text)
+    if errs:
+        print("QG STAGNATION-MINOR DRIFT DETECTED:")
+        for e in errs:
+            print(f"  - {e}")
+        return 1
+    print(
+        "OK — Minor-aware judge rule + DR-Cause enum + reconciled Minor prose "
+        "+ convergence-log dr_cause schema all present and aligned."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -660,10 +660,12 @@ For thresholds 3-5 the short window means no silent-seed pass is feasible; the j
 4. The content of any prior `round-*-comparison.md` files (for consecutive-round state tracking)
 5. The full content of `stagnation-judge-prompt.md` as the agent's instructions
 
-**Reading the verdict:** The judge returns a structured verdict: **PROGRESS**, **STAGNATION**, or **DIMINISHING_RETURNS**.
+**Reading the verdict:** The judge returns a structured verdict: **PROGRESS**, **STAGNATION**, or **DIMINISHING_RETURNS**. The orchestrator **parses the judge's `DR-Cause:` line the same way it parses the `Verdict:` line**, writes the resolved value into `round-N-comparison.md`, and uses it for (a) selecting the DIMINISHING_RETURNS user-facing message below and (b) the convergence-log `dr_cause` field (`none → null` on write — see Convergence Telemetry).
 - **PROGRESS** → loop again
 - **STAGNATION** → escalate: "Stagnation detected: Round N has [X] recurring issues from round N-1 and [Y] new issues. Recurring: [list from judge]. Escalating."
-- **DIMINISHING_RETURNS** → escalate: "Quality gate has resolved all prior issues. Round N found [X] new findings, all Structural (require design-level decisions). Remaining findings: [list from judge]. Presenting for user judgment."
+- **DIMINISHING_RETURNS** → escalate, with the message **keyed off `DR-Cause`** (the judge emits which cause fired; the orchestrator — not the judge — composes the matching user-facing message). `minor-accumulation` is the only special arm; everything else routes to the default message so every DR exit has a defined message:
+  - When `DR-Cause = minor-accumulation` → "Quality gate: Minors are accumulating at a flat score while Fatal/Significant findings still churn without converging. Recurring Minors: [list from judge]. This is user-judgment, not a forced fix loop (Minors never trigger fix rounds). Presenting for user judgment."
+  - Otherwise (`structural-saturation`, `consensus`, or absent/unattributable) → "Quality gate has resolved all prior issues. Round N found [X] new findings, all Structural (require design-level decisions). Remaining findings: [list from judge]. Presenting for user judgment."
 
 **The judge also writes:** a `round-N-comparison.md` file. The orchestrator saves the judge's full output as `round-N-comparison.md` in the scratch directory. This file is used by future judge dispatches for consecutive-round tracking.
 
@@ -722,6 +724,8 @@ A chunked gate has two independent round counters: a **local** counter per chunk
 
 **Cross-chunk round:** After all chunks complete, the final integration round increments the global counter but is conceptually its own "mini-chunk" with `suppression_threshold` = 5 (lower, because integration issues should escalate faster than within-chunk issues). Consensus is mandatory for the cross-chunk round (single-model review is too narrow for integration-surface bugs).
 
+**Siege on chunked gates:** siege dispatches **once on the full artifact**, not per-chunk (see Security Surface Detection → Dispatch timing → Chunked-gate siege scope for the rationale and the chunk-local tradeoff).
+
 **Canonical `chunk_id` grammar (INV-A15 / #265).** Chunk identifiers used in marker fields (`LookHarderRounds`, `PersistentFindingRounds`), convergence-log entries (`look_harder_rounds`, `persistent_finding_rounds`), and scratch directory names are restricted to TWO forms:
 
 - `chunk-<N>` where `<N>` is a positive integer matching the chunk's directory name (`chunk-1`, `chunk-2`, ...). Used for author-defined chunks.
@@ -757,7 +761,7 @@ Include these in the dispatch prompt alongside the standard red-team template. T
 
 ## Minor Issue Handling
 
-Minor issues do not trigger fix rounds and do not count toward stagnation. However, they accumulate across rounds and contain useful information. Do not silently discard them.
+Minor issues still **do not enter the weighted score and never trigger fix rounds**, but the **stagnation judge may weigh sustained Minor accumulation** at round ≥ threshold (per D1 — see the Step 3 Mixed-branch Minor-accumulation rule in `stagnation-judge-prompt.md`). They accumulate across rounds and contain useful information. Do not silently discard them.
 
 **After the gate completes** (artifact approved or stagnation escalated):
 
@@ -817,6 +821,8 @@ After detection runs:
 - Else → no siege dispatch (log as "no-security-surface")
 
 **Dispatch timing:** Immediately before the first red-team round, in parallel. Quality-gate's loop proceeds independently; siege runs on its own scratch directory and its own counters.
+
+**Chunked-gate siege scope:** When a *chunked* gate detects a security surface, dispatch `/siege` **once on the full artifact**, NOT per-chunk. Rationale: siege is expensive (~6 Opus agents) and security surfaces are typically cross-cutting (auth / data-flow span chunk boundaries), so per-chunk dispatch both multiplies cost *and* misses cross-chunk interactions. **Acknowledged tradeoff (R1 M2):** once-on-full-artifact can under-weight a chunk-*local* sink that only a per-chunk view would surface; this is accepted because (a) siege itself reasons over the full artifact and (b) the per-chunk red-team loop runs on each chunk and would independently flag a local injection sink.
 
 **Awaiting siege (all exit paths):** Before writing any terminal verdict marker, the orchestrator verifies siege has completed. This applies to ALL exits — PASS, ARCHITECTURAL, SUSTAINED_REGRESSION, STAGNATION, ESCALATED. If siege is still running:
 
@@ -1098,8 +1104,12 @@ Fields mirror the verdict marker plus `threshold` (the active `suppression_thres
 - `look_harder_skipped_reason`: enum value `"circuit-breaker"` | `"tail-rubric-already-applied"` recorded on a per-run basis. First reason recorded if multiple skips occur. `null` when no skip occurred.
 - `persistent_finding_rounds`: JSON list, same element grammar as `look_harder_rounds`. Empty list `[]` when no rounds produced `persistent_finding_count ≥ 1`.
 - `persistent_check_count`: integer count of persistence-checker dispatches (error dispatches DO count). Defaults to 0. Invariant: `len(persistent_finding_rounds) ≤ persistent_check_count`.
+- `dr_cause`: convergence-log JSON **only** (there is **no verdict-marker `dr_cause` field** and **no `marker_version` bump** — key presence resolves the null ambiguity). Value set: `"minor-accumulation" | "structural-saturation" | "consensus" | null`.
+  Populated from the judge's `DR-Cause:` discriminator when the resolved reason is `diminishing-returns`, else `null`. The orchestrator **translates `none → null`** when writing — it must NOT write the literal string `"none"`.
+  On a **consensus-resolved** DR exit (no single-judge discriminator line to read), set the sentinel `"consensus"`; a `"consensus"` value **cannot attribute** minor-accumulation vs. structural-saturation, since consensus synthesis collapses the cause.
+  Key-presence semantics: every **post-D5** entry carries the `dr_cause` key (value in `{minor-accumulation, structural-saturation, consensus, null}`); every **pre-D5** entry lacks it entirely. A present-but-`null` value means "this DR-eligible run did not exit on diminishing-returns," not "unknown vintage."
 
-**Version-aware backward compatibility (canonical):** Existing convergence-log entries written before this version was deployed lack `marker_version`, `artifact_hash`, and the new telemetry fields. Consumers MUST treat any missing field on a legacy entry as `null` (unknown), NOT as `false` / `0` / `[]`. **Legacy entries are explicitly excluded from any rate-denominator computation** — clean-confirmation rates, non-clean rates, persistence-checker correlation rates, and the recurrence-rate measurements in Open Questions are computed only over entries with `marker_version: 2`. Forge consumers analyzing pre-design entries treat all new fields as `null` and skip those entries when computing rates.
+**Version-aware backward compatibility (canonical):** Existing convergence-log entries written before this version was deployed lack `marker_version`, `artifact_hash`, and the new telemetry fields. Consumers MUST treat any missing field on a legacy entry as `null` (unknown), NOT as `false` / `0` / `[]`. **Legacy entries are explicitly excluded from any rate-denominator computation** — clean-confirmation rates, non-clean rates, persistence-checker correlation rates, and the recurrence-rate measurements in Open Questions are computed only over entries with `marker_version: 2`. Forge consumers analyzing pre-design entries treat all new fields as `null` and skip those entries when computing rates. **`dr_cause` firing-rate denominators filter on `dr_cause` key-presence** (post-D5 entries always carry the key), **not on `marker_version` alone** — so a pre-D5 (`marker_version:2`-but-no-`dr_cause`) entry is not pulled into a `dr_cause` denominator.
 
 **Size management:** The log is append-only. Rotate via mtime check: if the file exceeds 10,000 lines, the next gate run renames it to `convergence-log-<YYYY-MM>.jsonl` (archive) and starts a fresh log. Archives are never deleted by quality-gate — the user manages retention.
 
@@ -1157,7 +1167,7 @@ Exit modes beyond clean approval. **Single-round stagnation, single-round regres
 - **Sustained regression** (any round) → escalate immediately: "Sustained regression detected: scores [N-2: X, N-1: Y, N: Z] strictly increasing. Fix cycle is actively worsening the artifact. Escalating." Verdict: `SUSTAINED_REGRESSION`. Applies pre-threshold too — guarantees loop termination under suppression.
 - **No-op fix** (any round) → escalate immediately on byte-identical artifact OR all-Unresolved verifier (see Fix Mechanism > No-Op Fix Detection). Verdict: `ESCALATED`. Applies pre-threshold too.
 - **Stagnation** (round ≥ threshold) → escalate to user with recurring/new classification from the judge: "Stagnation detected: Round N has [X] recurring issues from round N-1 and [Y] new issues. Recurring: [list]. Escalating." Verdict: `STAGNATION`.
-- **Diminishing returns** (round ≥ threshold) → escalate to user with structural findings from the judge: "Quality gate has resolved all prior issues. Round N found [X] new findings, all Structural (require design-level decisions). Remaining findings: [list]. Presenting for user judgment." Verdict: `ESCALATED`.
+- **Diminishing returns** (round ≥ threshold) → escalate to user, message **keyed off the judge's `DR-Cause`** (Verdict: `ESCALATED` in every case). `minor-accumulation` is the only special arm; everything else routes to the default message so every DR exit has a defined message. When `DR-Cause = minor-accumulation`: "Quality gate: Minors are accumulating at a flat score while Fatal/Significant findings still churn without converging. Recurring Minors: [list]. Presenting for user judgment (Minors never trigger fix rounds — this is a judgment call, not a forced fix)." Otherwise (`structural-saturation`, `consensus`, or absent/unattributable): "Quality gate has resolved all prior issues. Round N found [X] new findings, all Structural (require design-level decisions). Remaining findings: [list]. Presenting for user judgment."
 - **Single-round regression** (round ≥ `suppression_threshold`) → escalate immediately, no judge needed: "Round N score (X) is higher than Round N-1 score (Y). The fix cycle introduced new issues. Escalating." Verdict: `ESCALATED`.
 - **Global safety limit reached (15 rounds)** → escalate to user with full round history. Applies regardless of `suppression_threshold`. Verdict: `ESCALATED`.
 - **Architectural concerns** → fix agent returns `VERDICT: ARCHITECTURAL_BLOCK` (see Architectural Concerns Exit). Escalate immediately, terminal verdict `ARCHITECTURAL`. Applies at any round.

--- a/skills/quality-gate/stagnation-judge-prompt.md
+++ b/skills/quality-gate/stagnation-judge-prompt.md
@@ -55,13 +55,14 @@ Build the comparison table (see Output Format below).
 - Any recurring Fatal → **STAGNATION**. A Fatal that survives a fix attempt is genuinely stuck.
 - Only recurring Significants (no recurring Fatals) AND at least one new finding → **PROGRESS**. However, check prior comparison files: if the same Significant recurs for 2 consecutive rounds (appeared in rounds N-2, N-1, and N), treat as stuck → **STAGNATION**.
 - Only recurring Significants, no new findings → **STAGNATION**.
+- **Minor accumulation (zero recurring F/S).** Maintain the persisted **"Consecutive recurring-Minor rounds"** counter (Output Format → Classification). **Increment** it when this round has **zero recurring Fatals and zero recurring Significants** AND Minors are recurring or the Minor count is non-decreasing across this and the prior comparison round; **reset to 0** otherwise. When that counter reaches **2** (this round plus the prior comparison file's persisted value), classify **DIMINISHING_RETURNS** — the loop is surfacing spec-hygiene without converging it. A single round (counter = 1) is not enough. This sits alongside the recurring-Significant bullets above and does not touch the recurring-F/S STAGNATION cases (their "recurring Fatal" / "recurring Significant" preconditions are mutually exclusive with "zero recurring F/S"). **Fail-open:** if uncertain whether Minors are recurring, classify as New, reset the counter, and prefer PROGRESS. **DR-Cause on this path:** when this rule fires, emit `DR-Cause: minor-accumulation`.
 
 ### Step 4: Consecutive-Round Tracking (only when all findings are new)
 
 Read prior comparison files to determine if this is the second consecutive all-new-all-Structural round:
 
 - **First all-Structural round** (no prior comparison file shows all-Structural, or prior round was not all-Structural): verdict = **PROGRESS**. Continue to confirm classification is stable.
-- **Second consecutive all-Structural round** (prior comparison file also shows all-new-all-Structural): verdict = **DIMINISHING_RETURNS**.
+- **Second consecutive all-Structural round** (prior comparison file also shows all-new-all-Structural): verdict = **DIMINISHING_RETURNS** → emit `DR-Cause: structural-saturation`.
 
 ### Fail-Open Defaults
 
@@ -80,6 +81,8 @@ Return exactly this structure:
 
 **Verdict:** PROGRESS | STAGNATION | DIMINISHING_RETURNS
 
+**DR-Cause:** minor-accumulation | structural-saturation | none
+
 ### Comparison Table
 | Round N-1 Finding | Round N Finding | Match | Fix Status | Reasoning |
 |---|---|---|---|---|
@@ -90,9 +93,12 @@ Return exactly this structure:
 - **New findings:** [list or "None"]
 - **Difficulty classes (if all new):** [Surface/Structural per finding, or "N/A"]
 - **Consecutive structural rounds:** [0 | 1 | 2]
+- **Consecutive recurring-Minor rounds:** [0 | 1 | 2]
 
 ### Reasoning
 [1-2 sentences explaining the verdict]
 ~~~
 
-**Important:** Do not pad, hedge, or add caveats outside the structure. The orchestrator parses the Verdict line directly.
+**DR-Cause emission.** On any **DIMINISHING_RETURNS** verdict, set `DR-Cause` to the cause of *this* firing: `minor-accumulation` (Step 3 Mixed Minor-accumulation rule) or `structural-saturation` (Step 4 all-Structural rule). On **any non-DIMINISHING_RETURNS verdict** (PROGRESS / STAGNATION), emit `DR-Cause: none`.
+
+**Important:** Do not pad, hedge, or add caveats outside the structure. The orchestrator parses the `Verdict:` and `DR-Cause:` lines directly (it reads the `DR-Cause:` line the same way it reads the `Verdict:` line).

--- a/skills/stocktake/SKILL.md
+++ b/skills/stocktake/SKILL.md
@@ -52,6 +52,7 @@ Present inventory table:
 
 **Structural invariants (repo-level).** Run the tracked invariant checker from the repo root and treat a non-zero exit as a stocktake failure to surface:
 - `python3 scripts/check_i2_marker.py` — the I2 engine-dispatch marker allowlist: the set of files carrying a column-0 `` `dispatch: delve-engine` `` body line must equal exactly `{delve, temper}` (a stray third dispatcher or a missing one fails). Added #336.
+- `python3 scripts/check_qg_stagnation_minor.py` — the Minor-aware stagnation judge contract: asserts `quality-gate/stagnation-judge-prompt.md` carries the Step-3 Mixed-branch Minor-accumulation rule + the `Consecutive recurring-Minor rounds` counter + the `DR-Cause` enum; that `quality-gate/SKILL.md`'s Minor prose is reconciled (the bare "do not count toward stagnation" claim is gone; path-pinned, literal match); and that the convergence-log `dr_cause` value set (`minor-accumulation | structural-saturation | consensus | null`) is documented. Added #260.
 
 (Other tracked checkers under `scripts/check_*.py` may be run here too as they are brought into alignment.)
 


### PR DESCRIPTION
## What & why

`/quality-gate` drove stagnation/regression detection off a weighted score (`Fatal=3, Significant=1, Minor=0`), so accumulating **Minors were invisible** to convergence detection (#260). A recent `audit` gate ended round 7 clean of F/S but with 7 Minors; "fix surfaces deeper Minors" thrash was undetectable.

**Re-weighting was the obvious move — and it's wrong.** The design gate's red-team proved any `Minor>0` weighting is unsound: the weighted score feeds **magnitude-blind sign-test hard-exits** (sustained-regression at `SKILL.md:558`, oscillation at `:560`) that fire on the *direction* of two strict score increases. Under `Minor>0`, a clean-of-F/S artifact surfacing 4→6→9 Minors (exactly what look-harder/tail-rubric is *designed* to produce) would trip a **false `SUSTAINED_REGRESSION`**. So this PR is **judge-only**: it makes the semantic stagnation judge Minor-aware and leaves the weighted score untouched.

## The change

- **D1 — judge rule.** New Step-3 **Mixed-branch** rule: when 2 consecutive rounds have **zero recurring Fatals/Significants but recurring/non-decreasing Minors** (tracked by a new persisted `Consecutive recurring-Minor rounds` counter, mirroring the existing structural counter) → **DIMINISHING_RETURNS**. Mutually exclusive with the recurring-F/S STAGNATION cases (no shadowing/override). Fail-open to PROGRESS. Routes to **user judgment, not a forced fix loop** — Minors still never trigger fix rounds and never enter the weighted score.
- **D5 — telemetry.** A `DR-Cause:` judge-output discriminator (`minor-accumulation | structural-saturation | none`) + a **convergence-log-only** `dr_cause` field (no `marker_version` bump; firing-rate denominators filter on key-presence). Distinct user message per cause at both DR escalation sites; consensus/unattributable falls back to the default. Lets the new rule's firing rate actually be measured.
- **D2.** Reconcile the Minor-handling prose (`SKILL.md:760`) — it no longer claims Minors are wholly stagnation-irrelevant.
- **D3 (#258 item 1).** Document that a chunked gate dispatches **siege once on the full artifact**, not per-chunk, with the chunk-local tradeoff.
- **Acceptance test.** `scripts/check_qg_stagnation_minor.py` — a path-pinned stdlib structural checker (two-stage `dr_cause` scope, section-anchored Mixed-branch guard), wired into `/stocktake`. Authored RED, flips GREEN after the edits.

## Honest scope boundary

This does **not** catch #260's *literal* example — a **clean-of-F/S round** that accumulates Minors — because a `0F/0S` round is a clean PASS (precedence slot #1) that shadows the judge (slot #7). Catching it requires gating clean-pass on Minors, a load-bearing-criterion change with its own risk budget — **deferred to a separate ticket**. What this delivers is the reachable case: Minor accumulation on rounds that still carry churning F/S at a flat score.

## #258 disposition
- **(1) chunked-gate siege scope** — FIXED (D3).
- **(2) interactive check-in placement** — addressed (check-in is now `ceil(threshold/2)`, threshold-relative); the ~1-round window at `threshold=3` is inherent to short-threshold artifacts and accepted.
- **(3) `diminishing-returns` naming asymmetry** — won't-fix; the token is load-bearing across the verdict grammar / Reason enum / convergence-log, so a rename is a breaking change for cosmetic gain.

## Verification
- `check_qg_stagnation_minor.py`, `check_canonical_drift.py`, `check_i2_marker.py` — all exit 0.
- Weighted score (`3/1/0`) unchanged; no `marker_version` bump; no verdict-marker field; clean-pass not gated on Minors.
- Built via the full `/build` pipeline: design gate (10→10→3→2→0, look-harder confirmed), plan gate (4→1→1→0), code gate (1→0). Cumulative across gates: 2 Fatal + ~16 Significant found and fixed before merge.

Refs #260, #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)