### PR TITLE
docs: correct CLAUDE.md test + calibration-ledger claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,10 @@ Markdown workflow). `shared/` holds canonical conventions every skill links to;
 lifecycle hooks; `docs/` is the catalog, architecture, and measured eval deltas.
 
 ## Running & testing
-- Internal TS/JS tests: `npm test` (vitest).
+- Internal tests are Python + bash: `scripts/check_*.py`, `scripts/test_*.py`,
+  and `hooks/tests/*.sh`, run individually; the gating subset also runs in
+  `.github/workflows/ci.yml` (full CI coverage is still being wired up — see #394).
+  (`npm test`/vitest is currently non-functional — no JS/TS tests are tracked; see #395.)
 - Skill behavior evals: defined in `skills/<skill>/evals/evals.json`, run via
   Anthropic's skill-creator (blind A/B); measured deltas live in `docs/evals.md`.
 - Install for live use: symlink skills into Claude Code —
@@ -33,9 +36,11 @@ lifecycle hooks; `docs/` is the catalog, architecture, and measured eval deltas.
 - **Find-and-report-only skills don't edit code.** `red-team`, `audit`,
   `code-review` report findings; they must not modify the artifact under review.
 - **The calibration ledger is the epistemic backbone.** Tier-A gate verdicts
-  append to `.crucible/ledger/runs.jsonl` (committed). The
-  `CRUCIBLE_CALIBRATION_DISABLED=1` kill-switch is fixture-only — never silence
-  production verdicts.
+  append to the machine-local central store `~/.claude/crucible/ledger/runs.jsonl`
+  (never committed — this repo is public; not to be confused with the deliberate
+  11-row test fixture committed in-repo at `.crucible/ledger/runs.jsonl`, which is
+  intentional — keep it). The `CRUCIBLE_CALIBRATION_DISABLED=1`
+  kill-switch is fixture-only — never silence production verdicts.
 - **Eval before you publish.** A skill change ships with its evals run; prefer
   anti-rationalization tables + stagnation detection over trusting the model to
   not shortcut under pressure.


### PR DESCRIPTION
## What

Two factual corrections to the standing project instructions (`CLAUDE.md`), both replacing **known-false** claims that were caught during repo audit:

1. **`## Running & testing`** — the old `Internal TS/JS tests: \`npm test\` (vitest).` line was false. The tracked tests are Python + bash (`scripts/check_*.py`, `scripts/test_*.py`, `hooks/tests/*.sh`), `package.json`/vitest is gitignored and non-functional for tracked code, and CI runs no npm/vitest. The new bullet states this and scopes the CI claim to the gating subset that actually runs in `.github/workflows/ci.yml` (full CI wiring is in progress — see #394; vitest remove-vs-repoint is #395).

2. **Calibration-ledger bullet** — corrected from the old `.crucible/ledger/runs.jsonl (committed)` to the truth: live Tier-A verdicts append to the machine-local central store `~/.claude/crucible/ledger/runs.jsonl` (never committed — this repo is public). Added a disambiguator so the intentional in-repo 11-row `.crucible/ledger/runs.jsonl` **test fixture** isn't mistaken for a public-repo leak and deleted.

## Quality gate

Ran `/quality-gate` (full loop + look-harder, red-team pinned to Opus). **3 rounds, weighted score 2 → 1 → 0**, look-harder under the tightened rubric confirmed the clean round. The gate earned its keep on a "2-line doc fix" — it caught **three real defects**, two of them introduced by the correction itself:
- a delete-the-fixture omission (the `.crucible/ledger/runs.jsonl` fixture vs the never-committed central store),
- an over-claimed `mirrored in ci.yml` that omitted 4 suites,
- an over-general `scripts/check_*.py --selftest` glob (4 of 7 scripts ignore the flag — verified by execution).

Scope is surgical: 1 file, +9/-4, only the two bullets touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)