### PR TITLE
fix(#396): repoint backfill ledger to central store + AST write-path guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,5 @@ jobs:
       - run: python3 scripts/test_brier_advise.py
       - run: python3 scripts/check_model_pins.py --selftest
       - run: python3 scripts/check_model_pins.py
+      - run: python3 scripts/check_ledger_write_path.py --selftest
+      - run: python3 scripts/check_ledger_write_path.py

--- a/scripts/backfill-ledger.py
+++ b/scripts/backfill-ledger.py
@@ -2,7 +2,9 @@
 """Phase 3 — 90-day fix-branch ledger backfill.
 
 Walks merged `fix/*` and `hotfix/*` PRs in a lookback window and appends
-synthetic schema-v1 calibration entries to `.crucible/ledger/runs.jsonl`.
+synthetic schema-v1 calibration entries to the machine-local central ledger
+store (`default_ledger_dir()` → ~/.claude/crucible/ledger/runs.jsonl, override
+via CRUCIBLE_LEDGER_DIR) — the same store every reducer/render/reconcile reads.
 
 These entries seed the corpus to honor #272's "≥10 entries" intent WITHOUT
 polluting accuracy claims:
@@ -34,9 +36,24 @@ REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
-from scripts.ledger_append import append, caller_dedup  # noqa: E402
+from scripts.ledger_append import (  # noqa: E402
+    append,
+    caller_dedup,
+    default_ledger_dir,
+)
 
-LEDGER_PATH = os.path.join(REPO_ROOT, ".crucible", "ledger", "runs.jsonl")
+# Write to the machine-local central store every reader actually consumes
+# (#270): render_ledger / reconcile_ledger / brier_advisory all route through
+# default_ledger_dir() → ~/.claude/crucible/ledger (override via
+# CRUCIBLE_LEDGER_DIR). Pinning this to the in-repo .crucible/ tree — as an
+# earlier version did — both made the backfill a dead store (no reader reads it)
+# and leaked finding data into the PUBLIC repo tree. Do NOT reintroduce an
+# in-repo .crucible/ write path here. scripts/check_ledger_write_path.py is an
+# AST guard that flags any `.crucible` path-shaped STRING LITERAL in scripts/ —
+# it catches every realistic spelling (os.path.join, pathlib, concat, f-string,
+# variable segment, multi-line). The only uncaught case is a path assembled with
+# no `.crucible` literal at all (e.g. runtime string concat) — don't do that.
+LEDGER_PATH = os.path.join(default_ledger_dir(), "runs.jsonl")
 DEFAULT_LOOKBACK_DAYS = 90
 
 

--- a/scripts/check_ledger_write_path.py
+++ b/scripts/check_ledger_write_path.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Regression guard: no scripts/ module may build an in-repo `.crucible/` path (#396).
+
+Invocation (from repo root):
+    python3 scripts/check_ledger_write_path.py            # check the tracked tree
+    python3 scripts/check_ledger_write_path.py --selftest # run the built-in logic tests
+
+Why this exists
+---------------
+The calibration ledger and grudge store are machine-local central stores
+(`default_ledger_dir()` / `default_grudge_dir()` → ~/.claude/crucible/...,
+override via CRUCIBLE_LEDGER_DIR). crucible is a PUBLIC repo and entries carry
+private file paths plus verbatim finding quotes, so a writer aimed at the
+in-repo `.crucible/` tree both (a) becomes a dead store no reader consumes and
+(b) leaks finding data into version control. backfill-ledger.py shipped with
+exactly that bug (#396); this guard catches its reintroduction.
+
+What it flags
+-------------
+This is an AST-based string-literal detector. It parses each scripts/ source and
+flags any string CONSTANT whose value is a path-shaped string containing
+`.crucible` as a path segment (matches `^[\\w./~+-]*\\.crucible[\\w./~+-]*$` — path
+chars only, no spaces/backticks). Because every realistic way of assembling the
+in-repo path carries a `.crucible` literal SOMEWHERE in the source —
+`os.path.join(..., ".crucible", ...)`, `Path(root) / ".crucible"`,
+`root + "/.crucible/ledger"`, a variable `seg = ".crucible"`, an f-string
+`f"{root}/.crucible/ledger/runs.jsonl"` (ast exposes the `/.crucible/...`
+constant inside the JoinedStr), or a multi-line join — all are caught regardless
+of the surrounding call syntax.
+
+What it does NOT flag, and why:
+  - Prose. A docstring like ``Reads `.crucible/ledger/runs.jsonl`, groups...`` is
+    ONE string constant whose value has spaces + backticks → not path-shaped.
+    Comments are not in the AST at all → never reachable.
+  - The central store. `os.path.join("~/.claude", "crucible", "ledger")` uses the
+    segment `"crucible"` (no leading dot) and `".claude"`; neither value contains
+    `.crucible`, and the path-only regex does not match `.claude`.
+
+Residual gap (honest)
+---------------------
+The detector covers every spelling that puts a `.crucible` STRING LITERAL in the
+source. The one residual gap is a path assembled with NO `.crucible` literal
+anywhere — e.g. `"." + "crucible"` concatenated at runtime. That is absurdly
+contrived and is not claimed to be caught. Also out of scope by design: a
+`bytes` literal (`b".crucible"`) — the detector only inspects `str` constants —
+and any non-`.py` writer (e.g. a shell script) under `scripts/`, since the scan
+is `.py`-only.
+
+Scope is `scripts/` only, deliberately: privacy-isolation tests elsewhere (e.g.
+eval/grudge/test-grudge-privacy-isolation.py) construct the in-repo path on
+purpose to assert writers AVOID it.
+
+Pure stdlib. No third-party deps.
+"""
+import ast
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+SCRIPTS_DIR = os.path.join(REPO_ROOT, "scripts")
+
+# A string value is the in-repo write path iff it is path-shaped (only path
+# characters — no spaces, no backticks) AND contains `.crucible` as a segment.
+# This matches `.crucible`, `/.crucible/ledger`, `.crucible/ledger/runs.jsonl`,
+# but NOT prose (spaces/backticks) and NOT `.claude` (no `.crucible` substring).
+_PATH_CRUCIBLE = re.compile(r"^[\w./~+-]*\.crucible[\w./~+-]*$")
+
+
+def scan_source(text: str) -> list:
+    """Return sorted 1-based line numbers in `text` that build an in-repo `.crucible` path.
+
+    `text` is a whole-module source string. It is parsed with `ast`; every
+    string constant whose value is a path-shaped `.crucible` segment is flagged
+    at its node `lineno`. Raises SyntaxError if `text` does not parse.
+    """
+    tree = ast.parse(text)
+    hits = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if _PATH_CRUCIBLE.match(node.value):
+                hits.add(node.lineno)
+    return sorted(hits)
+
+
+def check_tree() -> int:
+    """Recursively scan every scripts/**/*.py for the in-repo `.crucible/` anti-pattern."""
+    # Skip this guard itself by ABSOLUTE path: its _selftest() fixtures embed the
+    # anti-pattern as test data, and a check script is never a ledger/grudge
+    # writer. Absolute-path compare so a same-named file in a subdir is not
+    # skipped by basename.
+    self_path = os.path.abspath(__file__)
+    violations = []
+    for dirpath, dirnames, filenames in os.walk(SCRIPTS_DIR):
+        # Prune __pycache__ and any dot-directories in place.
+        dirnames[:] = [
+            d for d in dirnames if d != "__pycache__" and not d.startswith(".")
+        ]
+        for name in sorted(filenames):
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, name)
+            if os.path.abspath(path) == self_path:
+                continue
+            rel = os.path.relpath(path, REPO_ROOT)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    text = f.read()
+            except OSError as e:
+                print(f"[check_ledger_write_path] could not read {rel}: {e}", file=sys.stderr)
+                return 2
+            try:
+                linenos = scan_source(text)
+            except SyntaxError as e:
+                print(
+                    f"[check_ledger_write_path] could not parse {rel}: {e}; "
+                    "a syntax-broken scripts/ file cannot be scanned for the "
+                    "`.crucible/` leak — fix the syntax error.",
+                    file=sys.stderr,
+                )
+                return 2
+            for lineno in linenos:
+                violations.append((rel, lineno))
+
+    if violations:
+        print(
+            "FAIL: scripts/ module(s) build an in-repo `.crucible/` path — the "
+            "ledger/grudge stores are machine-local (~/.claude/crucible) and this "
+            "repo is public. Route through default_ledger_dir()/default_grudge_dir().",
+            file=sys.stderr,
+        )
+        for rel, lineno in violations:
+            print(f"  {rel}:{lineno}", file=sys.stderr)
+        return 1
+
+    print("OK: no scripts/ module builds an in-repo `.crucible/` path")
+    return 0
+
+
+def _selftest() -> int:
+    """Built-in logic tests — no filesystem, no tree dependency.
+
+    Inputs are whole-module source snippets (parsed with AST), and assertions
+    check the flagged 1-based line numbers.
+    """
+    # --- Positives: every realistic reintroduction shape must be caught. ---
+
+    # The exact #396 bug shape (single-line os.path.join).
+    bad = 'LEDGER_PATH = os.path.join(REPO_ROOT, ".crucible", "ledger", "runs.jsonl")'
+    assert scan_source(bad) == [1], "must flag the in-repo .crucible join"
+
+    # Grudge variant.
+    bad_grudge = 'd = os.path.join(repo_root, ".crucible", "grudge")'
+    assert scan_source(bad_grudge) == [1], "must flag the in-repo .crucible/grudge join"
+
+    # pathlib operand.
+    pathlib_src = 'p = Path(REPO_ROOT) / ".crucible" / "ledger"'
+    assert scan_source(pathlib_src) == [1], "must flag a pathlib .crucible operand"
+
+    # String concat.
+    concat_src = 'p = REPO_ROOT + "/.crucible/ledger"'
+    assert scan_source(concat_src) == [1], "must flag a string-concat .crucible path"
+
+    # Variable-held segment.
+    varseg_src = 'seg = ".crucible"\np = os.path.join(REPO_ROOT, seg, "ledger")'
+    assert scan_source(varseg_src) == [1], "must flag a variable-held .crucible segment"
+
+    # f-string: ast exposes the `/.crucible/ledger/...` constant inside JoinedStr.
+    fstr_src = 'f = open(f"{REPO_ROOT}/.crucible/ledger/runs.jsonl", "a")'
+    assert scan_source(fstr_src) == [1], "must flag the .crucible literal inside an f-string"
+
+    # Multi-line os.path.join — the node lineno is the call's first line.
+    multiline_src = (
+        "p = os.path.join(\n"
+        '    REPO_ROOT, ".crucible", "ledger",\n'
+        ")\n"
+    )
+    assert scan_source(multiline_src) == [2], "must flag the .crucible literal in a multi-line join"
+
+    # os.sep.join with a list of segments.
+    sepjoin_src = 'p = os.sep.join([REPO_ROOT, ".crucible", "x"])'
+    assert scan_source(sepjoin_src) == [1], "must flag an os.sep.join .crucible segment"
+
+    # A `+` after the `.crucible` segment: suffix char-class includes `+`, so the
+    # whole literal stays path-shaped and is flagged.
+    plus_suffix_src = 'p = "/.crucible/ledger+x"'
+    assert scan_source(plus_suffix_src) == [1], "must flag a .crucible path with a `+` in the suffix"
+
+    # --- Negatives: legitimate / prose must NOT be flagged. ---
+
+    # The legitimate central store (no leading dot on `crucible`; `.claude` only).
+    good = 'os.path.join(os.path.expanduser("~"), ".claude", "crucible", "ledger")'
+    assert scan_source(good) == [], "must NOT flag the ~/.claude/crucible central store"
+
+    # A bare `.claude` path literal must not match the path-only regex.
+    claude_path = 'p = "~/.claude/crucible/ledger/runs.jsonl"'
+    assert scan_source(claude_path) == [], "must NOT flag a .claude path literal"
+
+    # The fixed backfill line.
+    fixed = 'LEDGER_PATH = os.path.join(default_ledger_dir(), "runs.jsonl")'
+    assert scan_source(fixed) == [], "must NOT flag the default_ledger_dir() derivation"
+
+    # Prose docstring mentioning the path (spaces + backticks -> not path-shaped):
+    # this is render_ledger.py:4 / the SP-3 trap.
+    docstr_mod = '"""Reads `.crucible/ledger/runs.jsonl`, groups entries by ISO week."""\n'
+    assert scan_source(docstr_mod) == [], "must NOT flag a prose docstring mentioning .crucible/"
+
+    # Prose comment mentioning the path (comments are not in the AST at all):
+    # this is brier_advisory.py:42.
+    comment_mod = 'x = 1  # writes to, NOT the cwd-relative .crucible/ledger/ the design text\n'
+    assert scan_source(comment_mod) == [], "must NOT flag a comment mentioning .crucible/"
+
+    print("selftest OK")
+    return 0
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if "--selftest" in argv:
+        return _selftest()
+    return check_tree()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #396.

