### PR TITLE
fix(#366): make red-team a first-class Evidence Receipt citizen (RT-QG-RECEIPT-DRIFT)

### DIFF
--- a/scripts/check_rt_receipt_contract.py
+++ b/scripts/check_rt_receipt_contract.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Structural checker for the #366 red-team ↔ quality-gate Evidence Receipt contract.
+
+Invocation (from repo root):
+    python3 scripts/check_rt_receipt_contract.py
+
+Acceptance test for #366 (design:
+`docs/plans/2026-06-06-366-rt-qg-receipt-contract-design.md`). Asserts the design's
+acceptance criteria over exactly FOUR named skill-methodology Markdown files:
+
+    skills/red-team/red-team-prompt.md   — Report Format / RCPT v1.1 / worked examples
+    skills/quality-gate/SKILL.md         — consumption + fix-agent supersession + writer-inversion
+    skills/red-team/SKILL.md             — standalone consumption (Tier-1 lint, no Layer-2 sweep)
+    skills/shared/return-convention.md   — kind=grep artifact/range clarification
+
+Each assertion is keyed to a design AC and carries an ID prefix ([A1], [C13], …) in
+its violation string. Every assertion pins on a token/phrase the corresponding edit
+INTRODUCES (absent in the unedited file) so it discriminates RED→GREEN; [A6] is the
+sole exception — a retain-guard that is GREEN at baseline and only goes RED if a
+future edit DELETES the rich findings sections.
+
+NO directory tree-walk: only the four named files are read, so the checker can never
+self-match its own literal pin strings. Stdlib only (`pathlib`, `re`, `sys`).
+Exits 0 if all assertions hold, 1 with a bulleted violation list otherwise.
+
+Mirrors `scripts/check_canonical_drift.py` and `scripts/check_i2_marker.py`.
+"""
+from __future__ import annotations
+import pathlib, re, sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+RT_PROMPT = ROOT / "skills/red-team/red-team-prompt.md"
+QG_SKILL = ROOT / "skills/quality-gate/SKILL.md"
+RT_SKILL = ROOT / "skills/red-team/SKILL.md"
+RETURN_CONV = ROOT / "skills/shared/return-convention.md"
+
+# Worked-example markers Task 1 DECLARES and Task 2 emits verbatim (load-bearing
+# coupling — the checker keys block extraction off these exact strings).
+PASS_MARKER = "<!-- worked-example: PASS -->"
+FAIL_MARKER = "<!-- worked-example: FAIL -->"
+
+
+# ---------------------------------------------------------------------------
+# A. red-team-prompt.md — Report Format / RCPT v1.1 (design AC#1, #2)
+# ---------------------------------------------------------------------------
+
+def check_rt_prompt(text: str) -> list[str]:
+    errs: list[str] = []
+
+    # [A1] receipt header token
+    if "RCPT v1.1" not in text:
+        errs.append("[A1] red-team-prompt.md: missing receipt header token 'RCPT v1.1'")
+
+    # [A2] all seven receipt section labels — CASE-SENSITIVE uppercase labels.
+    # The existing prose `Verdict:` / `Confidence` must NOT satisfy these pins.
+    for label in ("VERDICT", "ARTIFACTS", "TRACE", "CLAIMS", "WITNESS", "SUSPICION", "NEXT"):
+        if label not in text:
+            errs.append(f"[A2] red-team-prompt.md: missing uppercase receipt label '{label}'")
+
+    # [A3] mandatory v1.1 lines
+    for tok in ("TRIPWIRE:", "SUPERSEDES:"):
+        if tok not in text:
+            errs.append(f"[A3] red-team-prompt.md: missing mandatory v1.1 line token '{tok}'")
+
+    # [A4] findings-output placeholder
+    if "[FINDINGS_OUTPUT_PATH]" not in text:
+        errs.append("[A4] red-team-prompt.md: missing placeholder '[FINDINGS_OUTPUT_PATH]'")
+
+    # [A5] counts-line spec token + field names
+    if "SEVERITY-COUNTS:" not in text:
+        errs.append("[A5] red-team-prompt.md: missing counts-line token 'SEVERITY-COUNTS:'")
+    for field in ("fatal=", "significant=", "minor="):
+        if field not in text:
+            errs.append(f"[A5] red-team-prompt.md: missing SEVERITY-COUNTS field name '{field}'")
+
+    # [A6] RETAIN-GUARD: rich findings sections still present. GREEN at baseline;
+    # goes RED only if a future edit deletes these sections.
+    for section in ("### Fatal Challenges", "### Significant Challenges",
+                    "### Minor Observations", "### Dimension Coverage"):
+        if section not in text:
+            errs.append(f"[A6] red-team-prompt.md: rich findings section '{section}' was DELETED (retain-guard)")
+
+    # [A7] count-derived VERDICT mapping: '0 Fatal' co-located with 'PASS'.
+    if not (re.search(r"0\s+[Ff]atal", text) and "PASS" in text):
+        errs.append("[A7] red-team-prompt.md: missing count-derived VERDICT mapping ('0 Fatal' → 'PASS')")
+
+    # ---- worked PASS/FAIL example pair (design AC#2b) ----
+    pass_marks = text.count(PASS_MARKER)
+    fail_marks = text.count(FAIL_MARKER)
+
+    # [A8] both example markers present, each exactly once
+    if pass_marks != 1 or fail_marks != 1:
+        errs.append(
+            f"[A8] red-team-prompt.md: worked-example markers not found exactly once "
+            f"(PASS marker x{pass_marks}, FAIL marker x{fail_marks}; expected 1 each)"
+        )
+        # Cannot extract blocks reliably — A9/A9b/A10/A11/A12 all depend on the
+        # markers; report them as un-evaluable and return.
+        errs.append("[A9] red-team-prompt.md: WITNESS byte-identity unverifiable — example markers missing")
+        errs.append("[A9b] red-team-prompt.md: WITNESS polarity unverifiable — example markers missing")
+        errs.append("[A10] red-team-prompt.md: PASS-example zero-counts unverifiable — example markers missing")
+        errs.append("[A11] red-team-prompt.md: FAIL-example nonzero-count unverifiable — example markers missing")
+        errs.append("[A12] red-team-prompt.md: FAIL-example internal consistency unverifiable — example markers missing")
+        return errs
+
+    # Each worked example is an indented ```…``` code fence: the marker is followed by
+    # an opening fence, the receipt body, then the receipt's own (indented) closing
+    # fence. Bound each block on that closing fence rather than on a "next ### heading"
+    # — the headings here are indented 4 spaces inside the outer fence, so a bare
+    # "\n### " never matches and the old logic let the block run to EOF (dead boundary).
+    def example_block(marker: str) -> str:
+        start = text.index(marker)
+        body = text[start:]
+        # opening fence (indented ```), then the closing fence that ends the receipt.
+        m_open = re.search(r"\n[ \t]*```[^\n]*\n", body)
+        if m_open is None:
+            return body  # no fence found — fall back to remainder (markers guaranteed present)
+        after_open = m_open.end()
+        m_close = re.search(r"\n[ \t]*```[ \t]*(?:\n|$)", body[after_open:])
+        if m_close is None:
+            return body  # unterminated fence — fall back to remainder
+        return body[: after_open + m_close.end()]
+
+    pass_block = example_block(PASS_MARKER)
+    fail_block = example_block(FAIL_MARKER)
+
+    # [A9] WITNESS line byte-identical between the two examples (strip ONE trailing newline).
+    def witness_line(block: str) -> str | None:
+        m = re.search(r"^[ \t>]*WITNESS .*$", block, re.MULTILINE)
+        return m.group(0) if m else None
+
+    w_pass = witness_line(pass_block)
+    w_fail = witness_line(fail_block)
+    if w_pass is None or w_fail is None:
+        errs.append("[A9] red-team-prompt.md: WITNESS line missing in PASS and/or FAIL example block")
+    else:
+        if w_pass.rstrip("\n") != w_fail.rstrip("\n"):
+            errs.append(
+                "[A9] red-team-prompt.md: WITNESS lines differ between PASS and FAIL examples "
+                "(must be byte-identical):\n"
+                f"        PASS: {w_pass!r}\n        FAIL: {w_fail!r}"
+            )
+        # [A9b] shared WITNESS line carries correct semantic polarity.
+        shared = w_pass
+        m_pat = re.search(r"pattern=(\S+)", shared)
+        pat = m_pat.group(1) if m_pat else ""
+        ok_a9b = (
+            "fatal=[1-9]" in shared
+            and "significant=[1-9]" in shared
+            and "expect-fail=match" in shared
+        )
+        if not ok_a9b:
+            errs.append(
+                "[A9b] red-team-prompt.md: shared WITNESS line lacks correct polarity — "
+                "pattern= must contain both 'fatal=[1-9]' and 'significant=[1-9]' AND the line "
+                f"must carry 'expect-fail=match' (got pattern={pat!r})"
+            )
+
+    # [A10] PASS example: fatal-count=0 AND significant-count=0 in CLAIMS,
+    #       AND a SEVERITY-COUNTS line with fatal=0 significant=0.
+    a10_ok = (
+        "fatal-count=0" in pass_block
+        and "significant-count=0" in pass_block
+        and re.search(r"SEVERITY-COUNTS:.*fatal=0", pass_block)
+        and re.search(r"SEVERITY-COUNTS:.*significant=0", pass_block)
+    )
+    if not a10_ok:
+        errs.append(
+            "[A10] red-team-prompt.md: PASS example must carry CLAIMS 'fatal-count=0' + "
+            "'significant-count=0' AND a 'SEVERITY-COUNTS:' line with fatal=0 significant=0"
+        )
+
+    # [A11] FAIL example: a non-zero fatal-count= or significant-count=.
+    if not re.search(r"(fatal|significant)-count=[1-9]", fail_block):
+        errs.append(
+            "[A11] red-team-prompt.md: FAIL example must carry a non-zero "
+            "'(fatal|significant)-count=[1-9]'"
+        )
+
+    # [A12] FAIL example internally consistent: CLAIMS pattern value-pins match the
+    #       FAIL block's own SEVERITY-COUNTS line. Field-order/whitespace tolerant.
+    sc = re.search(r"SEVERITY-COUNTS:(.*)", fail_block)
+    if sc is None:
+        errs.append("[A12] red-team-prompt.md: FAIL example missing its own 'SEVERITY-COUNTS:' line")
+    else:
+        sc_line = sc.group(1)
+        m_a = re.search(r"fatal=(\d+)", sc_line)
+        m_b = re.search(r"significant=(\d+)", sc_line)
+        # pattern=fatal=(\d+) cannot latch onto the witness line because the witness
+        # pattern= is immediately followed by '/' (a non-digit) — see M5 note in plan.
+        m_c = re.search(r"pattern=fatal=(\d+)", fail_block)
+        m_d = re.search(r"pattern=significant=(\d+)", fail_block)
+        if not (m_a and m_b and m_c and m_d):
+            errs.append(
+                "[A12] red-team-prompt.md: FAIL example missing parseable SEVERITY-COUNTS "
+                "fatal=/significant= AND CLAIMS pattern=fatal=/pattern=significant= value-pins"
+            )
+        else:
+            a, b, c, d = (m_a.group(1), m_b.group(1), m_c.group(1), m_d.group(1))
+            if a != c or b != d:
+                errs.append(
+                    "[A12] red-team-prompt.md: FAIL example CLAIMS value-pins contradict its own "
+                    f"SEVERITY-COUNTS line (counts fatal={a} significant={b}; "
+                    f"CLAIMS pattern=fatal={c} pattern=significant={d})"
+                )
+
+    # [A13] CLAIMS citations use the convention's two-endpoint range form
+    #       (<artifact>#L<a>-L<b>; return-convention.md:85), NOT a bare <artifact>#L<n>.
+    #       Bare #L<n> is not an enumerated citation grammar form. Scans every CLAIMS
+    #       `from=` in both worked-example blocks: each must carry an L-range, and NONE
+    #       may carry a bare #L<n> with no '-L' suffix.
+    for label, block in (("PASS", pass_block), ("FAIL", fail_block)):
+        from_cites = re.findall(r"from=\S+#L\d+(?:-L\d+)?", block)
+        bad = [c for c in from_cites if not re.search(r"#L\d+-L\d+$", c)]
+        if not from_cites:
+            errs.append(
+                f"[A13] red-team-prompt.md: {label} example has no CLAIMS 'from=...#L<a>-L<b>' "
+                "citation (expected the SEVERITY-COUNTS line range form)"
+            )
+        elif bad:
+            errs.append(
+                f"[A13] red-team-prompt.md: {label} example CLAIMS citation uses the "
+                "non-conformant bare '#L<n>' form instead of the convention's '#L<a>-L<b>' "
+                f"range form (return-convention.md:85): {bad}"
+            )
+
+    return errs
+
+
+# ---------------------------------------------------------------------------
+# C. quality-gate/SKILL.md — consumption + supersession + writer-inversion
+# ---------------------------------------------------------------------------
+
+def check_qg(text: str) -> list[str]:
+    errs: list[str] = []
+
+    # [C13] score computed from findings-file severity sections, NOT from CLAIMS.
+    if not ("### Fatal Challenges" in text and "### Significant Challenges" in text
+            and "cross-check" in text):
+        errs.append(
+            "[C13] quality-gate/SKILL.md: missing score-source wording pinning the weighted "
+            "score to counting '### Fatal Challenges' / '### Significant Challenges' sections of "
+            "the cited findings file with an explicit CLAIMS 'cross-check' disclaimer"
+        )
+
+    # [C14] [FINDINGS_OUTPUT_PATH] named as orchestrator-supplied (NEW phrase only;
+    #       do NOT pin on round-N-findings.md which pre-exists ~10x).
+    if "orchestrator-supplied" not in text:
+        errs.append(
+            "[C14] quality-gate/SKILL.md: missing 'orchestrator-supplied' wording naming "
+            "[FINDINGS_OUTPUT_PATH] as supplied by the orchestrator"
+        )
+
+    # [C15] :30 no longer implies red-team prose is linted-to-BLOCKED — keyed to the
+    #       rewrite's positive token (findings come from the cited artifact).
+    if "cited artifact" not in text:
+        errs.append(
+            "[C15] quality-gate/SKILL.md: missing the :30 rewrite asserting red-team findings "
+            "come from the 'cited artifact' (negative-corruption phrasing not yet replaced)"
+        )
+
+    # [C16] SP2 clean-PASS TRIPWIRE predicate as a contextual POINTER to the convention.
+    c16_ok = (
+        "TRIPWIRE: none" in text
+        and "SUSPICION=0.00" in text
+        and "return-convention.md" in text
+    )
+    if not c16_ok:
+        errs.append(
+            "[C16] quality-gate/SKILL.md: missing SP2 pointer — 'TRIPWIRE: none' co-located with "
+            "'SUSPICION=0.00' AND a 'return-convention.md' reference (link, not redeclaration)"
+        )
+
+    # [C17] SP3 negative invariant: no manifest-sweep re-hashes pinned ARTIFACTS after insertion.
+    c17_ok = ("re-hash" in text and "ARTIFACTS" in text and "after insertion" in text)
+    if not c17_ok:
+        errs.append(
+            "[C17] quality-gate/SKILL.md: missing SP3 negative invariant (no manifest-sweep step "
+            "'re-hash'es a prior entry's pinned 'ARTIFACTS' 'after insertion')"
+        )
+
+    # [C18] fix-agent test-less superseding-witness pattern (NEW phrasing only;
+    #       NOT bare 'revised artifact' which pre-exists).
+    c18_ok = ("test-less" in text and ("finding-anchor" in text or "no longer appears" in text))
+    if not c18_ok:
+        errs.append(
+            "[C18] quality-gate/SKILL.md: missing fix-agent test-less superseding-witness pattern "
+            "('test-less' co-located with 'finding-anchor' / 'no longer appears')"
+        )
+
+    # [C18b] writer-inversion token.
+    if "initial writer" not in text:
+        errs.append(
+            "[C18b] quality-gate/SKILL.md: missing writer-inversion token 'initial writer' "
+            "(reviewer is the initial writer of round-N-findings.md)"
+        )
+
+    return errs
+
+
+# ---------------------------------------------------------------------------
+# D. red-team/SKILL.md — standalone consumption (design AC#4)
+# ---------------------------------------------------------------------------
+
+def check_rt_skill(text: str) -> list[str]:
+    errs: list[str] = []
+
+    # [D19] both qualitative branch + weighted-score loop derive from the same single
+    #       source: the orchestrator's count of the cited findings file's sections.
+    d19_ok = ("cited findings" in text
+              and ("### Fatal Challenges" in text or "### Significant Challenges" in text)
+              and ("single source" in text or "same source" in text or "same single source" in text))
+    if not d19_ok:
+        errs.append(
+            "[D19] red-team/SKILL.md: missing single-source-of-truth wording pinning BOTH the "
+            "qualitative branch and the weighted-score loop to the cited findings file's severity "
+            "sections (e.g. 'cited findings' + section heading + 'same/single source')"
+        )
+
+    # [D20] Tier-1 structural lint applied AND NOT the Layer-2 sweep.
+    d20_ok = (("Tier-1" in text or "Tier 1" in text)
+              and ("Layer-2 sweep" in text or "Layer 2 sweep" in text))
+    if not d20_ok:
+        errs.append(
+            "[D20] red-team/SKILL.md: missing standalone Tier-1-lint pin AND a 'Layer-2 sweep' "
+            "(QG-only / 'no Layer-2 sweep') exclusion pin"
+        )
+
+    return errs
+
+
+# ---------------------------------------------------------------------------
+# E. return-convention.md — kind=grep clarification (design AC#4c)
+# ---------------------------------------------------------------------------
+
+def check_return_conv(text: str) -> list[str]:
+    errs: list[str] = []
+
+    # [E21] one statement: for kind=grep the cited artifact/range are the payload's own
+    #       #<range>; out= resolution is kind=exec-only; scope references Tier-1 + Tier-2.
+    # Pin on NEW phrases ('payload's own' + an out=…exec-only clause) — 'kind=grep',
+    # 'Tier-1', 'Tier-2', 'out=' all pre-exist and cannot discriminate alone.
+    has_payload_range = "payload's own" in text
+    has_out_exec_only = bool(re.search(r"out=[^\n]{0,60}?\bexec[`)]?-only", text))
+    has_scope = ("Tier-1" in text and "Tier-2" in text)
+    if not (has_payload_range and has_out_exec_only and has_scope):
+        missing = []
+        if not has_payload_range:
+            missing.append("\"payload's own\" range wording")
+        if not has_out_exec_only:
+            missing.append("an 'out=' resolution is 'exec-only' clause")
+        if not has_scope:
+            missing.append("Tier-1 + Tier-2 scope reference")
+        errs.append(
+            "[E21] return-convention.md: missing the kind=grep artifact/range clarification — "
+            + "; ".join(missing)
+        )
+
+    return errs
+
+
+def main() -> int:
+    errs: list[str] = []
+    errs += check_rt_prompt(RT_PROMPT.read_text(encoding="utf-8"))
+    errs += check_qg(QG_SKILL.read_text(encoding="utf-8"))
+    errs += check_rt_skill(RT_SKILL.read_text(encoding="utf-8"))
+    errs += check_return_conv(RETURN_CONV.read_text(encoding="utf-8"))
+
+    if errs:
+        print("RT-RECEIPT-CONTRACT VIOLATIONS:")
+        for e in errs:
+            print(f"  - {e}")
+        return 1
+    print("OK — #366 red-team↔quality-gate receipt contract satisfied across all four files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -29,6 +29,8 @@ Apply Tier 1 (structural) and Tier 2 (witness verification) lint per `shared/ret
 
 **Quality-gate-specific obligations:** Receipts from red-team, fix, judge, verifier (the fix-verification dispatch; the persistence-checker JSON output is consumed directly, not receipt-linted — see Persistence Check), and dependency-audit subagents are all linted before their VERDICT is consumed. A lint failure is treated as structurally `BLOCKED` regardless of declared VERDICT — see "Lint failure handling" in the shared convention.
 
+**Red-team receipts lint clean (#366).** Red-team returns a structured `RCPT v1.1` receipt (not prose), so its receipt passes Tier-1/Tier-2 normally — it does **not** lint-to-`BLOCKED`. The red-team **findings** themselves come from the **cited artifact** the receipt pins (`round-N-findings.md`, an `[FINDINGS_OUTPUT_PATH]` the orchestrator supplies — see the score step and writer-inversion below), which the orchestrator reads directly; the receipt's VERDICT is the witness-verified PASS/FAIL boundary plus the supersession/tripwire anchor, not the findings channel. This makes the `:44`/`:56`/`:62` couplings operational (red-team genuinely emits a receipt).
+
 ## Cairn (Layer 3)
 
 Per `shared/cairn-convention.md`. Quality-gate-specific bindings:
@@ -54,6 +56,13 @@ Namespace CLAIM-key discriminators as `quality-gate:<key>` (e.g. `quality-gate:s
 **Sweep (dispatch-loop clause):** The orchestrator MAY NOT dispatch the next round until it has: (1) linted; (2) appended; (3) processed SUPERSEDES; (4) evaluated self-checks; (5) evaluated forward-checks against every active prior entry (TRIPWIRE ∪ TRIPWIRE-CHILD); (6) Read each firing M's full receipt and narrated the re-read; (7) then dispatch.
 
 **Fix-agent supersession.** A QG fix-agent supersedes the prior FAIL red-team receipt. `SUPERSEDES: <fail-prefix>` + cited CLAIM + `exec`/`grep` witness with `ran=TRACE#N`. Tier-2 re-runs the witness against the fix — only survives if clean.
+
+**Fix-agent superseding-witness by artifact class (#366).** Because the red-team FAIL receipt is now a real supersession anchor, the convention's witness-evidence requirement (a FAIL / `SUSPICION ≥ 0.30` predecessor demands the superseding `WITNESS` be `kind ∈ {exec, grep}` + `ran=TRACE#N`) is live on the fix-agent's superseding receipt:
+
+- **Test-less artifacts (test-less design / plan / doc gates — the dominant QG case):** the fix-agent's superseding receipt carries a **`grep` witness against the revised artifact** proving the superseded red-team **finding-anchor** text **no longer appears** (`kind=grep`, `ran=TRACE#N`), **plus** the justification CLAIM citing the FAIL receipt's prefix (`from=<fail-prefix>#…`, per the SUPERSEDES Tier-1 justification requirement in `return-convention.md`). This is what makes the supersession survive Tier-2 — the original concern demonstrably no longer reproduces.
+- **Artifacts WITH tests:** the existing `run-tests` exec witness applies (the `run-tests` mandatory-work declaration above).
+
+**Clean-PASS TRIPWIRE predicate (#366, SP2).** Per the convention's TRIPWIRE-none rule at `return-convention.md` (the Tripwire Manifest section, ~`:427`), `TRIPWIRE: none` is permitted **only** on a PASS receipt with `SUSPICION=0.00`; a FAIL red-team receipt carries `TRIPWIRE: verdict=FAIL`. This is a pointer to the canonical rule, not a redeclaration of the grammar (per CLAUDE.md "link, never copy").
 
 **Stagnation-judge tripwires.** A stagnation judge's receipt declaring `TRIPWIRE: peer-dispatch-disagrees(count)` lets a later round's divergent issue-count fire a re-read, surfacing judge-vs-judge disagreement without a separate escalation channel.
 
@@ -227,6 +236,8 @@ The user's response routes to: continue (loop with suppression intact), escalate
 
         After step 3, the round becomes a normal non-clean round and proceeds to the fix loop (step 6 below). Do NOT re-dispatch siege — siege's prior verdict carries forward; the existing siege-await ordering applies on the next candidate-clean round without a fresh siege dispatch. The terminal sentinel `round-N-complete.md` is NOT written (round became non-terminal). `LookHarderFiredCount` is incremented and the round's LOCAL number is appended to `LookHarderRounds`. `round-N-look-harder.md` is retained as a separate telemetry artifact.
 
+        **Stale-pin inertness (#366) — no supersession needed.** The candidate-clean PASS red-team receipt pinned the pre-overwrite `round-N-findings.md` sha256 in its `ARTIFACTS`; the INV-A17 overwrite makes that pinned hash **stale**. This stale pin is **inert** and needs **no `SUPERSEDES:`**: (a) the candidate-clean PASS receipt's Tier-2 ran **once at insertion** against the then-current file (pre-overwrite) and passed, and (b) no manifest-sweep step re-hashes a prior entry's pinned `ARTIFACTS` against disk after insertion (see the SP3 negative invariant in the invariant table) — so nothing ever reads the stale pin again. The demotion is recorded by the existing INV-A17 mechanism (the overwrite + the Phase-2 flags write), **not** by supersession: a demotion ("the prior clean verdict was wrong", whose witness MUST fire) is the opposite of supersession's semantics ("the prior concern no longer reproduces", whose witness must NOT fire), so `SUPERSEDES:` is the wrong primitive for a demotion. The look-harder FAIL receipt is therefore a normal fresh manifest entry, not a superseding one.
+
       Look-harder does NOT increment the gate's round counter (INV-A2). It is a verification step within slot #1; if it confirms, slot #1 stands; if it demotes, slot #1 is invalidated.
 
    5. Proceed to **Minor Issue Handling** (quick-fix pass on consolidated minors). Minor Issue Handling does not re-trigger siege — it operates on a known-passed artifact.
@@ -250,6 +261,11 @@ The user's response routes to: continue (loop with suppression intact), escalate
    e. If Significant-severity Unresolved: appended to fix journal as informational context
    f. Invoke a FRESH red-team on the revised artifact (no anchoring)
 7. Track weighted score between rounds (Fatal=3, Significant=1):
+
+   **Score source (#366).** The weighted score is computed by the **orchestrator counting the cited findings file's `### Fatal Challenges` / `### Significant Challenges` sections** (the entries under each heading) — **not** from the receipt's CLAIMS. The receipt's `SEVERITY-COUNTS:` line and CLAIMS `*-count=` values are **reviewer-declared cross-checks**: on disagreement with the orchestrator's own section count, the orchestrator **trusts its own count for scoring and flags the discrepancy** in the narration log. This keeps the score un-spoofable — a fabricated declared count cannot move it. The receipt's role is narrower than the score: trust-check VERDICT boundary, supersession anchor (`:56`), tripwire participation (`:44`), and hash-pinned findings artifact.
+
+   **Findings path & writer-inversion (#366).** The `[FINDINGS_OUTPUT_PATH]` is **orchestrator-supplied**: the orchestrator supplies it = the round's `round-N-findings.md` path when it composes the red-team dispatch (it already owns that path). The red-team reviewer is now the **initial writer** of `round-N-findings.md` (it `WROTE`s the file; the receipt's TRACE carries that write) — QG no longer transcribes the reviewer's prose return into that file; it only **reads** the cited artifact (for fix-agent context, the stagnation judge, and look-harder/persistence diffs). The prepended `SEVERITY-COUNTS:` first line is benign for the persistence-checker (it matches findings by title/root-cause, not line number) and tolerated by the look-harder format.
+
    - **Strictly lower score** → progress, loop again
    - **Same or higher score** → dispatch the Stagnation Judge (see Stagnation Detection below)
 8. Read the judge's verdict and act on it (see Stagnation Detection below). See `## Stagnation Detection > Persistence Check` for the orchestrator step that runs BEFORE judge dispatch (Component 4 / #265), and `## Stagnation Detection > Verdict-Level Promotion` for the post-judge promotion step that may convert a `PROGRESS` verdict to `STAGNATION, Reason: persistent-finding-corroborated`.
@@ -1265,6 +1281,7 @@ The invariants below govern the look-harder verification (Component 1), the tail
 | INV-A15 | `chunk_id` grammar restricted to `chunk-<N>` (positive integer) | `cross-chunk`; gate refuses to start on non-conforming chunk dirs |
 | INV-A16 | `ChunkHash` on per-chunk markers only; omitted on non-chunked markers and on cross-chunk integration marker |
 | INV-A17 | On a look-harder-demoted round, `round-N-findings.md` is overwritten with look-harder findings before fix dispatch; `round-N-look-harder.md` is retained |
+| INV-A18 | No manifest-sweep step re-hashes a prior manifest entry's pinned `ARTIFACTS` against disk after insertion (the sweep only re-reads a receipt's text on a tripwire fire) — this is the load-bearing fact making a look-harder-demoted candidate-clean receipt's now-stale pinned hash inert (#366, SP3) |
 
 ### Testable (INV-T1 — INV-T16, with T2b/T2c/T5b suffix variants)
 

--- a/skills/red-team/SKILL.md
+++ b/skills/red-team/SKILL.md
@@ -107,7 +107,7 @@ Cost-cap signal: <fired | not fired>
 (none)
 ```
 
-The ledger is emitted every round regardless of `cost_cap_threshold` / `dr_signal_findings` values (those args control prompts, not emission).
+The ledger is emitted every round regardless of `cost_cap_threshold` / `dr_signal_findings` values (those args control prompts, not emission). The ledger format is **unchanged**; its `Total findings: N (F: x, S: y, M: z)` counts now derive from the orchestrator's own section count of the cited findings file (the same single source as the score, #366), with the receipt's `SEVERITY-COUNTS:` line as a declared cross-check.
 
 **Diminishing-return signal (standalone-mode, interactive only, #303):** When `dr_signal_findings != null` AND LOCAL round ≥ 2 AND the count of NEW (delta-vs-prior-round) Fatal+Significant findings ≤ `dr_signal_findings`, emit prompt: "Red-team round N surfaced only K NEW Fatal+Significant findings. Diminishing returns reached. Continue or escalate?" Non-interactive: log `DR signal: fired` in the round ledger; no prompt; loop continues.
 
@@ -148,13 +148,19 @@ type-resolution failure, not a transcript/metadata read.
 
 ### 3. Process findings
 
-- **No Fatal/Significant issues:** Artifact is approved. Proceed.
-- **Fatal/Significant issues found:** Compute the weighted score (Fatal=3, Significant=1). Dispatch fix mechanism. Then go to step 4.
+**Single source of truth (#366).** The reviewer `WROTE`s its rich findings to the cited findings file (`[FINDINGS_OUTPUT_PATH]`) and returns an `RCPT v1.1` receipt citing it. **Both** the qualitative branches below **and** the weighted-score loop (step 4) derive from the **orchestrator's own count of the cited findings file's `### Fatal Challenges` / `### Significant Challenges` sections** — the **same single source**, so the qualitative verdict and the score cannot diverge. The receipt's CLAIMS / `SEVERITY-COUNTS:` line remain reviewer-declared cross-checks, **not** the score source.
+
+- **No Fatal/Significant issues** (cited findings file has zero `### Fatal Challenges` / `### Significant Challenges` entries)**:** Artifact is approved. Proceed.
+- **Fatal/Significant issues found** (cited findings file has ≥1 such entry)**:** Compute the weighted score (Fatal=3, Significant=1) from those sections. Dispatch fix mechanism. Then go to step 4.
 - **Architectural concerns:** Escalate to user immediately. Do not attempt to fix.
+
+**Tier-1 structural lint (standalone, #366).** The **same** `RCPT v1.1` receipt `red-team-prompt.md` emits is received here regardless of caller. Standalone runs the v1.1 **Tier-1** structural linter **only** (per `shared/return-convention.md`'s Integration Checklist — link it, don't copy), including the mandatory `TRIPWIRE:` / `SUPERSEDES:` structural checks. Standalone does **NOT** run QG's **Layer-2 sweep** — the tripwire manifest, the 7-step dispatch-loop sweep, `SUPERSEDES:` processing, and `receipt-ledger.jsonl` parent-child binding are **QG-only** (only QG has the multi-dispatch manifest those operate over). In standalone the `TRIPWIRE:` / `SUPERSEDES:` lines are validated structurally but are **inert as tripwires** (no manifest to sweep). A Tier-2 witness re-read of the receipt's grep is permitted but optional.
+
+<!-- CANONICAL: shared/return-convention.md -->
 
 ### 4. Re-review after fixes
 
-Dispatch a NEW Devil's Advocate subagent (fresh, no prior context, `subagent_type: crucible-red-team`). Compute weighted score and compare:
+Dispatch a NEW Devil's Advocate subagent (fresh, no prior context, `subagent_type: crucible-red-team`). Compute the weighted score from the **same single source** — the orchestrator's count of the new round's cited findings file's `### Fatal Challenges` / `### Significant Challenges` sections (not from the return prose, not from CLAIMS) — and compare:
 - **Strictly lower weighted score:** Progress. Loop back to step 3.
 - **Same or higher weighted score:** Stagnation. Escalate to user with findings from both rounds.
 

--- a/skills/red-team/red-team-prompt.md
+++ b/skills/red-team/red-team-prompt.md
@@ -121,6 +121,24 @@ Task tool (subagent_type: crucible-red-team):
 
     ## Report Format
 
+    Your output has **two channels**: (1) you **WRITE** your full rich report to the
+    findings file the orchestrator supplies via `[FINDINGS_OUTPUT_PATH]`; (2) you **RETURN**
+    exactly one Evidence Receipt that cites that file. **No report content is lost — only its
+    return channel moves from inline prose to an on-disk artifact.**
+
+    ### Channel 1 — the findings file (written to `[FINDINGS_OUTPUT_PATH]`)
+
+    Write your complete report to `[FINDINGS_OUTPUT_PATH]`. The **first line** of that file
+    MUST be the machine-readable counts line:
+
+    ```
+    SEVERITY-COUNTS: fatal=<F> significant=<S> minor=<M>
+    ```
+
+    where `<F>`/`<S>`/`<M>` are your Fatal / Significant / Minor counts. The rest of the file
+    is your full report — **keep every section below verbatim in intent** (the report content
+    is moved on-disk, not deleted):
+
     ### Fatal Challenges
     [Each using the steel-man-then-kill protocol]
 
@@ -140,4 +158,140 @@ Task tool (subagent_type: crucible-red-team):
     - **Verdict:** Plan is solid | Has issues that must be addressed | Fundamentally flawed
     - **Confidence:** How confident are you in your challenges? Did you verify your claims against the codebase, or are they based on assumptions?
     - **Summary:** 2-3 sentence overall take
+
+    **Prose-vs-count consistency (REQUIRED).** The prose `### Overall Assessment` verdict in
+    the findings file MUST be consistent with your `SEVERITY-COUNTS:` line: do not write
+    "Has issues that must be addressed" with `fatal=0 significant=0`, and do not write
+    "Plan is solid" with a non-zero `fatal=` or `significant=`. The receipt VERDICT (below),
+    not this prose label, is what the orchestrator consumes — but an inconsistent prose label
+    is a self-contradiction the reviewer must avoid.
+
+    ### Channel 2 — the Evidence Receipt (your RETURN)
+
+    <!-- CANONICAL: shared/return-convention.md -->
+    Return exactly one Evidence Receipt per `shared/return-convention.md` — ONLY the receipt,
+    no surrounding prose. See the shared convention for the grammar, the closed verb
+    vocabulary, and the WITNESS protocol. Pin the header to **`RCPT v1.1`** (quality-gate
+    operates on convention v1.1), so the receipt carries the mandatory Layer-2 `TRIPWIRE:` /
+    `SUPERSEDES:` lines after `NEXT`. Do not copy the convention grammar into this report —
+    link to it. The seven sections, with red-team-specific content:
+
+    - **`VERDICT`** — **count-derived and authoritative**: **0 Fatal AND 0 Significant → `PASS`**
+      (artifact clean this round); **≥1 Fatal or Significant → `FAIL`**. Return `BLOCKED` only
+      if you genuinely cannot review (missing artifact, unsupplied path — see below). `conf=`
+      ← your stated confidence. The receipt VERDICT, not the prose label, is what the
+      orchestrator consumes.
+    - **`ARTIFACTS`** — the findings file you wrote (`<name>  sha256:<hex64>  <size>`).
+    - **`TRACE`** — `READ <artifact-under-review>`; `WROTE <findings-file>` (these satisfy the
+      `read-artifact` / `emit-findings` mandatory-work declarations the orchestrator checks).
+    - **`CLAIMS`** — `fatal-count=<F>`, `significant-count=<S>`, `minor-count=<M>`, each
+      `from=<findings-file>#L1-L1` (the `SEVERITY-COUNTS:` line) with a `pattern=` value-pin
+      matching that line (e.g. `pattern=significant=2` for a 2-Significant round, or
+      `pattern=significant=0` / `pattern=fatal=0` for a clean round). **These CLAIMS counts
+      are reviewer-declared cross-checks, not the score source** — the orchestrator re-derives
+      the weighted score by counting the findings file's severity sections.
+    - **`WITNESS`** — `grep:<findings-file>#<range covering L1>  pattern=/significant=[1-9]|fatal=[1-9]/  expect-fail=match  ran=TRACE#<the-WROTE-findings-file-index>`.
+      The cited range covers `#L1` (the `SEVERITY-COUNTS:` line) and is ≤ 4 KiB. `ran=` points
+      at the `WROTE <findings-file>` TRACE entry. Keep the witness `pattern=` **leading with `/`**
+      (a regex literal). A `WROTE` carries **no `out=` field** (only `EXEC` does); the witness
+      range is named on the WITNESS line itself. **This one line is correct for both verdicts:**
+      Tier-2 fails a `PASS` if the pattern matches (a clean round must have no F/S), and rejects
+      a `FAIL` if the pattern does **not** match (a non-clean round must have ≥1 F/S).
+    - **`SUSPICION`**, **`NEXT`** — per convention.
+    - After `NEXT`: mandatory v1.1 **`TRIPWIRE:`** / **`SUPERSEDES:`** lines. A **FAIL** receipt's
+      `TRIPWIRE:` carries `verdict=FAIL` (the self-firing predicate). `TRIPWIRE: none` is
+      permitted **only** on a PASS receipt with `SUSPICION=0.00` (per the convention's
+      TRIPWIRE-none rule at `return-convention.md`). A FAIL red-team receipt is the
+      supersession anchor the fix-agent later cites — emit a stable receipt.
+
+    **Unsupplied `[FINDINGS_OUTPUT_PATH]` → BLOCKED.** If the orchestrator did not supply
+    `[FINDINGS_OUTPUT_PATH]`, you cannot write a findings file, so return `VERDICT BLOCKED`
+    with `ARTIFACTS` = the literal indented line `(none)` and a Tier-1-valid witness following
+    the convention's BLOCKED example: an `exec:` (or `lint:`) witness with a `≥4-char`
+    `expect-fail` and `ran=UNRUNNABLE:requires-human-input` (the supplied path is a
+    human/orchestrator obligation, and a BLOCKED return has no `WROTE` to point a `ran=TRACE#N`
+    at). Do **not** use `kind=grep` — grep needs a cited artifact a no-findings BLOCKED return
+    does not have. Example:
+
+    ```
+    WITNESS    exec:`test -f [FINDINGS_OUTPUT_PATH]`  expect-fail=/written/  ran=UNRUNNABLE:requires-human-input
+    ```
+
+    ### Worked example receipts (PASS and FAIL)
+
+    Both examples below carry the **byte-identical WITNESS line** and **identical TRACE shapes**
+    (same verbs in the same order, so `ran=TRACE#2` resolves to the `WROTE` in both). This is
+    the load-bearing pair — the single shared WITNESS line is what makes the same receipt format
+    correct for both a clean and a non-clean round.
+
+    Both examples cite the same findings-file name (`round-N-findings.md`) so the WITNESS line
+    is **byte-identical** between them; in a real round `N` is the concrete round number. The
+    findings file's first line (the `SEVERITY-COUNTS:` line) is shown as a leading comment inside
+    each block.
+
+    The PASS example below is a clean round (`fatal=0 significant=0`). The shared WITNESS line's
+    pattern `/significant=[1-9]|fatal=[1-9]/` does **NOT** match the `0/0` counts line, so under
+    `expect-fail=match` the witness does not fire → Tier-2 accepts the PASS. (If it *did* match,
+    a PASS was filed on a non-clean round → reject.)
+
+    <!-- worked-example: PASS -->
+    ```
+    # round-N-findings.md first line: SEVERITY-COUNTS: fatal=0 significant=0 minor=2
+    RCPT v1.1 red-team/N-devils-advocate
+    VERDICT  PASS  conf=0.85
+    ARTIFACTS
+      round-N-findings.md  sha256:b2e7c3a4d5f6e7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2  2980
+    TRACE
+      1  READ   docs/plans/foo-design.md  sha256:dd8cef1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c90
+      2  WROTE  round-N-findings.md  sha256:b2e7c3a4d5f6e7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2
+    CLAIMS
+      fatal-count=0        from=round-N-findings.md#L1-L1  pattern=fatal=0
+      significant-count=0  from=round-N-findings.md#L1-L1  pattern=significant=0
+      minor-count=2        from=round-N-findings.md#L1-L1  pattern=minor=2
+    WITNESS    grep:round-N-findings.md#L1-L1  pattern=/significant=[1-9]|fatal=[1-9]/  expect-fail=match  ran=TRACE#2
+    SUSPICION  0.10
+    NEXT       re-run WITNESS grep at next gate point
+    TRIPWIRE:  suspicion>=0.30
+    SUPERSEDES: none
+    ```
+
+    The FAIL example below is a non-clean round (`fatal=1 significant=2`). The **same** WITNESS
+    line's pattern MUST match the nonzero counts line, so under `expect-fail=match` the witness
+    fires → Tier-2 accepts the FAIL. (If it did not match — a `0/0` counts line — a FAIL was
+    filed with no witness firing → reject.) Its CLAIMS value-pins are consistent with its own
+    `SEVERITY-COUNTS:` counts line (shown as the leading comment).
+
+    <!-- worked-example: FAIL -->
+    ```
+    # round-N-findings.md first line: SEVERITY-COUNTS: fatal=1 significant=2 minor=0
+    RCPT v1.1 red-team/N-devils-advocate
+    VERDICT  FAIL  conf=0.90
+    ARTIFACTS
+      round-N-findings.md  sha256:c3f8d4b5e6a7f8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3  4120
+    TRACE
+      1  READ   docs/plans/foo-design.md  sha256:dd8cef1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c90
+      2  WROTE  round-N-findings.md  sha256:c3f8d4b5e6a7f8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3
+    CLAIMS
+      fatal-count=1        from=round-N-findings.md#L1-L1  pattern=fatal=1
+      significant-count=2  from=round-N-findings.md#L1-L1  pattern=significant=2
+      minor-count=0        from=round-N-findings.md#L1-L1  pattern=minor=0
+    WITNESS    grep:round-N-findings.md#L1-L1  pattern=/significant=[1-9]|fatal=[1-9]/  expect-fail=match  ran=TRACE#2
+    SUSPICION  0.05
+    NEXT       dispatch fix-agent against the two Fatal/Significant anchors
+    TRIPWIRE:  verdict=FAIL
+    SUPERSEDES: none
+    ```
+
+    ### Why the single shared WITNESS line is correct for both
+
+    One witness line serves both verdicts because it checks the **PASS/FAIL boundary**, not the
+    magnitude. `expect-fail=match` means "the failing world is when the pattern matches." The
+    pattern `/significant=[1-9]|fatal=[1-9]/` matches the counts line iff at least one of Fatal
+    or Significant is nonzero. So on a clean (PASS) round the pattern does not match → witness
+    does not fire → the PASS is consistent; on a non-clean (FAIL) round the pattern matches →
+    witness fires → the FAIL is consistent. A PASS that secretly had F/S would make the pattern
+    match and Tier-2 would reject it; a FAIL that secretly had `0/0` would leave the pattern
+    unmatched and Tier-2 would reject it. The witness verifies only the boundary; the exact
+    F/S magnitude for scoring is re-derived by the orchestrator from the findings file's
+    severity sections, not from this witness.
 ```

--- a/skills/shared/return-convention.md
+++ b/skills/shared/return-convention.md
@@ -195,6 +195,8 @@ if VERDICT=BLOCKED:
   no Tier-2; the dispatch is not trusted for forward progress regardless.
 ```
 
+**`kind=grep` artifact/range resolution (applies to Tier-1 and both Tier-2 branches — PASS and FAIL).** For `kind=grep`, the cited artifact and range are those named on the `grep:<artifact>#<range>` payload's own `#<range>` (the witness line itself), **not** an `out=` field. `out=` resolution is **`kind=exec`-only** — only `EXEC` carries `out=`; `READ`/`WROTE` (the verbs a `grep` witness may cite via `ran=TRACE#N`) carry none. Where the Tier-1 and Tier-2 pseudocode above reads "the cited `out=<artifact>#<range>`", that phrasing is `kind=exec`-specific; for `kind=grep` read the `grep:<artifact>#<range>` payload's own range. No grammar change — the witness range was always named on the WITNESS line.
+
 **Grounds-binding limitation (known, v1).** Tier-2 `FAIL` is *weak positive evidence* — the witness fired, but the linter cannot structurally prove it fired *for the reason the subagent claimed*. Accepted gap. Mitigated by existing fix-dispatch escalation (the fix agent's own receipt carries its own witness) and by Cairn capturing lingering FAIL receipts in `OPEN_OBLIGATIONS`.
 
 ### Lint failure handling


### PR DESCRIPTION
## What & why

Resolves **#366** (RT-QG-RECEIPT-DRIFT), the highest-severity functional defect from the 2026-06 audit (A15). PR2 of the milestone-15 P0 sweep.

`skills/red-team/red-team-prompt.md`'s "Report Format" returned **free-form prose**, but `skills/quality-gate/SKILL.md:30` receipt-lints **every** red-team return (lint failure ⇒ structurally `BLOCKED`). Taken literally, **every red-team round would lint to BLOCKED**, silently corrupting the gate's verdict stream. The machinery was aspirational: the receipt-lint claim plus the `:44`/`:56`/`:62` couplings (tripwire manifest, fix-agent supersession anchor, mandatory-work declarations) all assume a red-team receipt that the prompt never emitted.

## Resolution — Option A (red-team becomes a receipt citizen)

The A-vs-B fork was decided in the `/build` design phase. **B** (carve red-team out of the lint) looked surgical but would orphan 3 couplings *and* drop the trust-check on the suite's primary reviewer; **A** makes the existing machinery *true*. Since QG already persists findings to `round-N-findings.md`, the receipt is a thin wrapper citing that file.

- **`red-team-prompt.md`** — two-channel Report Format: WRITE rich findings to `[FINDINGS_OUTPUT_PATH]` (first line `SEVERITY-COUNTS:`), RETURN a seven-section `RCPT v1.1` receipt citing it. Contrasting **PASS/FAIL worked examples** share one byte-identical WITNESS line correct for both verdicts (checks the PASS/FAIL boundary, not magnitude). Rich findings sections retained; BLOCKED-on-unsupplied-path specified.
- **`quality-gate/SKILL.md`** — weighted score computed from the findings file's `### Fatal/Significant Challenges` sections (not CLAIMS — un-spoofable); writer-inversion; look-harder demotion recorded via **INV-A17, not SUPERSEDES** (a demotion is the opposite of "concern resolved"), codified as **INV-A18**; fix-agent test-less superseding-witness; clean-PASS TRIPWIRE pointer. Links the convention, never copies.
- **`red-team/SKILL.md`** — standalone single-source consumption + **Tier-1-only** lint (Layer-2 sweep stays QG-only).
- **`return-convention.md`** — one-sentence `kind=grep` artifact/range resolution clarification (grep payload range; `out=` is exec-only) across Tier-1 + both Tier-2 branches. No grammar change.
- **`scripts/check_rt_receipt_contract.py`** — new structural acceptance-test checker (21 assertions; RED before edits, GREEN after) wired as a permanent regression guard.

## Verification

- New checker `python scripts/check_rt_receipt_contract.py` → exit 0; `check_canonical_drift.py` → 0; `check_i2_marker.py` → 0. (`npm test` reports "no test files" — pre-existing repo state; the structural checker is the acceptance test.)
- Gated end-to-end via `/build`: **design** 5 rounds (trajectory 11→5→1→look-harder-demote→0), **plan** 2 rounds + look-harder, **code** 2 rounds + look-harder (checker mutation-tested across 8 defect classes). Look-harder caught a real supersession-primitive inversion the standard rounds missed.

**Out of scope:** consensus mode, the tightened-rubric addendum, audit/siege reviewer prompts, and #368 (scope the universal receipt MUST claim — A is consistent with it).

Refs #366 (close on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)