### PR TITLE
fix(#370): reconcile cross-skill doc-drift cluster (A5/A19/A26/A47/A48/A50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,3 +141,38 @@ Skills are Markdown — there is **no data migration**. Behavioral notes:
 - **OpenCode runtime validation is deferred to the non-gating follow-up #337.**
   The milestone gate (#335) validates Claude Code only; skills remain authored
   harness-neutral via the harness-adapter.
+
+## Calibration Ledger, Regression Memory & Arc-State — 2026-06-01
+
+Backfilled record of the Epistemics Stack milestone (skills shipped 2026-05-20 →
+2026-06-01) — the calibration-ledger subsystem and its companion persistence
+skills that were not previously recorded here. The calibration ledger is the
+epistemic backbone of the Tier-A gate: gate verdicts are appended and later
+falsified against merged fixes, turning the suite's "caught a real bug" claims
+into measurable calibration scores.
+
+### Added
+
+- **`/compass`** — persistent per-repo arc-state in `docs/compass.md` (current
+  arc, last meaningful commit, open loops, next move, don't-forget items).
+  Auto-maintained by build, merge-pr, and finish; read by getting-started.
+  Tickets #273, #286, #308.
+- **`/ledger`** — weekly calibration-ledger renderer: the honest "Crucible
+  caught N silent bugs" headline, verdict breakdown, per-skill severity rates,
+  and an inflation detector. Backed by `scripts/render_ledger.py`,
+  `ledger_append.py`, and `ledger_reduce.py`. Ticket #272.
+- **`/calibration-reconcile`** — walks merged fix/hotfix branches to falsify the
+  originating gating verdicts, computes per-skill Brier calibration scores, and
+  appends a falsification record. Backed by `scripts/reconcile_ledger.py`,
+  `brier_advisory.py`, and `calibrate_tolerance.py`. Ticket #270.
+- **`/grudge`** — the Book of Grudges: a machine-local, per-repo (never
+  committed) cross-session bug graveyard. Every fixed bug is recorded as a
+  structured grudge; before touching code, skills query the grudgebook for the
+  files in scope and surface past regressions as forced "DO NOT REPEAT" context.
+  Backed by `scripts/grudge_append.py` and `grudge_query.py`. Ticket #271.
+
+### Note
+
+The calibration ledger is machine-local central (`~/.claude/crucible/ledger/`)
+and is **never committed**; only the fixture kill-switch
+(`CRUCIBLE_CALIBRATION_DISABLED=1`) silences it, and only for tests.

--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -6,22 +6,21 @@ Crucible skills use the SKILL.md format published by Anthropic and adopted by Cl
 
 ### Tier 1 — Fully Portable
 
-These skills contain methodology instructions only. No platform-specific tool references in their workflow. They work identically on any platform that reads SKILL.md files. Some reference other crucible skills by name (e.g., `crucible:quality-gate`) — these are inter-skill dependencies, not platform coupling. If the referenced skill is installed, it works; if not, the agent skips it.
+These skills contain methodology instructions only. No platform-specific tool references in their workflow. They work identically on any platform that reads SKILL.md files. Some reference other crucible skills by name (e.g., `crucible:quality-gate`) — these are inter-skill dependencies, not platform coupling. If the referenced skill is installed, it works; if not, the agent skips it. Incidental use of universal tooling (`git`, `gh`/`glab`) to read or record local state is permitted and does not count as platform coupling — what places a skill here is the absence of subagent dispatch and of any *required* specialized platform feature.
 
 | Skill | What It Does |
 |-------|-------------|
 | planning | Structured implementation planning with task decomposition |
-| design | Interactive design refinement with investigation-driven decisions |
 | test-driven-development | Red-green-refactor discipline with rationalization counters |
 | verify | Evidence-before-claims verification discipline |
 | review-feedback | Technical rigor when processing code review feedback |
-| innovate | Divergent creativity injection before adversarial review |
 | getting-started | Skill discovery and invocation discipline |
-| finish | Branch completion workflow with structured options |
+| handoff | Session-handoff doc capturing arc state and the next pickup |
+| workshop | Guided tour of the headline orchestrator skills |
 
 ### Tier 2 — Portable with Reduced Capability
 
-These skills use subagent dispatch for parallelism or fresh-perspective reviews. On platforms without subagent support, the methodology still applies — the agent follows the workflow sequentially instead of dispatching parallel reviewers.
+These skills depend on either subagent dispatch (for parallelism or fresh-perspective reviews) or a *required* specialized external tool — shadow git snapshots, a forge CLI for CI/merge, document converters, or package auditors — that the skill's core function cannot proceed without. On a platform lacking the feature, the methodology still applies but with reduced capability: subagent work runs sequentially in-context, and tool-backed work falls back to manual steps.
 
 | Skill | Platform Feature Used | Degraded Behavior |
 |-------|----------------------|-------------------|
@@ -31,9 +30,29 @@ These skills use subagent dispatch for parallelism or fresh-perspective reviews.
 | temper | Subagent dispatch for review | Agent reviews in-context |
 | parallel | Subagent dispatch for independent tasks | Tasks run sequentially |
 | adversarial-tester | Subagent dispatch for test writing | Agent writes tests in-context |
+| skill-creator | Subagent dispatch for blind A/B skill evals | Eval runs sequentially in-context; quantitative benchmarking skipped |
+| assay | Subagent dispatch for approach evaluation (Opus evaluator) | Evaluates approaches in-context |
+| prd | Subagent dispatch for PRD authoring (Sonnet writer) | Writes the PRD in-context |
+| test-coverage | Subagent dispatch for the test-audit agent (Opus) | Audits tests in-context |
 | debugging | Multiple subagent types (investigator, analyst, synthesis) | Agent runs all phases in-context |
+| design | Subagent dispatch for parallel investigation + Challenger | Investigation/challenge run in-context |
+| innovate | Subagent dispatch for the Innovation proposer (Opus) | Proposal generated in-context |
+| finish | `git` + forge CLI (`gh`) for completion; subagent dispatch for code review | Manual completion + in-context review |
 | worktree | Git worktree creation | Standard branch-based isolation |
 | stocktake | Subagent dispatch for skill auditing | Agent audits sequentially |
+| audit | Subagent dispatch for parallel analytical lenses | Lenses run sequentially in-context |
+| delve | Subagent dispatch for finder fan-out + verify gate | Finders run sequentially |
+| recon | Subagent dispatch for parallel scouts | Scouts run sequentially |
+| prospector | Subagent dispatch for parallel exploration | Explores sequentially |
+| siege | Parallel attacker-perspective agents (scales 3–6) | Perspectives run sequentially |
+| spec | Subagent dispatch for per-ticket investigation | Tickets processed sequentially |
+| migrate | Subagent dispatch (recon/assay); build for execution | Planning runs sequentially; execution mode needs build (Tier 3) |
+| checkpoint | Shadow git snapshots for pipeline rollback | No automatic rollback; manual git recovery |
+| compass | `scripts/compass.py` CLI (POSIX only) | Arc-state file (`docs/compass.md`) maintained by hand |
+| merge-pr | `git` + a forge CLI (`gh` or equivalent) for CI checks and merge | Manual merge + CI inspection |
+| distill | External document converters (pandoc, pdftotext, LibreOffice) | Cannot ingest binary document formats |
+| dependency-audit | External auditors (npm/cargo/pip-audit) | No supply-chain signal produced |
+| source-driven-development | Live documentation fetch (web access) | Falls back to (possibly stale) training recall |
 
 ### Tier 3 — Platform-Dependent
 
@@ -43,7 +62,17 @@ These skills require features specific to Claude Code. They will not work on oth
 |-------|-------------------|---------------------|
 | build | Agent teams (TeamCreate, TaskCreate, SendMessage) | Orchestrates 20+ subagents across 4 phases; sequential fallback exists but is Claude Code-specific |
 | forge | Persistent memory (`~/.claude/projects/<hash>/memory/forge/`) | Retrospectives must persist across sessions to provide value |
-| cartographer | Persistent memory (`~/.claude/projects/<hash>/memory/cartographer/`) | Codebase maps must persist across sessions to accumulate knowledge |
+| cartographer-skill | Persistent memory (`~/.claude/projects/<hash>/memory/cartographer/`) | Codebase maps must persist across sessions to accumulate knowledge |
+| project-init | Persistent cartographer memory + subagent scan | Onboarding output must persist across sessions, like cartographer's |
+| grudge | Machine-local per-repo persistent memory (regression graveyard) | Regression memory must persist across sessions to guard future edits |
+| ledger | Machine-local calibration ledger (`~/.claude/crucible/ledger/`) | Calibration history must persist to be meaningful |
+| calibration-reconcile | Machine-local ledger + git branch walkback | Falsification needs the persisted verdict history |
+| recall | Session activity index maintained by PostToolUse hooks | No event log without the hook infrastructure |
+| replay | Pipeline dispatch manifests + checkpoints | Crash recovery needs Claude Code pipeline state |
+| consensus | MCP multi-provider model dispatch | Multi-model synthesis needs MCP providers |
+| temper-eval-calibrate | Session-dispatch eval harness (Claude Code) | Wraps live session invocations; no portable equivalent |
+| temper-eval-collect | Task-tool parallel reviewer dispatch (Claude Code) | Live reviewer dispatch is harness-specific |
+| skill-selection-evals | Anthropic skill-creator eval harness | Eval-only; consumed by the blind A/B tooling, not invoked at runtime |
 
 ### Tier 4 — Domain-Specific (Unity UI Toolkit)
 
@@ -95,7 +124,7 @@ Skills reference each other using the `crucible:` prefix (e.g., `crucible:qualit
 
 ### Persistent Storage
 
-Two skills (forge, cartographer) store data in `~/.claude/projects/<project-hash>/memory/`. Other platforms would need an equivalent persistent storage mechanism for these skills to accumulate knowledge across sessions.
+Two skills (forge, cartographer-skill) store data in `~/.claude/projects/<project-hash>/memory/`. Other platforms would need an equivalent persistent storage mechanism for these skills to accumulate knowledge across sessions.
 
 ## Migration Roadmap
 
@@ -103,7 +132,7 @@ Full cross-platform support would require:
 
 1. **Abstract tool references** — Replace Claude Code tool names in instructional text with platform-agnostic language (e.g., "spawn a subagent" instead of "use the Agent tool")
 2. **Platform adapter layer** — Create per-platform configuration that maps abstract operations to concrete tool calls
-3. **Storage abstraction** — Define a platform-agnostic storage interface for forge and cartographer
+3. **Storage abstraction** — Define a platform-agnostic storage interface for forge and cartographer-skill
 4. **Build skill refactor** — Replace TeamCreate/TaskCreate orchestration with a platform-agnostic dispatch pattern
 5. **Namespace resolution** — Map `crucible:` prefix to each platform's skill invocation syntax
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,8 @@ The **build** skill is the main entry point for feature development. It chains t
 3. **Phase 3: Execute** (autonomous, team-based) — Dispatch implementers per task, de-sloppify cleanup, two-pass code review (code quality + test quality + AI slop signal detection), test alignment audit (crucible:test-coverage audits existing tests for staleness), test gap writer (fills coverage gaps with dedup-aware auto-retry), and adversarial tester (writes tests designed to break the implementation).
 4. **Phase 4: Complete** (autonomous) — Code review on full implementation, inquisitor (5 parallel adversarial dimensions against the full feature diff), quality gate, session metrics, full test suite, Forge retrospective, Cartographer recording, branch completion.
 
+Phase 4 also runs a conditional security pass and a supply-chain scan around the gate. **crucible:siege** is dispatched at Step 5.5 — sequentially *before* the quality gate — but only when security signals are detected (or siege is forced); if it completes clean, the build continues to the gate. **dependency-audit** (npm/cargo/pip-audit) runs alongside the gate as an independent supply-chain signal. Both can block completion, yet are deliberately kept out of the gate's weighted score (INV-2 — the score sums only the host red-team's own Fatal/Significant findings; siege, dependency-audit, and external-model signals are all excluded) and out of red-team's input (anti-anchoring: a sibling signal shares the artifact, never the reviewer's context).
+
 ## Knowledge accelerators
 
 The **forge** and **cartographer** skills are recommended (not required) knowledge accelerators. Forge learns about agent behavior (process wisdom), Cartographer learns about the codebase (domain wisdom — including defect signatures that surface known bug patterns proactively). Both accumulate across sessions.
@@ -40,6 +42,12 @@ The **replay** skill provides crash recovery and A/B experimentation for any pip
 ## Session continuity
 
 The **recall** skill queries the session activity index — a searchable log of file edits, git operations, test runs, and errors maintained by PostToolUse hooks. Compaction recovery steps in build, debugging, and spec re-read session state after context compression. Skills emit semantic events (phase transitions, design decisions) via an outbox pattern for cross-skill continuity.
+
+The **compass** skill maintains per-repo arc-state in `docs/compass.md` (current arc, last meaningful commit, open loops, next move, don't-forget items). It is auto-maintained by build, merge-pr, and finish, and read by getting-started, so a new session can recover *where the work was* without re-deriving it from git.
+
+## Calibration and regression memory
+
+These skills make Crucible's quality claims falsifiable and let past defects guard future ones. The **calibration ledger** is the epistemic backbone: Tier-A gate verdicts are appended to a machine-local central store (`~/.claude/crucible/ledger/`, never committed). **calibration-reconcile** later walks merged fix/hotfix branches to falsify those verdicts and computes per-skill Brier scores; **ledger** renders the weekly report — the honest "Crucible caught N silent bugs" headline, verdict breakdown, per-skill severity rates, and an inflation detector. The **grudge** skill (the Book of Grudges) is the complementary regression memory: every fixed bug is recorded as a machine-local, per-repo grudge, and skills query it for the files in scope before touching code, surfacing past regressions as forced "DO NOT REPEAT" context.
 
 ## Token efficiency
 

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -499,7 +499,7 @@ The Forge produces proposals for human review. It does not edit skill files. It 
 | `crucible:build` | Retrospective | Phase 4, after red-team, before finishing | Full build summary |
 | `crucible:debugging` | Retrospective | After fix verified | Bug description + hypothesis log |
 | `crucible:debugging` | Retrospective (diagnostic extraction) | After fix verified | Session artifacts → cartographer landmines with `dead_ends` + `diagnostic_path` |
-| `crucible:finish` | Retrospective | After Step 3, before Step 4 | Branch summary + review findings |
+| `crucible:finish` | Retrospective | Step 2.75, before red-team | Branch summary + review findings |
 | `crucible:design` | Feed-Forward | Before first question | Topic description |
 | `crucible:build` | Retrospective (decision extraction) | After fix verified | Decision journal + task list → cartographer decisions via recorder |
 | Any skill | Trajectory Record | After retrospective step 7 | Execution data + retrospective output (opt-in only) |

--- a/skills/skill-selection-evals/SKILL.md
+++ b/skills/skill-selection-evals/SKILL.md
@@ -25,6 +25,7 @@ Crucible's 49 execution evals measure quality once a skill is invoked. Selection
 3. **adversarial-scope** — red-team vs inquisitor vs audit vs siege
 4. **completion-claims** — verify vs finish
 5. **bug-handling** — debugging vs verify vs audit
+6. **build-vs-raw-dispatch** — build (full idea→PR pipeline) vs a single-skill dispatch (planning, test-driven-development, …)
 
 ## Difficulty Ratings
 

--- a/skills/stocktake/SKILL.md
+++ b/skills/stocktake/SKILL.md
@@ -68,6 +68,8 @@ Each skill is evaluated against:
 - [ ] Scope fit — name, trigger, and content aligned
 - [ ] Actionability — concrete steps vs vague advice
 - [ ] Cross-references — do `crucible:` links resolve to existing skills?
+- [ ] Convention drift — does a skill that dispatches subagents carry the `<!-- CANONICAL: shared/dispatch-convention.md -->` / `return-convention.md` markers (vs. copying or omitting them)?
+- [ ] Eval presence — does the skill have an `evals/` directory, or is one warranted given its surface? (eval-before-publish; flag absence, don't auto-fail — evals are aspirational across the suite)
 
 Each skill gets a verdict:
 


### PR DESCRIPTION
## What

Documentation-accuracy sweep over the `audit-2026-06` cross-skill doc-drift cluster (#370). Six surgical, code-risk-free edits:

| Finding | File | Change |
|---|---|---|
| **A5** | `skills/forge/SKILL.md` | finish-retrospective cell → "Step 2.75, before red-team" (matches `finish:89-93`; was "After Step 3, before Step 4") |
| **A19** | `skills/skill-selection-evals/SKILL.md` | add boundary #6 `build-vs-raw-dispatch` (10/33 evals — the largest — was missing from SKILL.md) |
| **A26** | `skills/stocktake/SKILL.md` | add Phase-2 rubric checks: convention-drift (CANONICAL dispatch/return markers) + eval-presence — makes the auditor self-consistent |
| **A47** | `docs/architecture.md` | document Phase-4 siege (Step 5.5) / dependency-audit signals, compass arc-state, and a new "Calibration and regression memory" section |
| **A48** | `PLATFORMS.md` | tier **all 52 skills** (was 23); `cartographer`→`cartographer-skill`; clarify Tier-1/Tier-2 definitions (incidental universal git/gh permitted; Tier 2 = subagent dispatch **or** a required specialized tool) |
| **A50** | `CHANGELOG.md` | backfill the Calibration Ledger + Arc-State subsystem (#270/#271/#272/#273) |

## Quality gate

Real `/quality-gate`, **7 rounds → PASS** (score `5→1→1→1→1→2→0`); look-harder confirmed the clean round under the tightened rubric. The gate caught **1 Fatal** (architecture.md falsely claimed siege runs *in parallel with* the Phase-4 gate — build runs it sequentially at Step 5.5 *before* the gate) and **8 Significants** (a CHANGELOG ticket misattribution — PR #326 is `feat(#270)`, not grudge; and six PLATFORMS tier misclassifications: compass/assay/prd/test-coverage/skill-creator/design/innovate/finish, plus a tier-criterion contradiction and a `markitdown`→`pandoc/pdftotext` factual error) — all of which standard single-pass review would have shipped. Tier-A verdict emitted to the calibration ledger (`019ead83-0820-72dc-9acc-887f952120be`). `check_crossref` + `check_canonical_drift` green.

## Scope note

The gate surfaced that several **pre-existing** Tier-1 entries (design/innovate/finish) were misclassified (they dispatch subagents). Since A48 *is* "make the PLATFORMS tiers accurate," these were corrected and the tier definitions clarified so the table is internally consistent. The pre-existing untracked `docs/research/audit-innovate-2026-06-06.md` is left untouched.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)