### PR TITLE
chore: genericize private project names out of tracked files

### DIFF
--- a/eval/calibration-ledger/test-central-store.py
+++ b/eval/calibration-ledger/test-central-store.py
@@ -153,22 +153,22 @@ def test_repo_population_git_and_fallback():
 
     # git repo -> toplevel basename, even from a subdir
     with tempfile.TemporaryDirectory(prefix="cs-git-") as gitparent:
-        repo_dir = os.path.join(gitparent, "riftlock")
+        repo_dir = os.path.join(gitparent, "repo-alpha")
         os.makedirs(os.path.join(repo_dir, "src"))
         try:
             subprocess.run(["git", "init", "-q"], cwd=repo_dir, check=True,
                            capture_output=True)
             got = default_repo(os.path.join(repo_dir, "src"))
             _check("INV-7 git repo -> toplevel basename from subdir",
-                   got == "riftlock", got)
+                   got == "repo-alpha", got)
         except (FileNotFoundError, subprocess.CalledProcessError):
             _check("INV-7 git repo -> toplevel basename (SKIPPED: no git)", True)
 
     # The emit CLI auto-stamps repo when the entry omits it. Emit from a SUBDIR
-    # of the git repo so the git-toplevel basename ("driftmap") genuinely
+    # of the git repo so the git-toplevel basename ("repo-beta") genuinely
     # differs from the cwd basename ("sub") — this exercises which branch fires.
     with tempfile.TemporaryDirectory(prefix="cs-emit-git-") as gp:
-        repo_dir = os.path.join(gp, "driftmap")
+        repo_dir = os.path.join(gp, "repo-beta")
         sub_dir = os.path.join(repo_dir, "sub")
         os.makedirs(sub_dir)
         central_dir = os.path.join(gp, "central")
@@ -182,8 +182,8 @@ def test_repo_population_git_and_fallback():
                      cwd=sub_dir,
                      extra_env={"CRUCIBLE_LEDGER_DIR": central_dir})
         rows = _read_lines(os.path.join(central_dir, "runs.jsonl"))
-        # git present -> toplevel basename "driftmap"; absent -> cwd basename "sub"
-        expected = "driftmap" if ok_git else "sub"
+        # git present -> toplevel basename "repo-beta"; absent -> cwd basename "sub"
+        expected = "repo-beta" if ok_git else "sub"
         _check("INV-7 emit auto-stamps repo (git toplevel, not cwd subdir)",
                proc.returncode == 0 and len(rows) == 1
                and rows[0].get("repo") == expected,
@@ -214,7 +214,7 @@ def test_mixed_v1_v2_read_dedup_render():
         _check("INV-8 v1 append ok",
                append(ledger, _v1("v1-a", "quality-gate"), overflow_dir=ov))
         _check("INV-8 v2 append ok",
-               append(ledger, _v2("v2-a", "siege", repo="riftlock"),
+               append(ledger, _v2("v2-a", "siege", repo="repo-alpha"),
                       overflow_dir=ov))
         # caller_dedup tolerates mixed rows
         _check("INV-8 dedup sees v1 row",
@@ -230,7 +230,7 @@ def test_mixed_v1_v2_read_dedup_render():
             repos = summary.get("per_repo", {})
             ok = (len(entries) == 2
                   and "unknown" in repos
-                  and "riftlock" in repos)
+                  and "repo-alpha" in repos)
             _check("INV-8 per_repo buckets v1->unknown, v2->repo", ok,
                    f"per_repo={repos}")
         except Exception as exc:  # noqa: BLE001

--- a/hooks/rcpt-verify-hook.sh
+++ b/hooks/rcpt-verify-hook.sh
@@ -64,8 +64,8 @@ RCPT_BLOCK="$(printf '%s\n' "$TEXT" | awk '/^RCPT v1 /{p=1} p')"
 [ -z "$RCPT_BLOCK" ] && exit 0
 
 # ── 6. Resolve repo root + the existence gate (M2) ────────────────────
-# Without this gate a SubagentStop in a non-crucible repo (per MEMORY the user runs
-# gating skills in Riftlock/DriftMap) would `python3 <nonexistent>` → exit 2 → a
+# Without this gate a SubagentStop in a non-crucible repo (these gating skills run
+# in other repos too) would `python3 <nonexistent>` → exit 2 → a
 # misleading "structural lint failed" advisory on every receipt. Never-fatal holds
 # regardless; the gate prevents the spurious advisory.
 REPO="$(git rev-parse --show-toplevel 2>/dev/null)"

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -413,7 +413,7 @@ No scoping agent needed — the artifact IS the scope. The orchestrator:
    - Issue references (`#NNN`)
    - Explicit "see also" references
    - **Project-memory references** — bare filenames or relative paths that match Crucible-style memory conventions (see Project-Memory Reference Resolution below)
-   - **Skill name references** — names of skills the artifact mentions (e.g., "the `riftlock-standards` skill", "`feedback_use_component_library`")
+   - **Skill name references** — names of skills the artifact mentions (e.g., "the `project-standards` skill", "`feedback_use_component_library`")
 
    For each referenced file that exists locally: read and include as supporting context. For issue references: fetch title and body via `gh issue view`. **Soft cap: 800 lines total.** This bounds the Supporting Context section of the shared dispatch-context bundle (step 4.5), which the lens agents read as a file alongside the artifact (~300-500 lines) and operating environment (≤500 lines). These are per-section soft caps and can sum above the bundle's hard ceiling; step 4.5 enforces the actual 1500-line ceiling on the assembled bundle via a deterministic truncation order, with Supporting Context truncated first. If exceeded: prioritize files referenced in decision-critical sections (Key Decisions, Risk Areas) over background references. Truncate with note: "[truncated — 800-line context cap reached]". If no references found: proceed with artifact-only context.
 

--- a/skills/shared/ledger-append.md
+++ b/skills/shared/ledger-append.md
@@ -27,7 +27,7 @@ The live ledger is **machine-local and shared across every repo**:
 `~/.claude/crucible/ledger/runs.jsonl` (override with `CRUCIBLE_LEDGER_DIR`).
 It is deliberately **not** inside any git repo — entries carry private file
 paths and verbatim finding quotes, and crucible is public. Gating skills run
-in arbitrary repos (Riftlock, DriftMap, …); they all aggregate here so
+in arbitrary repos (any project on the machine, …); they all aggregate here so
 `/ledger` can render one honest cross-repo headline with a per-repo breakdown.
 `scripts.ledger_append.default_ledger_path()` is the single source of truth for
 this path; the renderer imports it too.


### PR DESCRIPTION
Removes references to two of the author's other (private) projects — **Riftlock** / **DriftMap** — from the public repo, replacing them with neutral placeholders.

- `eval/calibration-ledger/test-central-store.py` — fixture repo dirs + expected-basename assertions `riftlock`/`driftmap` → `repo-alpha`/`repo-beta` (arbitrary names; test still passes 19/19).
- `hooks/rcpt-verify-hook.sh` — comment genericized to "these gating skills run in other repos too".
- `skills/audit/SKILL.md` — example skill name `riftlock-standards` → `project-standards`.
- `skills/shared/ledger-append.md` — "arbitrary repos (Riftlock, DriftMap, …)" → "(any project on the machine, …)".

Zero behavior change. Verified: zero `riftlock|driftmap` references remain in tracked files; gating suite `run_tests.sh` 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)