### PR TITLE
fix(#368): scope return-convention receipt mandate to adopting skills

### DIFF
--- a/skills/shared/return-convention.md
+++ b/skills/shared/return-convention.md
@@ -5,14 +5,21 @@ version: 1
 # Return Convention (Ledger Return Protocol)
 
 > Canonical reference for the subagent → orchestrator return channel.
-> Every subagent dispatched via `shared/dispatch-convention.md` MUST return exactly one
-> Evidence Receipt in the format defined below. Prose outside the receipt is a protocol
-> violation.
+> A skill **adopts** this convention by referencing it via
+> `<!-- CANONICAL: shared/return-convention.md -->`. Within an adopting skill, every
+> subagent it dispatches via `shared/dispatch-convention.md` MUST return exactly one
+> Evidence Receipt in the format defined below, and prose outside the receipt is a
+> protocol violation. This MUST binds **only** adopting skills — it is not a repo-wide
+> mandate on every dispatcher; a skill that does not carry the marker is not bound, and
+> its subagents returning prose is not a violation of this convention.
 >
-> **This is a shared skill reference, not a CLAUDE.md directive.** Pilot skills
-> (`/build`, `/quality-gate`, `/siege`) reference this file via
-> `<!-- CANONICAL: shared/return-convention.md -->`. Templates do not duplicate the
-> grammar; they link here.
+> **This is a shared skill reference, not a CLAUDE.md directive.** Adopting skills link
+> here rather than duplicating the grammar; a skill signals adoption by carrying a
+> `<!-- CANONICAL: shared/return-convention.md -->` marker. To enumerate the live adopter
+> set, grep `skills/` for that marker: every file it matches except this definition file
+> (which names the marker to define it, and is not itself an adopter) belongs to an
+> adopting skill. Rollout beyond the initial pilots is tracked in issue #202; the dated
+> entries in Version History below are historical, not the current adopter roster.
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

Resolves audit finding **A34**: `skills/shared/return-convention.md`'s opening blockquote asserted a universal "**Every** subagent dispatched ... MUST return exactly one Evidence Receipt; prose outside the receipt is a protocol violation" — which contradicted its own next paragraph (pilots only) and the Version History, and would have an auditor flag every one of the ~48 non-adopting dispatchers as a protocol violation.

Refs #368

### Change
Scope the MUST to skills that **adopt** the convention, where adoption is defined by the machine-checkable `<!-- CANONICAL: shared/return-convention.md -->` marker:
- A skill adopts by carrying the marker; within an adopting skill, its dispatched subagents MUST return one receipt. A non-adopting skill's subagent returning prose is **not** a violation.
- Enumeration is grep-based (single source of truth, no hardcoded list to drift): `grep -rl 'CANONICAL: shared/return-convention.md' skills/` — every match except this definition file belongs to an adopting skill. This auto-includes `red-team` (the 4th adopter, via #366) and any future adopter.
- The Version History pilot list is flagged as historical, not the current roster.

This does not weaken the real adopters (build / quality-gate / siege / red-team each restate the MUST in their own templates and lint every return).

### Ticket part (b) already done
#368 also asked to align `README.md:5` "Every skill is eval-tested" → "13 core skills" (matching `docs/evals.md:26`). That was already shipped in **#380**; verified satisfied on `main`.

### Quality gate (dogfooded)
Real `/quality-gate` loop: 4 red-team rounds (1→1→0) + a look-harder verification pass that caught a real synthesis gap (enumeration method removed → false-negative on red-team), fixed, confirmed clean. All 6 tracked structural checkers (canonical-drift, i2-marker, qg-stagnation-minor, crossref, rt-receipt-contract, catalog) exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)