### PR TITLE
feat(#394,#395): canonical test runner — single source of truth for CI + local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python3 scripts/check_canonical_drift.py
-      - run: python3 scripts/check_i2_marker.py
-      - run: python3 scripts/check_qg_stagnation_minor.py
-      - run: python3 scripts/check_crossref.py --selftest
-      - run: python3 scripts/check_crossref.py
-      - run: python3 scripts/catalog.py check
-      - run: python3 scripts/rcpt_verify.py --selftest
-      - run: python3 scripts/test_rcpt_verify.py
-      - run: bash hooks/tests/test-rcpt-verify-hook.sh
-      - run: python3 scripts/check_calibration_dispatch.py --selftest
-      - run: python3 scripts/check_calibration_dispatch.py
-      - run: python3 scripts/test_brier_advise.py
-      - run: python3 scripts/check_model_pins.py --selftest
-      - run: python3 scripts/check_model_pins.py
-      - run: python3 scripts/check_ledger_write_path.py --selftest
-      - run: python3 scripts/check_ledger_write_path.py
+      # Single source of truth: scripts/run_tests.sh runs the same suite
+      # locally and in CI, so the two can never drift. Add suites there.
+      - run: bash scripts/run_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ tests/
 !skills/build/evals/fixtures/**/src/**
 !skills/build/evals/fixtures/**/tests/
 !skills/build/evals/fixtures/**/tests/**
+# Vestigial Node scaffolding from the original `npm init`. Crucible has no
+# JS/TS source — tests are Python + bash via scripts/run_tests.sh. Do NOT
+# un-ignore these; `npm test` is not the gate (see CLAUDE.md "Running & testing").
 package.json
 package-lock.json
 tsconfig.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,12 @@ Markdown workflow). `shared/` holds canonical conventions every skill links to;
 lifecycle hooks; `docs/` is the catalog, architecture, and measured eval deltas.
 
 ## Running & testing
-- Internal tests are Python + bash: `scripts/check_*.py`, `scripts/test_*.py`,
-  and `hooks/tests/*.sh`, run individually; the gating subset also runs in
-  `.github/workflows/ci.yml` (full CI coverage is still being wired up — see #394).
-  (`npm test`/vitest is currently non-functional — no JS/TS tests are tracked; see #395.)
+- Internal tests are Python + bash (`scripts/check_*.py`, `scripts/test_*.py`,
+  `hooks/tests/*.sh`). Run the whole gating suite with **`bash scripts/run_tests.sh`**
+  — the single source of truth that `.github/workflows/ci.yml` also invokes, so
+  local and CI never drift. Add a suite by adding one `run` line to that script.
+  There is no JS/TS toolchain: any `package.json`/`tsconfig.json`/`node_modules/`
+  in your tree is vestigial `npm init` scaffolding (gitignored, never shipped).
 - Skill behavior evals: defined in `skills/<skill>/evals/evals.json`, run via
   Anthropic's skill-creator (blind A/B); measured deltas live in `docs/evals.md`.
 - Install for live use: symlink skills into Claude Code —

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/run_tests.sh
+# Canonical test runner for Crucible — the single source of truth for the
+# repo's gating suite. Both CI (.github/workflows/ci.yml) and humans invoke
+# THIS script, so the local suite and the CI suite can never drift.
+#
+# Runs every suite even if an earlier one fails (no `set -e`), collects the
+# failures, and exits non-zero iff any suite failed. `::group::`/`::endgroup::`
+# markers fold each suite in the GitHub Actions log (and print harmlessly as
+# plain lines locally).
+#
+# Adding a suite? Add ONE `run` line below — it is then covered locally and in
+# CI atomically.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+failed=()
+total=0
+
+run() {
+  total=$((total + 1))
+  echo "::group::$*"
+  if "$@"; then
+    echo "::endgroup::"
+  else
+    echo "::endgroup::"
+    failed+=("$*")
+  fi
+}
+
+# --- Structural / canonical checks ---
+run python3 scripts/check_canonical_drift.py
+run python3 scripts/check_i2_marker.py
+run python3 scripts/check_qg_stagnation_minor.py
+run python3 scripts/check_crossref.py --selftest
+run python3 scripts/check_crossref.py
+run python3 scripts/catalog.py check
+
+# --- Receipt-verify (rcpt_verify) ---
+run python3 scripts/rcpt_verify.py --selftest
+run python3 scripts/test_rcpt_verify.py
+run bash hooks/tests/test-rcpt-verify-hook.sh
+
+# --- Calibration dispatch / Brier advisory ---
+run python3 scripts/check_calibration_dispatch.py --selftest
+run python3 scripts/check_calibration_dispatch.py
+run python3 scripts/test_brier_advise.py
+
+# --- Model-pin guardrail ---
+run python3 scripts/check_model_pins.py --selftest
+run python3 scripts/check_model_pins.py
+
+# --- Ledger write-path guard ---
+run python3 scripts/check_ledger_write_path.py --selftest
+run python3 scripts/check_ledger_write_path.py
+
+# --- #366 red-team <-> quality-gate receipt contract ---
+run python3 scripts/check_rt_receipt_contract.py
+
+# --- Catalog unit suite ---
+run python3 scripts/test_catalog.py
+
+# --- Build-routing advisor + reconcile hooks ---
+run bash hooks/tests/test-build-routing-advisor.sh
+run bash hooks/tests/test-gate-ledger-guard.sh
+run bash hooks/tests/tools/test-build-routing-reconcile.sh
+
+# --- Summary ---
+if [ ${#failed[@]} -ne 0 ]; then
+  echo
+  echo "FAILED (${#failed[@]}):"
+  for f in "${failed[@]}"; do echo "  - $f"; done
+  exit 1
+fi
+
+echo
+echo "All ${total} suite invocations passed."


### PR DESCRIPTION
## What

Closes **#394** (wire 5 green-but-orphaned suites into CI) and **#395** (retire the vestigial Node toolchain) as one coherent change.

- **New `scripts/run_tests.sh`** — the single canonical gating suite: 21 invocations / 16 suites = the 16 previously-enumerated CI `run:` lines **plus the 5 orphans** (`check_rt_receipt_contract.py`, `test_catalog.py`, `test-build-routing-advisor.sh`, `test-gate-ledger-guard.sh`, `tools/test-build-routing-reconcile.sh`). Runs all suites, collects failures, exits non-zero iff any fail (`set -uo pipefail`, no `-e`); `::group::` markers fold the Actions log.
- **`ci.yml` collapses** its 16 enumerated `run:` lines to a single `bash scripts/run_tests.sh`. CI and local are now provably identical — **one list, zero drift surface.** This is the structural fix for the rot that left those 5 suites unwired, not a patch over the instances.
- **#395 is docs-only.** The Node toolchain (`package.json`/`tsconfig.json`/`node_modules/`) is **gitignored and was never shipped** — `npm test` was only "broken" on machines carrying stale local `npm init` scaffolding; a clean clone has no Node files. `CLAUDE.md` "Running & testing" is repointed at the runner and now states plainly there is no JS/TS toolchain; `.gitignore` gains a comment so the vestigial files aren't re-adopted.

## Why this shape

The handoff flagged the real spaghetti risk as *two drifting suite lists*. A runner that merely duplicates CI's list wouldn't fix that — so CI now **consumes** the runner. Adding a future suite is one `run` line in one file, covered locally and in CI atomically. Tradeoff accepted (user-chosen): GitHub Actions shows one step instead of 16; the failing suite is named in the log/summary via `::group::` + the `FAILED:` list.

## Verification

- All 21 invocations green on `af1f6c5` (each individually + through the runner).
- Runner **fails closed** — proven by injecting `run false` → exit 1 with `FAILED` summary; all-pass → exit 0.
- cwd-independent (`REPO_ROOT` via `BASH_SOURCE`).
- **Quality gate: PASS** (clean-pass, 1 round + look-harder confirmation, 0 Fatal / 0 Significant across two independent Opus passes). One Minor hardening applied: `cd "$REPO_ROOT" || exit 1` fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)