## The bug
`scripts/backfill-ledger.py:39` pinned its write target to the **in-repo** tree:
```python
LEDGER_PATH = os.path.join(REPO_ROOT, ".crucible", "ledger", "runs.jsonl")
```
Two failures in one line:
1. **Dead store** — every reader (`render_ledger`, `reconcile_ledger`, `brier_advisory`, `ledger_append.append`) routes through `default_ledger_dir()` → the machine-local central store `~/.claude/crucible/ledger`. A backfill writing into the in-repo tree had **zero effect** on the corpus those readers consume.
2. **Public-tree leak** — crucible is a PUBLIC repo; ledger entries carry private file paths + verbatim finding quotes. Writing them into a tracked `.crucible/` file is the exact leak class the central-store decision (#270 / PR #326) exists to prevent.

## The fix
- **`scripts/backfill-ledger.py`** — derive `LEDGER_PATH` from `default_ledger_dir()` (honoring `CRUCIBLE_LEDGER_DIR`), mirroring `render_ledger.py:44`. Honest banner comment + `default_ledger_dir` import. The intentional committed **11-row `.crucible/ledger/runs.jsonl` test fixture is untouched.**
- **`scripts/check_ledger_write_path.py`** (new) — AST-based regression guard. It parses each `scripts/**.py` and flags any **path-shaped `.crucible` string literal** (`^[\w./~+-]*\.crucible[\w./~+-]*$`). Because every realistic in-repo path carries a `.crucible` literal *somewhere*, it catches the full spelling surface — `os.path.join`, `pathlib`, string concat, f-strings, variable-held segments, multi-line joins, `os.sep.join` — while leaving prose docstrings/comments and the `~/.claude/crucible` central store (no leading dot on `crucible`) unflagged. Recursive `os.walk`, fail-loud (`rc=2`) on `SyntaxError`, built-in `--selftest`.
- **`.github/workflows/ci.yml`** — wire the guard (`--selftest` + tree scan) into the `structural-checks` job.

## Verification
- `check_ledger_write_path.py --selftest` ✅ · tree scan ✅ · independently proven to FAIL (rc=1) on a reintroduced in-repo `.crucible/` path (incl. pathlib-in-subdir) and rc=2 on a syntax-broken file.
- `eval/calibration-ledger/test-backfill-smoke.py` 15/15 ✅ (repoint does not regress the pure core).
- 11-row in-repo fixture unchanged.

## Quality gate
**PASS** (2 rounds). Round 1 caught **2 Significants** — the guard initially pinned only one *spelling* of the bug (regex missed pathlib/concat/f-string) and scanned non-recursively (missed `scripts/hooks/`). Both fixed via the AST rewrite + `os.walk`, then confirmed clean by a fresh round + tightened-rubric look-harder pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)