### PR TITLE
docs: sync README eval figures to Opus 4.8 (v1.8.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crucible",
-  "version": "1.8.0",
-  "description": "52 agent skills for systematic software development. Covers design, planning, TDD, code review, debugging, quality gates, and adversarial testing. 13 core skills are eval-tested with measured A/B deltas using Anthropic's skill evaluation framework.",
+  "version": "1.8.1",
+  "description": "52 agent skills for systematic software development. Covers design, planning, TDD, code review, debugging, quality gates, and adversarial testing. 12 core skills are eval-tested with measured A/B deltas using Anthropic's skill evaluation framework.",
   "author": {
     "name": "raddue",
     "url": "https://github.com/raddue"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Notable changes to the Crucible skill library. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); entries are grouped by
 milestone since skills ship as a library rather than a versioned binary.
 
+## v1.8.1 — README eval-figure sync — 2026-06-14
+
+Docs-only patch. The README's headline A/B deltas still carried the Opus 4.6
+figures after `docs/evals.md` was re-measured on Opus 4.8; this syncs them and
+adds the inverse-capability thesis. No skill behavior changed.
+
+### Changed
+
+- **README eval figures synced to the Opus 4.8 re-measurement** — the headline
+  now matches `docs/evals.md`: execution evals **+23%** (52 evals, 475
+  assertions, graded blind on Opus 4.8; was the +29% Opus 4.6 figure), and
+  `quality-gate` **+55%** (93% vs 38%; was +68%). Sequence/ordering evals remain
+  **+31%** (Opus 4.6 — not yet re-run on 4.8), now labeled as such. Added the
+  "skill value scales inversely with model capability" framing (+29% on 4.6 →
+  +23% on 4.8). (#421 follow-up)
+
 ## v1.8.0 — Trust-Machinery Hardening & Test Coverage — 2026-06-12
 
 Two milestones land in this cut: the **Audit & Innovation Remediation** sweep

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A collection of agent skills for systematic software development. Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [OpenAI Codex](https://openai.com/codex/), [Amp](https://amp.dev), [Cline](https://cline.bot), and any platform that supports the SKILL.md format.
 
-52 skills across the full development lifecycle — design, planning, TDD implementation, code review, debugging, adversarial testing, and quality gates. 13 core skills are [eval-tested](docs/evals.md) with measured A/B deltas (49 execution evals + 18 sequence evals, +29% / +31% average).
+52 skills across the full development lifecycle — design, planning, TDD implementation, code review, debugging, adversarial testing, and quality gates. 12 core skills are [eval-tested](docs/evals.md) with measured A/B deltas: **+23%** on execution evals (52 evals, 475 assertions, graded blind on Claude Opus 4.8) and **+31%** on sequence/ordering evals (18 evals, Opus 4.6 — not yet re-run on 4.8).
+
+Skill value scales inversely with model capability: the same execution suite moved **+29% on Opus 4.6 → +23% on Opus 4.8**. The methodology is scaffolding that keeps a model on track, so the stronger the base model, the less lift it adds — one datapoint consistent with that thesis (not a controlled comparison — the two runs differ in more than the base model, since the methodology was also corrected between them, so the move can't be cleanly attributed to capability alone; see the [eval caveats](docs/evals.md)). On weaker models (Sonnet, Haiku, or non-Anthropic models in Cursor/Codex), we *expect* the deltas to widen — a prediction, not yet measured.
 
 Originally forked from [obra/superpowers](https://github.com/obra/superpowers), now independently maintained and significantly diverged. Pipeline checkpoint system, auto skill extraction, structured context compression, and trajectory capture inspired by [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent).
 
@@ -16,7 +18,7 @@ Originally forked from [obra/superpowers](https://github.com/obra/superpowers), 
 
 ## What you get
 
-- **Iterative quality gates, not single-pass review** — `quality-gate` loops until clean (red-team → fix → fresh re-review), with weighted stagnation detection. Measured **+68% delta** (see [eval results](docs/evals.md)).
+- **Iterative quality gates, not single-pass review** — `quality-gate` loops until clean (red-team → fix → fresh re-review), with weighted stagnation detection. Measured **+55% delta** (93% with vs 38% without — the largest delta in the suite even on Opus 4.8; see [eval results](docs/evals.md)).
 - **Full pipeline orchestration** — `build` chains design → plan → execute → complete with shadow-git checkpoints, crash recovery, and structured compaction-state blocks. One command, idea to merged PR.
 - **Adversarial testing at every level** — `adversarial-tester` writes tests designed to break the implementation; `inquisitor` runs 5 parallel attack dimensions against the full feature diff; `siege` runs 6 attacker-perspective security agents until zero Critical/High.
 - **Token-efficient by design** — orchestrators use [disk-mediated dispatch](skills/shared/dispatch-convention.md): full subagent prompts go to `/tmp`, only ~100-token pointers enter orchestrator context. A full build saves 73-131K tokens of fossilized context.


### PR DESCRIPTION
Docs-only patch. The README's headline A/B deltas still carried the Opus 4.6 figures after `docs/evals.md` was re-measured on Opus 4.8 (PR #421). This syncs them and adds the inverse-capability thesis (preserving evals.md's "suggestive, not a controlled proof" hedge + the methodology-correction confound).

## Changed
- **Execution evals:** +29% → **+23%** (52 evals, 475 assertions, graded blind on Opus 4.8)
- **quality-gate delta:** +68% → **+55%** (93% vs 38%)
- **Sequence evals:** +31% kept, now labeled **Opus 4.6** (not yet re-run on 4.8)
- **core-skills count:** 13 → **12** (README + plugin.json description; matches the 12-row table)
- CHANGELOG **v1.8.1** entry; `plugin.json` 1.8.0 → **1.8.1**

No skill behavior changed.

## Quality gate
Gated with the real `/quality-gate` (artifact: documentation, threshold 3): **PASS** — 1 round 0F/0S + look-harder confirmed clean. Both reviewers reconciled every figure line-for-line against `docs/evals.md`; look-harder independently recomputed the max delta (+55%) and the 12-row count. 1 of 4 Minors quick-fixed (added evals.md's methodology-correction caveat to the README hedge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)