### PR TITLE
fix(#397): harden rcpt_verify — root containment, (none) symmetry, witness span-cap

### DIFF
--- a/scripts/rcpt_verify.py
+++ b/scripts/rcpt_verify.py
@@ -114,6 +114,8 @@ def parse_trace(body):
         line = raw.strip()
         if not line:
             continue
+        if line == "(none)":
+            return []  # #397: empty sentinel accepted uniformly (cf. ARTIFACTS/NEXT)
         parts = line.split(None, 2)
         if len(parts) < 2:
             raise LintError(f"TRACE malformed: {raw!r}")
@@ -138,9 +140,15 @@ def check_exec_range_bound(args_str):
     kind, a, b = m.group(1), int(m.group(2)), int(m.group(3))
     if b < a:
         raise LintError(f"EXEC range negative: {args_str}")
-    span_bytes = (b - a) if kind == "B" else (b - a) * 80  # 80 bytes/line conservative estimate
+    # Tier-1 is disk-free, so a line range can only be ESTIMATED (80 bytes/line). This
+    # under-counts long lines, so it is a cheap pre-filter only — the authoritative 4 KiB
+    # cap is enforced against the ACTUAL bytes read at Tier-2 (tier2_witness, #397 defect 4).
+    span_bytes = (b - a) if kind == "B" else (b - a) * 80
     if span_bytes > 4096:
         raise LintError(f"EXEC range exceeds 4 KiB: {args_str}")
+
+
+WITNESS_SPAN_CAP = 4096
 
 
 def parse_claims(body):
@@ -149,6 +157,8 @@ def parse_claims(body):
         line = raw.strip()
         if not line:
             continue
+        if line == "(none)":
+            return []  # #397: empty sentinel accepted uniformly (cf. ARTIFACTS/NEXT)
         # pattern= may be quoted (containing spaces) or a /regex/ form or bare
         m = re.match(
             r'^([^\s=]+)=(\S+)\s+from=(\S+)(?:\s+pattern=("[^"]*"|/[^/]*/|\S+))?$',
@@ -462,20 +472,37 @@ def lint_v11_local(parsed):
 def resolve_base(name: str, root: pathlib.Path):
     """Probe {root, repo-root-of-root, absolute-as-is} in fixed order; return the
     FIRST base where the file exists, else None. repo-root = git toplevel of `root`
-    (NOT this script's checkout). Used by part-1 hash, part-2 witness read, and --strict."""
+    (NOT this script's checkout). Used by part-1 hash, part-2 witness read, and --strict.
+
+    #397 containment: a candidate is read ONLY if its realpath (symlinks + `..`
+    resolved) is contained under `root` or the repo toplevel. A `..`-traversal,
+    an absolute-outside-root name, or an in-tree symlink whose TARGET escapes the
+    tree resolves to None — never an out-of-tree disk read while linting an
+    attacker-influenced receipt. (None then becomes UNVERIFIABLE, or path-shaped +
+    --strict FAIL, in the callers — the same shape as a genuinely-absent file.)"""
+    repo = _git_toplevel(root)
+    allowed = [root.resolve()] + ([repo.resolve()] if repo else [])
     cands = []
     p = pathlib.Path(name)
     if p.is_absolute():
         cands.append(p)
     else:
         cands.append(root / name)
-        repo = _git_toplevel(root)
         if repo:
             cands.append(repo / name)
     for c in cands:
-        if c.is_file():
-            return c
+        real = c.resolve()  # normalizes `..` and follows symlinks
+        if not any(_contained(real, base) for base in allowed):
+            continue  # containment violation — never read
+        if real.is_file():
+            return real
     return None
+
+
+def _contained(child: pathlib.Path, base: pathlib.Path) -> bool:
+    """True iff resolved `child` is `base` itself or lies beneath it. Both paths
+    must already be realpath-resolved by the caller (resolve_base does so)."""
+    return child == base or base in child.parents
 
 
 def _git_toplevel(start: pathlib.Path):
@@ -643,6 +670,32 @@ def tier2_witness(witness, trace, root, strict, verdict):
             raise LintError(f"Tier-2 --strict: witness artifact {art_name} absent under all bases")
         return [f"UNVERIFIABLE: witness {art_name} (no file under root)"]
     body_text = _read_cited_range(resolved, cited)
+    # #397 defect 4 — authoritative 4 KiB cap on the cited range (Tier-1's 80-bytes/line
+    # estimate under-counts long lines). The cap measures EXACTLY what the reader read:
+    #  - #L: len(body_text.encode("utf-8")) — the reader's own slice. read_text() decodes
+    #    losslessly (no errors=), so there is NO U+FFFD inflation on this path; this also
+    #    makes the cap byte-count equal the reader's str.splitlines() slice exactly (vs.
+    #    bytes.splitlines(), which diverges on exotic separators U+2028/NEL/VT/FF).
+    #  - #B: len(raw[a-1:b]) on the RAW on-disk bytes — matches the reader's read_bytes()
+    #    slice. NOT body_text: a #B range over invalid UTF-8 decodes each bad byte to
+    #    U+FFFD (3 bytes), which would inflate an in-budget range past the cap and
+    #    false-FAIL.
+    # Scoped to ranged out= citations (the EXEC#L/#B read budget per return-convention.md:224);
+    # rangeless READ/WROTE grep reads carry no #range and keep their whole-file behavior.
+    m = re.search(r"out=\S+?#([LB])(\d+)-\1(\d+)", cited["args"])
+    if m:
+        kind, a, b = m.group(1), int(m.group(2)), int(m.group(3))
+        if a < 1:  # 1-based; clamp matches _read_cited_range
+            a = 1
+        if kind == "L":
+            span = len(body_text.encode("utf-8"))
+        else:
+            span = len(resolved.read_bytes()[a - 1:b])
+        if span > WITNESS_SPAN_CAP:
+            raise LintError(
+                f"Tier-2: cited witness range exceeds 4 KiB actual bytes "
+                f"({span} > {WITNESS_SPAN_CAP}; Tier-1's line estimate under-counted)"
+            )
     verify_witness(body_text, witness, verdict, cited)  # raises on FAIL
     return []
 

--- a/scripts/test_rcpt_verify.py
+++ b/scripts/test_rcpt_verify.py
@@ -575,5 +575,168 @@ class TestCliLedger(unittest.TestCase):
             self.assertNotIn("Traceback", r.stderr)
 
 
+class TestRootContainment(unittest.TestCase):
+    """#397 defect 2 — resolve_base must confine resolution to --root (or its git
+    toplevel). `..`-traversal and absolute-outside-root names must NOT be read; they
+    resolve to None (→ UNVERIFIABLE, or path-shaped+strict FAIL — never an out-of-tree
+    disk read while linting attacker-influenced receipts)."""
+
+    def test_resolve_base_rejects_dotdot_traversal(self):
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            outer = pathlib.Path(td)
+            (outer / "secret.txt").write_text("TOP SECRET")
+            root = outer / "root"
+            root.mkdir()
+            # `../secret.txt` escapes root → must not resolve to the outer file
+            self.assertIsNone(rv.resolve_base("../secret.txt", root))
+
+    def test_resolve_base_rejects_absolute_outside_root(self):
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            outer = pathlib.Path(td)
+            (outer / "secret.txt").write_text("TOP SECRET")
+            root = outer / "root"
+            root.mkdir()
+            self.assertIsNone(rv.resolve_base(str(outer / "secret.txt"), root))
+
+    def test_resolve_base_allows_absolute_inside_root(self):
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            f = root / "in.txt"
+            f.write_text("OK")
+            got = rv.resolve_base(str(f), root)
+            self.assertIsNotNone(got)
+            self.assertEqual(got.read_text(), "OK")
+
+    def test_resolve_base_rejects_symlink_escape(self):
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            outer = pathlib.Path(td)
+            (outer / "secret.txt").write_text("TOP SECRET")
+            root = outer / "root"
+            root.mkdir()
+            link = root / "link.txt"
+            link.symlink_to(outer / "secret.txt")  # in-tree name, out-of-tree target
+            self.assertIsNone(rv.resolve_base("link.txt", root))
+
+    def test_tier2_artifacts_traversal_strict_fails_not_reads(self):
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            outer = pathlib.Path(td)
+            data = b"TOP SECRET"
+            (outer / "secret.txt").write_bytes(data)
+            root = outer / "root"
+            root.mkdir()
+            art = {"../secret.txt": {"hash": hashlib.sha256(data).hexdigest(),
+                                     "size": str(len(data))}}
+            # Even though the out-of-tree file's hash WOULD match, containment forbids
+            # the read → strict + path-shaped → FAIL (never a silent hash "proof").
+            with self.assertRaises(rv.LintError):
+                rv.tier2_artifacts(art, [], root, True)
+
+    def test_resolve_base_repo_toplevel_allowance_boundary(self):
+        rv = _import_rv()
+        # Pin the repo-toplevel allowance BOUNDARY: a file inside the repo but
+        # OUTSIDE --root resolves (the documented repo-allowance), while a
+        # `..`-traversal to a file OUTSIDE the repo still returns None.
+        with tempfile.TemporaryDirectory() as td:
+            parent = pathlib.Path(td)
+            outer = parent / "outer"  # the repo
+            outer.mkdir()
+            (outer / ".git").mkdir()  # dir, so _git_toplevel finds `outer` as repo toplevel
+            root = outer / "root"
+            root.mkdir()
+            (outer / "in-repo.txt").write_text("IN REPO")  # in repo, outside --root
+            (parent / "out-of-repo.txt").write_text("OUT OF REPO")  # sibling of repo, outside it
+            # in-repo file outside --root resolves via the repo-toplevel allowance
+            got = rv.resolve_base("in-repo.txt", root)
+            self.assertIsNotNone(got)
+            self.assertEqual(got.read_text(), "IN REPO")
+            # `../`-traversal from root up past the repo to the out-of-repo file → None
+            self.assertIsNone(rv.resolve_base("../../out-of-repo.txt", root))
+
+
+class TestNoneSentinelSymmetry(unittest.TestCase):
+    """#397 defect 3 — the `(none)` empty sentinel is accepted uniformly across
+    ARTIFACTS / TRACE / CLAIMS (it already was for ARTIFACTS/NEXT)."""
+
+    def test_parse_trace_accepts_none(self):
+        rv = _import_rv()
+        self.assertEqual(rv.parse_trace(["  (none)"]), [])
+
+    def test_parse_claims_accepts_none(self):
+        rv = _import_rv()
+        self.assertEqual(rv.parse_claims(["  (none)"]), [])
+
+    def test_full_receipt_none_trace_and_claims_lints(self):
+        rv = _import_rv()
+        receipt = (
+            "RCPT v1 build/x\n"
+            "VERDICT  BLOCKED  conf=0.50\n"
+            "ARTIFACTS\n  (none)\n"
+            "TRACE\n  (none)\n"
+            "CLAIMS\n  (none)\n"
+            "WITNESS    exec:`run`  expect-fail=/\\d+ fail/  ran=UNRUNNABLE:tooling-absent\n"
+            "SUSPICION  0.00\nNEXT       (none)\n"
+        )
+        self.assertEqual(rv.lint_receipt(receipt), "BLOCKED")
+
+
+class TestWitnessSpanCapActual(unittest.TestCase):
+    """#397 defect 4 — the Tier-1 (b-a)*80 estimate under-counts long lines; the
+    authoritative 4 KiB cap is enforced at Tier-2 against the ACTUAL bytes read."""
+
+    def _w(self, expect="/zzzzz-no-match/", ran="TRACE#2"):
+        return {"kind": "exec", "payload": "x", "expect_fail": expect, "ran": ran}
+
+    def test_long_lines_exceed_actual_cap_raises(self):
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            # 40 lines × 200 bytes ≈ 8 KiB actual, but Tier-1 estimate (40-1)*80=3120 < 4096.
+            (root / "out.log").write_text("".join("X" * 199 + "\n" for _ in range(40)))
+            cited = {"n": 2, "verb": "EXEC", "args": "`run`  exit=0  out=out.log#L1-L40"}
+            trace = [{"n": 1, "verb": "READ", "args": "a"}, cited]
+            with self.assertRaises(rv.LintError) as cm:
+                rv.tier2_witness(self._w(), trace, root, False, "PASS")
+            self.assertIn("4 KiB", str(cm.exception))
+
+    def test_short_lines_within_cap_clean(self):
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "out.log").write_text("".join(f"line {i}\n" for i in range(1, 41)))
+            cited = {"n": 2, "verb": "EXEC", "args": "`run`  exit=0  out=out.log#L1-L40"}
+            trace = [{"n": 1, "verb": "READ", "args": "a"}, cited]
+            self.assertEqual(rv.tier2_witness(self._w(), trace, root, False, "PASS"), [])
+
+    def test_byte_range_invalid_utf8_within_cap_no_false_fail(self):
+        # 4000 raw bytes of 0xFF: under WITNESS_SPAN_CAP (4096), but each byte decodes
+        # to U+FFFD (3 bytes), so len(body_text.encode()) ≈ 12000 would false-FAIL the
+        # cap. The raw-bytes measurement must keep this in-budget range clean. Tier-1's
+        # #B span is b-a (B1-B4000 → 3999 < 4096), so it passes Tier-1 too.
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "out.log").write_bytes(b"\xff" * 4000)
+            cited = {"n": 2, "verb": "EXEC", "args": "`run`  exit=0  out=out.log#B1-B4000"}
+            trace = [{"n": 1, "verb": "READ", "args": "a"}, cited]
+            self.assertEqual(rv.tier2_witness(self._w(), trace, root, False, "PASS"), [])
+
+    def test_byte_range_raw_span_exceeds_cap_raises(self):
+        # The cap is real for #B too: 5000 raw bytes (> 4096) must still raise.
+        rv = _import_rv()
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "out.log").write_bytes(b"\xff" * 5000)
+            cited = {"n": 2, "verb": "EXEC", "args": "`run`  exit=0  out=out.log#B1-B5000"}
+            trace = [{"n": 1, "verb": "READ", "args": "a"}, cited]
+            with self.assertRaises(rv.LintError) as cm:
+                rv.tier2_witness(self._w(), trace, root, False, "PASS")
+            self.assertIn("4 KiB", str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hardens the receipt linter `scripts/rcpt_verify.py` (the repo's anti-fabrication trust boundary) — **three of four #397 sub-defects**. BS1 is deliberately deferred to **#412** (see below).

## What changed
| # | Defect | Fix |
|---|--------|-----|
| 2 | No `--root` containment — `resolve_base` probed `../` and absolute paths un-normalized → arbitrary-file-read while linting attacker-influenced receipts | realpath-resolve each candidate + a `_contained()` helper; read only candidates under `--root` or the git toplevel. `..`-traversal, absolute-outside-root, and in-tree symlink-escape now resolve to `None` (→ UNVERIFIABLE, or path-shaped+`--strict` FAIL). **Strictly tighter** than the prior behavior (which read any absolute path / any repo file with zero containment). |
| 3 | `(none)` sentinel asymmetry — `parse_artifacts` accepted it; `parse_trace`/`parse_claims` raised | accept a lone `(none)` body uniformly (`[]`), matching `parse_artifacts`/NEXT |
| 4 | Witness span-cap used a Tier-1 `(b-a)*80` estimate that under-counts long lines | `tier2_witness` enforces the 4 KiB cap against the **actual bytes** of the cited `out=#L/#B` range, measured to exactly match `_read_cited_range`'s slice (`#L` via the decoded text, `#B` via raw bytes — no lossy U+FFFD inflation) |

## BS1 deferred to #412 (design decision, not a bug-fix)
The audit's headline sub-defect — hard-FAIL undeclared EDIT/WROTE — conflicts head-on with a **deliberate** trust model: committed fixtures `a-clean-pass` and `f-multi-root-strict-pass` both PASS under `--strict` with `EDIT … sha256:0000…0` placeholder hashes (one with the file absent, one with the file present *and* correctly declared). EDIT/WROTE post-edit hashes are intentionally **never disk-verified**; verification is via declared ARTIFACTS + WITNESS + ledger. The literal fix would flip those clean-pass fixtures and rewrite the trust model — it needs a design decision (and a fix to the `return-convention.md:152-153` spec drift). Tracked in **#412**.

## Verification
- Gated with the **real `/quality-gate`** (artifact type: code) — 2 red-team rounds + look-harder, red-team pinned to Opus. Round 1 caught a `#B` invalid-UTF-8 false-FAIL in the *initial* span-cap (each `0xFF`→U+FFFD inflated 3× on re-encode → false-FAIL of an in-budget range); fixed to measure raw on-disk bytes and re-verified clean. Minor pass added `.git`-fixture coverage of the repo-allowance boundary + tightened the cap to track the reader exactly.
- `bash scripts/run_tests.sh` — all 21 invocations green (incl. `--selftest` against the committed Tier-2 fixtures, confirming no regression to the deliberate trust-model fixtures). 61 unit tests in `test_rcpt_verify.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)