### PR TITLE
chore(ci): wire check_crossref.py into structural-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       - run: python3 scripts/check_canonical_drift.py
       - run: python3 scripts/check_i2_marker.py
       - run: python3 scripts/check_qg_stagnation_minor.py
+      - run: python3 scripts/check_crossref.py --selftest
+      - run: python3 scripts/check_crossref.py
       - run: python3 scripts/catalog.py check
       - run: python3 scripts/rcpt_verify.py --selftest
       - run: python3 scripts/test_rcpt_verify.py


### PR DESCRIPTION
## What

Wires the existing, tracked, passing `scripts/check_crossref.py` into the `structural-checks` CI job:

```yaml
+      - run: python3 scripts/check_crossref.py --selftest
+      - run: python3 scripts/check_crossref.py
```

`--selftest` guards the checker's own exemption/detection logic; the bare invocation enforces the real tree invariant (every live `crucible:<token>` resolves to a `skills/<token>/` dir). Grouped with the other `check_*` checkers and mirroring the `rcpt_verify.py --selftest` + real-check wiring pattern already in the file.

## Why

Milestone-15 audit follow-up. `check_crossref.py` was added (#365/A40) but #364's plan deferred wiring it into CI "until #378 lands". #378 is long merged, so this closes that loose end. Without it, the cross-reference invariant (`crucible:cartographer` self-misroute class of bug) is checkable locally but not enforced in CI.

## Verification

- Both invocations exit 0 locally (`--selftest` → `SELFTEST OK`; bare → `OK`, 233 tracked `.md` scanned).
- The one structural novelty — first `git ls-files` consumer in the job — verified sound under `actions/checkout@v4`: `git ls-files` reads the always-populated index (not history), confirmed empirically via `git clone --depth 1`; broken-git fails loud via `check=True`, never a silent false-pass.
- Gated via `/quality-gate`: **PASS** (clean-pass, 1 round; look-harder confirmed under tightened rubric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)