### PR TITLE
feat(inquisitor): #424 fan-out eval harness (Phase 1, identification breadth)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ skills/*-workspace/
 skills/skill-creator/
 skills/stocktake/results.json
 skills/temper/evals/last_run.json
+skills/inquisitor/evals/last_run.json
+skills/inquisitor/evals/results.md
 src/
 tests/
 

--- a/scripts/check_ground_truth_provenance.py
+++ b/scripts/check_ground_truth_provenance.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Blind-boundary provenance check for the inquisitor ground-truth list (#424, S4).
+
+Invocation (from repo root):
+    python3 scripts/check_ground_truth_provenance.py            # check the tree
+    python3 scripts/check_ground_truth_provenance.py --selftest # built-in logic tests
+
+The PRIMARY recorded delta (acceptance #3) is graded against `ground-truth-bugs.json`,
+which design T1 requires be authored BLIND to evals.json's dimension-bucketed
+`expected_output` / `expectations` prose (authoring from that prose would re-import
+the dimension-aligned content selection and bias the lensed arms). "Trust the
+process" is what this repo's calibration ethos rejects, so the blind input is
+committed as `ground-truth-bugs.provenance.md` and this check makes the de-biasing
+machine-verifiable: it asserts the provenance artifact contains NONE of the
+`expected_output` / `expectations` strings. If any appears, the blind boundary leaked
+and the check fails.
+
+Stdlib only. Exit 0 clean / 1 on a detected leak.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+EVALS_JSON = ROOT / "skills/inquisitor/evals/evals.json"
+PROVENANCE = ROOT / "skills/inquisitor/evals/ground-truth-bugs.provenance.md"
+
+
+def expectation_strings(evals: dict) -> list:
+    """Every expectation/expected_output string the provenance must NOT contain."""
+    out = []
+    for e in evals["evals"]:
+        if e.get("expected_output"):
+            out.append(e["expected_output"])
+        for s in e.get("expectations", []):
+            if s:
+                out.append(s)
+    return out
+
+
+def leaks(provenance_text: str, strings) -> list:
+    """Return (string) entries that leaked into the provenance text."""
+    return [s for s in strings if s in provenance_text]
+
+
+def main() -> int:
+    evals = json.loads(EVALS_JSON.read_text(encoding="utf-8"))
+    strings = expectation_strings(evals)
+    text = PROVENANCE.read_text(encoding="utf-8")
+    found = leaks(text, strings)
+    if found:
+        print(f"GROUND-TRUTH BLIND BOUNDARY LEAKED in "
+              f"{PROVENANCE.relative_to(ROOT)}:")
+        for s in found:
+            print(f"  expectation string present: {s[:80]!r}...")
+        print("\nThe provenance artifact must contain only the diffs + factual "
+              "codebase context fed to the blind author — none of evals.json's "
+              "expectation prose. A leak means the ground-truth list may be "
+              "dimension-biased (design T1).")
+        return 1
+    print(f"OK — provenance contains none of the {len(strings)} evals.json "
+          "expectation strings; the blind boundary held.")
+    return 0
+
+
+def selftest() -> int:
+    """Built-in logic tests (in-memory) for the substring leak scan."""
+    strings = ["Identifies the in-memory scheduler problem",
+               "sent_at type mismatch"]
+    clean = "## Fixture 1\n```diff\n+const x = 1;\n```\nExisting codebase facts.\n"
+    leaky = clean + "Identifies the in-memory scheduler problem when restarted.\n"
+    cases = [
+        (clean, False, "diffs + context only → no leak"),
+        (leaky, True, "an expectation string in the provenance is caught"),
+    ]
+    failures = []
+    for text, expect_fail, reason in cases:
+        got = bool(leaks(text, strings))
+        if got != expect_fail:
+            failures.append(f"  expected leak={expect_fail} ({reason}), got={got}")
+    if failures:
+        print("SELFTEST FAILED:")
+        print("\n".join(failures))
+        return 1
+    print("SELFTEST OK — the substring leak scan fires on a seeded expectation "
+          "string and passes a diffs-plus-context-only provenance.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/check_inquisitor_helper_drift.py
+++ b/scripts/check_inquisitor_helper_drift.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Function-scoped drift check for the inquisitor eval-harness helpers (#424).
+
+Invocation (from repo root):
+    python3 scripts/check_inquisitor_helper_drift.py            # check the tree
+    python3 scripts/check_inquisitor_helper_drift.py --selftest # built-in logic tests
+
+The inquisitor eval harness copies temper's `_dispatch_paths.py` / `_runid.py`
+helpers (the design's "link/derive, never copy" rule is relaxed for these tiny
+path/hash/validation utilities — copying with a machine-checked no-drift invariant
+is cheaper than a shared-package refactor). This check replaces the retired
+"byte-identical at copy time" invariant with a structural one that tolerates the
+copy's *legitimate* edits yet still catches a logic fork.
+
+It is **function-scoped**: it diffs ONLY the bodies of the functions inquisitor
+actually imports —
+  - `resolve_dispatch_dir`, `fixture_sha`, `template_sha` from `_dispatch_paths.py`
+  - `validate_run_id` from `_runid.py`
+— against temper's, parsing each side with `ast` and comparing those named function
+nodes by `ast.dump` (whitespace/comment/line-number insensitive). It does NOT compare
+the whole file, so the inquisitor copy may freely omit temper-only helpers
+(`validate_prefix`, `sanitize_summary`) and inquisitor CI never reddens when temper
+edits a function inquisitor never calls (SP3).
+
+**Referenced module-level constants are in scope too (S2):** a compared function's
+real logic can live in a module constant it references by name — `validate_run_id`'s
+run-id cap is the regex constant `_RUN_ID_RE`, not code in the body. So in addition
+to each function body, this check diffs the module-level single-target `Assign`
+nodes (`NAME = …`) that a compared function *loads* (e.g. `_RUN_ID_RE`). A forked
+constant (widening `{0,31}`→`{0,99}`, dropping the leading-`-` guard) therefore
+registers as drift even though the function body is byte-identical. Scoping stays
+surgical — only constants a compared function references, not every module global
+(so inquisitor's intentional omission of `_PREFIX_RE`, referenced solely by the
+omitted `validate_prefix`, does not redden CI).
+
+**Docstring handling is by structural/AST position, NOT a blanket triple-quote
+regex (S-A):** a function's docstring is stripped before comparison ONLY for the
+sites the inquisitor copy legitimately rewrites — the module docstring (never in the
+compared set: we compare function nodes only) and `template_sha` (whose docstring
+names the hashed template). Every OTHER compared function (`resolve_dispatch_dir`,
+`fixture_sha`, `validate_run_id`) keeps its docstring in the comparison, so a
+logic-altering rewrite of a non-{module,template_sha} docstring still FAILS the
+check — an "all-docstrings" stripper would silently tolerate it.
+
+Exits 0 if the copies are faithful, 1 with a per-drift list otherwise. Stdlib only.
+"""
+from __future__ import annotations
+import ast
+import copy
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# (reference helper, inquisitor copy, the function names inquisitor imports)
+PAIRS = [
+    ("skills/temper/evals/_dispatch_paths.py",
+     "skills/inquisitor/evals/_dispatch_paths.py",
+     ("resolve_dispatch_dir", "fixture_sha", "template_sha")),
+    ("skills/temper/evals/_runid.py",
+     "skills/inquisitor/evals/_runid.py",
+     ("validate_run_id",)),
+]
+
+# Compared functions whose docstring the inquisitor copy legitimately rewrites;
+# their docstring is stripped (by AST position) before comparison. The module-level
+# docstring is likewise rewritten in the copy but is never in the compared set (we
+# compare only the named FunctionDef nodes), so it needs no entry here.
+DOCSTRING_REWRITTEN = {"template_sha"}
+
+
+def _functions(src: str) -> dict:
+    """Map function name -> FunctionDef node for the top-level defs in `src`."""
+    return {n.name: n for n in ast.parse(src).body
+            if isinstance(n, ast.FunctionDef)}
+
+
+def _module_assigns(src: str) -> dict:
+    """Map single-target module-level constant name -> its `Assign` node. Covers
+    only `NAME = …` top-level assignments (the `_RUN_ID_RE = re.compile(...)` shape);
+    tuple/attribute/annotated targets are out of scope (none of the compared
+    helpers reference such)."""
+    out: dict = {}
+    for n in ast.parse(src).body:
+        if isinstance(n, ast.Assign) and len(n.targets) == 1 \
+                and isinstance(n.targets[0], ast.Name):
+            out[n.targets[0].id] = n
+    return out
+
+
+def _referenced_names(node: ast.FunctionDef) -> set:
+    """The set of bare Name ids loaded inside a function body (e.g. `_RUN_ID_RE`).
+    Used to scope the module-constant drift diff to ONLY constants a compared
+    function actually references — not every module global (S2)."""
+    return {sub.id for sub in ast.walk(node)
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load)}
+
+
+def _strip_docstring(node: ast.FunctionDef) -> ast.FunctionDef:
+    """Return a copy of `node` with a leading docstring statement removed by AST
+    position (the first stmt iff it is a bare string Constant Expr) — NOT by a
+    triple-quote regex over the source."""
+    node = copy.deepcopy(node)
+    body = node.body
+    if (body and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)):
+        node.body = body[1:]
+    return node
+
+
+def _dump(node: ast.FunctionDef, strip: bool) -> str:
+    if strip:
+        node = _strip_docstring(node)
+    return ast.dump(node)
+
+
+def compare_sources(ref_src: str, copy_src: str, names) -> list:
+    """Return a list of drift descriptions for the named functions (empty == faithful).
+
+    Besides each function's body, this also diffs the module-level constant
+    `Assign` nodes that the function *references by name* (e.g. `validate_run_id`'s
+    `_RUN_ID_RE`). A compared function's real logic can live in such a constant
+    (the run-id cap regex), so a forked constant referenced by a faithful-looking
+    body must still register as drift (S2). Scoping is surgical: only constants a
+    compared function loads, not every module global."""
+    ref = _functions(ref_src)
+    cp = _functions(copy_src)
+    ref_assigns = _module_assigns(ref_src)
+    cp_assigns = _module_assigns(copy_src)
+    drift = []
+    for name in names:
+        if name not in ref:
+            drift.append(f"{name}: missing from reference (temper) helper")
+            continue
+        if name not in cp:
+            drift.append(f"{name}: missing from inquisitor copy")
+            continue
+        strip = name in DOCSTRING_REWRITTEN
+        if _dump(ref[name], strip) != _dump(cp[name], strip):
+            note = " (docstring-stripped)" if strip else ""
+            drift.append(f"{name}: body diverged from temper{note}")
+        # Diff module-level constants this function references (S2: catch a logic
+        # fork that lives in a referenced constant, not the function body).
+        refd = _referenced_names(ref[name]) | _referenced_names(cp[name])
+        for const in sorted(refd & (set(ref_assigns) | set(cp_assigns))):
+            in_ref, in_cp = const in ref_assigns, const in cp_assigns
+            if in_ref and in_cp:
+                if ast.dump(ref_assigns[const]) != ast.dump(cp_assigns[const]):
+                    drift.append(
+                        f"{name}: referenced module constant {const} diverged "
+                        f"from temper")
+            elif in_ref != in_cp:
+                where = "inquisitor copy" if in_ref else "reference (temper) helper"
+                drift.append(
+                    f"{name}: referenced module constant {const} missing from "
+                    f"{where}")
+    return drift
+
+
+def main() -> int:
+    all_drift = []
+    for ref_rel, copy_rel, names in PAIRS:
+        ref_src = (ROOT / ref_rel).read_text(encoding="utf-8")
+        copy_src = (ROOT / copy_rel).read_text(encoding="utf-8")
+        for d in compare_sources(ref_src, copy_src, names):
+            all_drift.append(f"{copy_rel}: {d}")
+    if all_drift:
+        print("INQUISITOR HELPER DRIFT — the copied helpers diverged from temper:")
+        for d in all_drift:
+            print(f"  {d}")
+        print("\nRe-sync the copied function bodies with "
+              "skills/temper/evals/, or update this check if the divergence is "
+              "intentional. See scripts/check_inquisitor_helper_drift.py docstring.")
+        return 1
+    print("OK — inquisitor's copied helpers match temper for every imported "
+          "function and each module constant they reference (e.g. _RUN_ID_RE); "
+          "module + template_sha docstrings excepted.")
+    return 0
+
+
+def selftest() -> int:
+    """Built-in logic tests, in-memory, against the real temper reference.
+
+    Two negative legs (R4-docstring) pin the structural docstring strip:
+      case-A — a non-docstring body-line fork in resolve_dispatch_dir must be caught;
+      case-B — a reworded NON-{module,template_sha} docstring (fixture_sha's) must be
+               caught (an "all-docstrings" stripper would false-PASS this).
+    A third negative leg (S2) pins the referenced-constant teeth:
+      case-D — a forked module constant `_RUN_ID_RE` (cap {0,31}->{0,99}) referenced
+               by an otherwise byte-identical validate_run_id must be caught.
+    Plus a positive leg (the real clean copy is faithful) and a tolerance leg (a
+    template_sha docstring reword is tolerated)."""
+    ref_rel, copy_rel, names = PAIRS[0]  # _dispatch_paths pair
+    ref_src = (ROOT / ref_rel).read_text(encoding="utf-8")
+    clean_copy = (ROOT / copy_rel).read_text(encoding="utf-8")
+
+    failures = []
+
+    # positive leg — the committed copy is faithful
+    drift = compare_sources(ref_src, clean_copy, names)
+    if drift:
+        failures.append(f"positive: clean copy unexpectedly drifted: {drift}")
+
+    # case-A — fork a non-docstring body line in resolve_dispatch_dir → must FAIL
+    case_a = clean_copy.replace(
+        'f"{user}-crucible-dispatch-{run_id}"',
+        'f"{user}-MUTATED-dispatch-{run_id}"')
+    if case_a == clean_copy:
+        failures.append("case-A: mutation anchor not found (test is vacuous)")
+    drift = compare_sources(ref_src, case_a, names)
+    if not any("resolve_dispatch_dir" in d for d in drift):
+        failures.append(f"case-A: body fork in resolve_dispatch_dir NOT caught: {drift}")
+
+    # case-B — reword fixture_sha's (non-stripped) docstring → must FAIL
+    case_b = clean_copy.replace(
+        '"""S-A: sha256 of canonical JSON of the evals.json fixture record."""',
+        '"""Reworded: hash the canonical fixture record."""')
+    if case_b == clean_copy:
+        failures.append("case-B: docstring anchor not found (test is vacuous)")
+    drift = compare_sources(ref_src, case_b, names)
+    if not any("fixture_sha" in d for d in drift):
+        failures.append(f"case-B: fixture_sha docstring reword NOT caught "
+                        f"(over-strip): {drift}")
+
+    # tolerance leg — rewording template_sha's docstring is tolerated (no drift)
+    case_c = clean_copy.replace(
+        "sha256 of a committed prompt template",
+        "sha256 of an inquisitor prompt template")
+    if case_c == clean_copy:
+        failures.append("tolerance: template_sha docstring anchor not found")
+    drift = compare_sources(ref_src, case_c, names)
+    if drift:
+        failures.append(f"tolerance: template_sha docstring reword should be "
+                        f"tolerated, got drift: {drift}")
+
+    # case-D (S2) — fork the referenced module constant _RUN_ID_RE (widen the cap
+    # {0,31}->{0,99}, a real behavior fork) with a byte-identical validate_run_id
+    # body → must FAIL on the constant, not the body. Uses the _runid pair (PAIRS[1]).
+    runid_ref_rel, runid_copy_rel, runid_names = PAIRS[1]
+    runid_ref_src = (ROOT / runid_ref_rel).read_text(encoding="utf-8")
+    runid_clean_copy = (ROOT / runid_copy_rel).read_text(encoding="utf-8")
+    # sanity: the clean copy is faithful (constant included)
+    drift = compare_sources(runid_ref_src, runid_clean_copy, runid_names)
+    if drift:
+        failures.append(f"case-D positive: clean _runid copy unexpectedly "
+                        f"drifted: {drift}")
+    case_d = runid_clean_copy.replace(
+        r"[A-Za-z0-9_-]{0,31}$", r"[A-Za-z0-9_-]{0,99}$")
+    if case_d == runid_clean_copy:
+        failures.append("case-D: _RUN_ID_RE cap anchor not found (test is vacuous)")
+    drift = compare_sources(runid_ref_src, case_d, runid_names)
+    if not any("_RUN_ID_RE" in d for d in drift):
+        failures.append(f"case-D: forked _RUN_ID_RE constant NOT caught "
+                        f"(referenced-constant blindness): {drift}")
+
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("SELFTEST OK — function-scoped comparison catches body forks (case-A), "
+          "non-{module,template_sha} docstring rewrites (case-B), and a forked "
+          "referenced module constant _RUN_ID_RE (case-D); tolerates the "
+          "template_sha docstring reword.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/check_inquisitor_secondary_count.py
+++ b/scripts/check_inquisitor_secondary_count.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Static guard for the inquisitor secondary-pool arithmetic (#424, S2).
+
+Invocation (from repo root):
+    python3 scripts/check_inquisitor_secondary_count.py            # check the tree
+    python3 scripts/check_inquisitor_secondary_count.py --selftest # built-in logic tests
+
+`score` derives `graded_expectations` from the observed judge records at runtime
+(correct — it cannot know the canonical pool without coupling to evals.json). But
+the README, a unit test, and `_render_results`'s label all assert the documented
+value **26 = total evals.json expectations (27) minus the single fixture-1 #8
+exclusion**. NOTHING in code/CI guards that this documented 26 stays consistent
+with evals.json: if someone adds/removes an expectation, the "26" silently goes
+stale. This static check makes the arithmetic machine-verifiable at the check_*.py
+layer (NOT inside `score`'s runtime, which would ripple through every score test).
+
+It asserts:
+  - evals.json's total expectation count across all fixtures == 27 (10+9+8), and
+    fixture id 1 carries 10 expectations (so the single #8 exclusion is well-defined);
+  - the README's secondary-pool description ties `graded_expectations` to 26; and
+  - 26 == total − 1 (the single fixture-1 #8 exclusion).
+
+If evals.json expectation counts change, this FAILS — forcing README / the
+documented exclusion count to be updated. Stdlib only. Exit 0 clean / 1 on drift.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+EVALS_JSON = ROOT / "skills/inquisitor/evals/evals.json"
+README = ROOT / "skills/inquisitor/evals/README.md"
+RUN_EVALS = ROOT / "skills/inquisitor/evals/run_evals.py"
+
+EXPECTED_TOTAL = 27          # 10 + 9 + 8 across the three fixtures
+EXPECTED_FIXTURE1 = 10       # fixture id 1's expectation count (the #8 lives here)
+DOCUMENTED_SECONDARY = 26    # total − 1 (the single fixture-1 #8 exclusion)
+
+
+def expectation_counts(evals: dict) -> dict:
+    """Map fixture id -> number of expectations for that fixture."""
+    return {e["id"]: len(e.get("expectations", [])) for e in evals["evals"]}
+
+
+def run_evals_pins_contracted_pool(run_evals_text: str) -> bool:
+    """Anchor: run_evals.py's score reconciles against the same documented pool via
+    a module-level `_CONTRACTED_SECONDARY_POOL = 26`. S-1 single-sources the two 26s
+    (this guard's DOCUMENTED_SECONDARY and score's reconciliation anchor) so they
+    cannot drift silently. Static source match — no runtime import of score."""
+    return bool(re.search(
+        r"_CONTRACTED_SECONDARY_POOL\s*=\s*%d\b" % DOCUMENTED_SECONDARY,
+        run_evals_text))
+
+
+def readme_ties_secondary_to_26(readme_text: str) -> bool:
+    """Anchor: a README line tying the graded secondary expectations to 26 (the
+    secondary-pool description), NOT any incidental '26' elsewhere. The committed
+    wording is 'the judge grades **26** secondary expectations (10−1 + 9 + 8)'."""
+    return bool(re.search(
+        r"grades\s+\*{0,2}26\*{0,2}\s+secondary expectations", readme_text))
+
+
+def check(counts: dict, readme_text: str, run_evals_text: str = "") -> list:
+    """Return a list of failure descriptions (empty == consistent).
+
+    `run_evals_text` is the run_evals.py source; when supplied, assert score's
+    `_CONTRACTED_SECONDARY_POOL` matches DOCUMENTED_SECONDARY (S-1 single-sourcing).
+    Defaults to "" so the in-memory count/README legs can be exercised standalone."""
+    failures = []
+    total = sum(counts.values())
+    if total != EXPECTED_TOTAL:
+        failures.append(
+            f"evals.json total expectations = {total}, expected {EXPECTED_TOTAL} "
+            f"(per-fixture: {counts}); the documented secondary pool "
+            f"({DOCUMENTED_SECONDARY}) is now stale — update README and this guard.")
+    if counts.get(1) != EXPECTED_FIXTURE1:
+        failures.append(
+            f"evals.json fixture id 1 has {counts.get(1)} expectations, expected "
+            f"{EXPECTED_FIXTURE1}; the fixture-1 #8 exclusion is no longer "
+            f"well-defined — update README and this guard.")
+    if not readme_ties_secondary_to_26(readme_text):
+        failures.append(
+            f"README.md no longer ties graded secondary expectations to "
+            f"{DOCUMENTED_SECONDARY} (expected a line like 'the judge grades "
+            f"**26** secondary expectations'); the documented arithmetic is "
+            f"unanchored.")
+    if DOCUMENTED_SECONDARY != EXPECTED_TOTAL - 1:
+        failures.append(
+            f"documented secondary {DOCUMENTED_SECONDARY} != total "
+            f"{EXPECTED_TOTAL} − 1 (the single fixture-1 #8 exclusion).")
+    if run_evals_text and not run_evals_pins_contracted_pool(run_evals_text):
+        failures.append(
+            f"run_evals.py no longer pins `_CONTRACTED_SECONDARY_POOL = "
+            f"{DOCUMENTED_SECONDARY}` (S-1's reconciliation anchor); score's "
+            f"diagnostic 26 has drifted from this guard's DOCUMENTED_SECONDARY.")
+    return failures
+
+
+def main() -> int:
+    evals = json.loads(EVALS_JSON.read_text(encoding="utf-8"))
+    counts = expectation_counts(evals)
+    readme_text = README.read_text(encoding="utf-8")
+    run_evals_text = RUN_EVALS.read_text(encoding="utf-8")
+    failures = check(counts, readme_text, run_evals_text)
+    if failures:
+        print("INQUISITOR SECONDARY-COUNT DRIFT — the documented 26 is "
+              "inconsistent with evals.json / README:")
+        for f in failures:
+            print(f"  {f}")
+        print("\nIf evals.json expectation counts changed, update the documented "
+              "secondary pool (README.md + score's label) and the constants in "
+              "scripts/check_inquisitor_secondary_count.py.")
+        return 1
+    print(f"OK — evals.json totals {EXPECTED_TOTAL} expectations "
+          f"(fixture 1 = {EXPECTED_FIXTURE1}); README ties graded secondary to "
+          f"{DOCUMENTED_SECONDARY} == {EXPECTED_TOTAL} − 1 (the fixture-1 #8 "
+          f"exclusion); run_evals.py pins _CONTRACTED_SECONDARY_POOL = "
+          f"{DOCUMENTED_SECONDARY}.")
+    return 0
+
+
+def selftest() -> int:
+    """Built-in logic tests (in-memory) for the count + README anchor checks."""
+    good_counts = {1: 10, 2: 9, 3: 8}                       # total 27
+    good_readme = ("...the judge grades **26** secondary expectations "
+                   "(10−1 + 9 + 8) and ...")
+    good_run_evals = "_CONTRACTED_SECONDARY_POOL = 26\n"
+    failures = []
+
+    # positive leg — current evals.json/README/run_evals shape passes
+    res = check(good_counts, good_readme, good_run_evals)
+    if res:
+        failures.append(f"positive: clean shape unexpectedly failed: {res}")
+
+    # negative leg A — a different expectation count (an added expectation) FAILS
+    res = check({1: 10, 2: 9, 3: 9}, good_readme)           # total 28
+    if not res:
+        failures.append("negative-A: a changed expectation count was NOT caught")
+
+    # negative leg B — README missing the 26 anchor FAILS
+    res = check(good_counts, "...the judge grades the secondary expectations...")
+    if not res:
+        failures.append("negative-B: README missing the 26 anchor was NOT caught")
+
+    # robustness — an incidental '26' elsewhere must NOT satisfy the anchor
+    if readme_ties_secondary_to_26("we filed issue #426 and graded 5 expectations"):
+        failures.append("robustness: an incidental 26 wrongly satisfied the anchor")
+
+    # negative leg C (S-1) — run_evals.py missing/drifted _CONTRACTED_SECONDARY_POOL FAILS
+    res = check(good_counts, good_readme, "_CONTRACTED_SECONDARY_POOL = 25\n")
+    if not res:
+        failures.append("negative-C: drifted _CONTRACTED_SECONDARY_POOL was NOT caught")
+
+    # the real committed tree must pass too (catches anchor regex vs real wording)
+    real_counts = expectation_counts(
+        json.loads(EVALS_JSON.read_text(encoding="utf-8")))
+    real_res = check(real_counts, README.read_text(encoding="utf-8"),
+                     RUN_EVALS.read_text(encoding="utf-8"))
+    if real_res:
+        failures.append(f"real-tree: committed evals.json/README/run_evals failed: "
+                        f"{real_res}")
+
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("SELFTEST OK — positive leg passes; a changed expectation count, a "
+          "README missing the 26 anchor, and a drifted _CONTRACTED_SECONDARY_POOL "
+          "all FAIL; an incidental 26 is rejected; and the real committed tree "
+          "passes.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/check_judge_prompt_contract.py
+++ b/scripts/check_judge_prompt_contract.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Judge-prompt contract check for the inquisitor eval harness (#424).
+
+Invocation (from repo root):
+    python3 scripts/check_judge_prompt_contract.py            # check committed file
+    python3 scripts/check_judge_prompt_contract.py --selftest # built-in logic tests
+
+Asserts `skills/inquisitor/evals/judge-prompt.md` encodes the reconciled
+**tagged-union** judge contract (S-FIND-2) AND instructs the **per-item
+verdict-record output schema** (S2):
+
+  REQUIRED — the prompt MUST reference the `tag` field and the `primary`/`secondary`
+    tag values, AND instruct the per-item output record by naming the `id`, `tag`,
+    and `verdict` fields as quoted JSON output keys (not merely mention `tag`).
+  FORBIDDEN — the prompt MUST NOT reproduce the gated design's stale per-expectation
+    framing (`per-expectation`, or the `(arm output, fixture expectations)` phrasing
+    from design L272), which graded `(arm output, fixture expectations)` per
+    expectation instead of grading the tagged union per item.
+
+Why this exists separately from the unit tests: the unit tests feed `score`
+*synthetic* tagged-union verdict files (tests 3/3b/3c), so they exercise the
+*parser* but structurally cannot catch a committed judge prompt that grades
+per-expectation OR omits the `id`+`tag`+`verdict` record `score` actually parses.
+This static check pins both the input contract and the output schema in CI.
+
+Stdlib only. Exit 0 clean / 1 on violation.
+"""
+from __future__ import annotations
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+JUDGE_PROMPT = ROOT / "skills/inquisitor/evals/judge-prompt.md"
+
+# Bare-token references to the tagged-union field + values, plus the quoted JSON
+# output keys that pin the per-item verdict record (S2 — not merely a `tag` mention),
+# plus the load-bearing non-comparative / per-item discipline anchors (S2-followup).
+#
+# The non-comparative anchors pin judge-prompt.md L11-12 verbatim ("You are grading
+# ONE arm's review output … you are NOT comparing one arm's output to another"). A
+# comparative-grading rewrite — one that keeps the tagged-union record schema but
+# grades "which arm is better / ranks the arms" — silently turns WITH−WITHOUT into a
+# verbosity/comparison artifact biased toward the higher-output arm, defeating the
+# whole control. Such a rewrite would necessarily drop these sentences → the check
+# fails. Anchored as REQUIRED (collision-free) rather than FORBIDDEN: the literal
+# "which arm is better" appears in the explanatory L7 HTML comment, so it must NOT be
+# added to FORBIDDEN (it would false-FAIL the committed file). "NOT comparing one arm"
+# is contiguous in the committed prompt and absent from that comment.
+REQUIRED = ("tag", "primary", "secondary", '"id"', '"tag"', '"verdict"',
+            "grading ONE arm", "NOT comparing one arm")
+# The design's retired per-expectation framing (design L272 / L278-284).
+FORBIDDEN = ("per-expectation", "arm output, fixture expectations")
+
+
+def violations(text: str) -> list:
+    """Return contract-violation strings for `text` (empty == compliant)."""
+    out = []
+    for tok in REQUIRED:
+        if tok not in text:
+            out.append(f"missing required token {tok!r}")
+    for tok in FORBIDDEN:
+        if tok in text:
+            out.append(f"contains forbidden stale per-expectation phrasing {tok!r}")
+    return out
+
+
+def main() -> int:
+    text = JUDGE_PROMPT.read_text(encoding="utf-8")
+    errs = violations(text)
+    if errs:
+        rel = JUDGE_PROMPT.relative_to(ROOT)
+        print(f"JUDGE-PROMPT CONTRACT VIOLATIONS in {rel}:")
+        for e in errs:
+            print(f"  {e}")
+        print("\nThe judge prompt must grade the tagged-union item list per item "
+              "(referencing `tag` / `primary` / `secondary`) and instruct the "
+              'per-item `{"id","tag","verdict"}` output record — not the design\'s '
+              "retired per-expectation framing.")
+        return 1
+    print("OK — judge-prompt.md encodes the tagged-union contract + the per-item "
+          "id/tag/verdict record schema, with no stale per-expectation phrasing.")
+    return 0
+
+
+def selftest() -> int:
+    """Built-in logic tests (in-memory) for the contract scan."""
+    good = (
+        "You are grading ONE arm's review output. You are NOT comparing one arm's "
+        "output to another.\n"
+        "Grade each item by its `tag` (`primary` or `secondary`).\n"
+        "For each item: is THIS issue identified? PASS/FAIL.\n"
+        'Emit one JSON object per item: {"id": "f1-b1", "tag": "primary", '
+        '"verdict": "PASS"}\n'
+    )
+    bad_per_exp = good + (
+        "Grade per-expectation against (arm output, fixture expectations).\n")
+    bad_no_tag = (
+        "You are grading ONE arm's review output. You are NOT comparing one arm's "
+        "output to another.\n"
+        'Emit one JSON object per item: {"id": "x", "verdict": "PASS"}\n')
+    bad_no_record = (
+        "You are grading ONE arm's review output. You are NOT comparing one arm's "
+        "output to another.\n"
+        "Grade each item by its `tag` (`primary` or `secondary`). Output PASS "
+        "or FAIL.\n")
+    # S2-followup: a comparative-grading rewrite that keeps the tagged-union record
+    # schema (all REQUIRED tag/record tokens) but DROPS the non-comparative anchor
+    # and grades "which arm found more / rank the arms" must now FAIL — without the
+    # anchor it would pass CI green while turning WITH−WITHOUT into a verbosity
+    # artifact. (Note: it includes the L7-comment substring "which arm is better" to
+    # prove that string is NOT forbidden — only the REQUIRED anchor catches this.)
+    bad_comparative = (
+        "Grade each item by its `tag` (`primary` or `secondary`).\n"
+        "Compare the arms and rank which found more bugs; decide which arm is "
+        "better.\n"
+        'Emit one JSON object per item: {"id": "f1-b1", "tag": "primary", '
+        '"verdict": "PASS"}\n'
+    )
+    cases = [
+        (good, False, "reconciled tagged-union + per-item record + anchor passes"),
+        (bad_per_exp, True, "stale per-expectation phrasing fails"),
+        (bad_no_tag, True, "missing tag/primary/secondary references fails"),
+        (bad_no_record, True,
+         "mentions tag but omits the id+verdict per-item record fails (S2)"),
+        (bad_comparative, True,
+         "comparative rewrite dropping the non-comparative anchor fails (S2-followup)"),
+    ]
+    failures = []
+    for text, expect_fail, reason in cases:
+        got = bool(violations(text))
+        if got != expect_fail:
+            failures.append(f"  expected fail={expect_fail} ({reason}), got={got}")
+    if failures:
+        print("SELFTEST FAILED:")
+        print("\n".join(failures))
+        return 1
+    print("SELFTEST OK — contract check fires on stale phrasing, missing "
+          "tag-references, a missing per-item id+verdict record, and a comparative "
+          "rewrite that drops the non-comparative anchor; the reconciled form passes.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -69,6 +69,19 @@ run python3 scripts/check_ledger_write_path.py
 # --- #366 red-team <-> quality-gate receipt contract ---
 run python3 scripts/check_rt_receipt_contract.py
 
+# --- Inquisitor eval harness (#424) ---
+run python3 scripts/check_inquisitor_helper_drift.py --selftest
+run python3 scripts/check_inquisitor_helper_drift.py
+run python3 scripts/check_judge_prompt_contract.py --selftest
+run python3 scripts/check_judge_prompt_contract.py
+run python3 scripts/check_ground_truth_provenance.py --selftest
+run python3 scripts/check_ground_truth_provenance.py
+run python3 scripts/check_inquisitor_secondary_count.py --selftest
+run python3 scripts/check_inquisitor_secondary_count.py
+run python3 skills/inquisitor/evals/test_run_evals_stage.py
+run python3 skills/inquisitor/evals/test_run_evals_score.py
+run python3 skills/inquisitor/evals/test_runid.py
+
 # --- Catalog unit suite ---
 run python3 scripts/test_catalog.py
 

--- a/skills/inquisitor/evals/README.md
+++ b/skills/inquisitor/evals/README.md
@@ -1,0 +1,155 @@
+# Inquisitor fan-out eval harness (#424, Phase 1)
+
+A bespoke **three-arm** harness that fires inquisitor's real 5-way fan-out
+**structure** over the existing `evals.json` fixtures with the **execution half
+stubbed** (real dimension lenses + test *reasoning*; tests are *described*, not
+run), and records a true **identification-breadth** delta. It mirrors temper's
+`stage` / `score` split — Python owns deterministic mechanics; the live
+orchestrator agent owns the two things Python can't do (dispatch + judgement).
+
+Implements the gated design
+`docs/plans/2026-06-13-inquisitor-fanout-eval-harness-design.md`. **Phase 1 only:**
+identification breadth; the execution axis is unmeasured (a non-positive delta is
+*inconclusive*, not condemning — see the design's go/no-go).
+
+## The three arms
+
+| Arm | Composition | Measures |
+|-----|-------------|----------|
+| **WITH** | 5 parallel dimension subagents (`inquisitor-dimension-prompt-eval.md`, execution stubbed) → a 6th aggregation subagent (`aggregation-prompt.md`) | the methodology with execution stubbed |
+| **MID** | ONE agent given the **same WITH per-dimension procedural shell** (relentless-hunter persona, `## Your Job` steps, NOT-do guard, Report Format) but with all 5 lenses applied sequentially in one pass + the same aggregation framing | holds the procedural scaffold + lenses + aggregation constant with WITH, varying ONLY the fan-out delivery |
+| **WITHOUT** | ONE agent, the bare neutral prompt | the unstructured baseline |
+
+`WITH − WITHOUT` is the **primary** (total methodology) delta. Because MID carries
+the **same per-dimension procedural scaffold** as WITH (reused from
+`inquisitor-dimension-prompt-eval.md`, not a bare lens list), `WITH − MID` isolates
+**only the fan-out delivery mechanism** — 5 parallel fresh subagents vs 1 sequential
+agent — holding the lens content and the procedural methodology constant.
+`MID − WITHOUT` is the combined dimension-scaffolding + procedure component.
+
+## Invocation (module form)
+
+Run from the repo root (the package uses relative imports, so `-m` is required):
+
+```
+python3 -m skills.inquisitor.evals.run_evals stage <run-id> [--trials N] [--fixture ID]
+python3 -m skills.inquisitor.evals.run_evals score <run-id> [--allow-incomplete]
+```
+
+`--trials` defaults to **5** (the decision-run count; smoke runs may use 1–3; odd
+counts recommended for the per-bug majority). `stage` prints the dispatch dir path.
+
+## Workflow
+
+1. **`stage`** renders, per `fixture × trial`, the three-arm dispatch files —
+   **WITH = 6** (5 dimension dispatches + 1 aggregation dispatch), **MID = 1**,
+   **WITHOUT = 1** — plus, **once**, the two shared deterministic prompt files
+   `aggregation-prompt.md` and `judge-prompt.md` (byte-identical across all
+   arms/cells; hashed in `stage-manifest.json`). It writes `stage-manifest.json`
+   enumerating every cell.
+
+2. **collect** (this document — the live orchestrator runs it; there is no
+   `collect` subcommand). For each cell, read the manifest and dispatch the staged
+   prompts **verbatim** — you author no framing, you paste staged files:
+   - **WITH:** dispatch the 5 `*-with-dim*.md` dimension subagents **in parallel**,
+     then dispatch the `*-with-agg.md` aggregation subagent fed the 5 dimension
+     reports through the staged `aggregation-prompt.md`; it emits the one aggregated
+     WITH report.
+   - **MID:** dispatch the single `*-mid.md` all-lenses subagent.
+   - **WITHOUT:** dispatch the single `*-without.md` neutral subagent.
+   - **judge:** for each `(fixture, arm, trial)`, dispatch one judge subagent with
+     the staged `judge-prompt.md` **verbatim** + that arm's output + the cell's
+     tagged item list (below). Write each judge's output to the cell's
+     `result_file` from the manifest using the `DISPATCH_STATUS: OK\n\n<body>`
+     sentinel. Write `.collect-status` when every cell is done.
+
+3. **`score`** reads `stage-manifest.json` + the judge verdict files and writes
+   `skills/inquisitor/evals/last_run.json` + `results.md` (both git-ignored). It
+   **refuses** to run without `.collect-status` unless `--allow-incomplete` (which
+   stamps `complete: false` — smoke/debug only; the go/no-go must read a
+   `complete: true` run).
+
+## The judge contract (what the live judge grades, and what it emits)
+
+The judge grades a single **tagged-union item list** per `(fixture, arm, trial)`,
+**strictly per item** — for each item it answers *"Is THIS specific issue
+identified in the arm's output? PASS / FAIL"*, never "which arm is better" (the
+verbosity-bias control). The list is the union of two pools, each item carrying a
+`tag`:
+
+- **`primary`** — the K skill-independent ground-truth bugs from
+  `ground-truth-bugs.json` (authored blind; the PRIMARY graded pool). Each
+  primary item's `id` is its ground-truth `bug_id` (e.g. `f1-b1`).
+- **`secondary`** — the dimension-bucketed `evals.json` expectations (a SECONDARY
+  diagnostic pool only). Each secondary item's `id` is that expectation's
+  index/key.
+
+The single judge dispatch grades the whole tagged list — there is **no** second
+judge pass; `score` then **partitions** the per-item verdicts by `tag` (`primary`
+→ `graded_bugs` + the paired `deltas`; `secondary` → the `secondary_diagnostic`
+block).
+
+**Secondary-pool exclusion (collect-time):** drop **fixture-1 expectation #8** (the
+dimension-counting, treatment-aligned expectation) from the secondary item list, so
+the judge grades **26** secondary expectations (10−1 + 9 + 8) and
+`secondary_diagnostic.graded_expectations == 26`, not 27.
+
+**Per-item verdict-record output schema** — the judge emits **one JSON object per
+graded item**, one per line, with exactly these fields (this is the exact format
+`score` parses, so the live judge output and the parser cannot drift):
+
+```
+{"id": "f1-b1", "tag": "primary", "verdict": "PASS"}
+{"id": "expectation-3", "tag": "secondary", "verdict": "FAIL"}
+```
+
+A `primary` item's `id` is its ground-truth `bug_id`; a `secondary` item's `id` is
+its expectation index/key. A missing or malformed record for an item is counted as
+`FAIL` and tallied into `malformed_verdicts`.
+
+`scripts/check_judge_prompt_contract.py` pins this contract in CI (the `tag` /
+`primary` / `secondary` references **and** the `id`+`tag`+`verdict` output record);
+the unit tests feed only *synthetic* verdict files, so they cannot catch a judge
+prompt that grades the wrong shape.
+
+## `last_run.json` (what `score` computes)
+
+Per-arm pass rates (`with`/`mid`/`without`, **majority-collapsed** per bug across
+trials — strict majority PASS, an even-N tie → FAIL), the three paired `deltas`
+(each carrying `paired` = the **mean of the per-trial paired deltas**, `trial_spread`
+min–max band, `mde_heuristic`, and — for `with_without`/`with_mid` — `beyond_spread`),
+`malformed_verdicts` per arm, `per_fixture` rates, `off_axis_diagnostic` (per-arm
+rates over only the `off_axis: true` primary bugs — makes the design's T1 bias-control
+machine-visible), and `secondary_diagnostic`.
+
+`deltas` carries a `_note`: **`paired` is the mean of per-trial deltas and does NOT
+equal `rate_with − rate_without`** (the per-arm rate is the majority-collapsed value,
+a different collapse rule). `beyond_spread` is forced `false` for `trials < 3` (a 1–2
+trial band trivially excludes zero).
+
+`mde_heuristic` = `1.96 × sample-stdev(per-trial paired deltas, ddof=1) / sqrt(trials)`
+(null for `trials < 2`) — an explicitly **no-α** noise-floor figure, not a
+significance test.
+
+## Files
+
+- `run_evals.py` — `stage` + `score` (no `collect`).
+- `inquisitor-dimension-prompt-eval.md` — the WITH dimension template (the real
+  lenses, execution stubbed) **and the single source of lens content**: its
+  `## Dimension Reference` blocks feed both the WITH per-dimension renders and the
+  MID all-lenses render (no lens text is duplicated).
+- `aggregation-prompt.md`, `judge-prompt.md` — the two shared staged prompts.
+- `ground-truth-bugs.json` — the blind-authored primary bug list, with
+  `ground-truth-bugs.provenance.md` (the exact blind input) +
+  `scripts/check_ground_truth_provenance.py` proving the blind boundary held.
+- `_dispatch_paths.py`, `_runid.py` — copied from temper. The drift check
+  `scripts/check_inquisitor_helper_drift.py` is **function-scoped** to the functions
+  inquisitor imports (`resolve_dispatch_dir` / `fixture_sha` / `template_sha` /
+  `validate_run_id`), so `_runid.py` may omit temper's unused `sanitize_summary` /
+  `validate_prefix` without reddening CI.
+- `test_run_evals_stage.py`, `test_run_evals_score.py`, `test_runid.py` — the gating
+  unit tests (stdlib `unittest`, run by `scripts/run_tests.sh`).
+
+**Deferred (post-merge, not in CI):** the live integration run that produces the
+actual delta (dispatches live Opus agents), recording it in `docs/evals.md`, and the
+Phase-2 go/no-go log on #424.

--- a/skills/inquisitor/evals/_dispatch_paths.py
+++ b/skills/inquisitor/evals/_dispatch_paths.py
@@ -1,0 +1,33 @@
+# Copied from skills/temper/evals/_dispatch_paths.py (#424). The bodies of the
+# functions inquisitor imports (resolve_dispatch_dir / fixture_sha / template_sha)
+# stay logic-identical to temper's — enforced by scripts/check_inquisitor_helper_drift.py
+# (function-scoped AST comparison). Only the module + template_sha docstrings are
+# rewritten to the inquisitor context (the drift check strips those two by AST position).
+"""Dispatch-dir path resolution + fixture hashing for the inquisitor fan-out eval
+harness (#424). Mirrors temper's helper of the same name."""
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+def resolve_dispatch_dir(run_id: str) -> Path:
+    """Resolve XDG_RUNTIME_DIR or /tmp + USER or UID namespacing.
+
+    M-α: USER may be unset in container environments.
+    """
+    base = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+    user = os.environ.get("USER") or str(os.getuid())
+    return Path(base) / f"{user}-crucible-dispatch-{run_id}"
+
+
+def fixture_sha(fixture_record: dict) -> str:
+    """S-A: sha256 of canonical JSON of the evals.json fixture record."""
+    canonical = json.dumps(fixture_record, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def template_sha(template_path: Path) -> str:
+    """sha256 of a committed prompt template (e.g. inquisitor-dimension-prompt-eval.md)
+    at stage time, recorded in the manifest so byte-identity invariants are checkable."""
+    return hashlib.sha256(template_path.read_bytes()).hexdigest()

--- a/skills/inquisitor/evals/_runid.py
+++ b/skills/inquisitor/evals/_runid.py
@@ -1,0 +1,21 @@
+# Copied from skills/temper/evals/_runid.py (#424). Inquisitor imports ONLY
+# validate_run_id; temper's calibrate-only helpers (sanitize_summary, validate_prefix)
+# are intentionally omitted — scripts/check_inquisitor_helper_drift.py is function-scoped
+# to the functions inquisitor imports, so dropping the unused helpers does not redden CI
+# (SP3). validate_run_id's body + docstring stay logic-identical to temper's.
+"""Run-id validation utility for the inquisitor fan-out eval harness (#424). I-9
+enforcement; mirrors temper's helper of the same name."""
+import re
+
+# 2P-4: first char must NOT be `-` (else run-id parses as a CLI flag downstream).
+# Subsequent chars may include `-`.
+# M-R7-1: leading underscore is technically legal; treated equivalent to alphanumeric for path-traversal safety (`_foo` resolves identically to `foo` w.r.t. directory escape).
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$")
+
+
+def validate_run_id(run_id: str) -> None:
+    """Raise ValueError if run-id violates I-9."""
+    if not _RUN_ID_RE.fullmatch(run_id):
+        raise ValueError(
+            f"invalid run-id {run_id!r}: must match {_RUN_ID_RE.pattern}"
+        )

--- a/skills/inquisitor/evals/aggregation-prompt.md
+++ b/skills/inquisitor/evals/aggregation-prompt.md
@@ -1,0 +1,26 @@
+<!-- DISPATCH: disk-mediated | Staged once by run_evals.py and shared BYTE-IDENTICALLY
+     by the WITH 6th aggregation subagent and the MID single agent (#424). Its
+     byte-identity across both arms is the load-bearing confound control (design T3):
+     do not fork per-arm copies. -->
+
+# Inquisitor Aggregation Prompt
+
+You are given a set of cross-component bug findings produced across the five
+inquisitor dimensions — Wiring, Integration, Edge Cases, State & Lifecycle, and
+Regression. Your job is to synthesize them into ONE consolidated report.
+
+1. **Merge** the findings into a single deduplicated list of distinct
+   cross-component issues. Collapse near-duplicate facets of the same underlying
+   bug into one entry (e.g. two findings that are different faces of "this code
+   assumes integer ids" are one issue).
+
+2. For each distinct issue, state:
+   - **Issue:** what breaks at runtime, and which components interact to cause it.
+   - **Dimension(s):** which lens(es) surfaced it.
+   - **Fix or test:** a specific proposed fix, or the test that would expose it.
+
+3. Do NOT invent issues that none of the dimension findings support. Do NOT drop a
+   real finding just to shorten the list. Do NOT execute any code — no runner is
+   available in this eval context.
+
+Report the consolidated issue list and nothing else.

--- a/skills/inquisitor/evals/ground-truth-bugs.json
+++ b/skills/inquisitor/evals/ground-truth-bugs.json
@@ -1,0 +1,39 @@
+{
+  "_provenance": "Authored BLIND from the raw fixture diffs + factual codebase context only (design T1 / D4 / S4). The evals.json expected_output/expectations prose was withheld from the authoring subagent. The exact input fed is committed at ground-truth-bugs.provenance.md and scripts/check_ground_truth_provenance.py asserts that file leaks none of the evals.json expectation strings. off_axis=true marks defects the 5 inquisitor lenses (Wiring/Integration/Edge Cases/State & Lifecycle/Regression) do NOT target, so the WITHOUT arm gets credit for off-axis finds.",
+  "fixtures": [
+    {
+      "id": 1,
+      "bugs": [
+        { "bug_id": "f1-b1", "desc": "notifier.ts sendNotification writes sentAt: Date.now() (an epoch-ms number) into the notifications.sent_at TIMESTAMP column — a data-type/persistence mismatch (also the field is named sentAt, not sent_at).", "off_axis": true },
+        { "bug_id": "f1-b2", "desc": "scheduler.ts keeps scheduled jobs only in an in-process Map, so all pending notifications are silently lost on server restart or crash — no persistence.", "off_axis": false },
+        { "bug_id": "f1-b3", "desc": "notifications.ts /schedule computes delay = new Date(scheduledAt).getTime() - Date.now() and passes negative/NaN values straight into setTimeout, so a past or malformed scheduledAt fires immediately (or never) with no validation.", "off_axis": false },
+        { "bug_id": "f1-b4", "desc": "notifications.ts route calls crypto.randomUUID() with no import of node:crypto, so the handler throws a ReferenceError at request time.", "off_axis": false },
+        { "bug_id": "f1-b5", "desc": "notifier.ts performs fetch(payload.webhookUrl) — an unvalidated outbound POST to a caller-supplied URL — an SSRF / open webhook-relay security hole.", "off_axis": true },
+        { "bug_id": "f1-b6", "desc": "notifier.ts never checks fetch response.ok and has no error handling, so a non-2xx webhook or thrown fetch rejects inside the unawaited setTimeout callback as an unhandled promise rejection while the notifications row is still recorded.", "off_axis": true },
+        { "bug_id": "f1-b7", "desc": "app.ts wires no initialization for NotificationScheduler and routes/notifications.ts constructs its own instance, so cancel cannot reach a job scheduled by another instance and pending timers are never disposed on shutdown.", "off_axis": false }
+      ]
+    },
+    {
+      "id": 2,
+      "bugs": [
+        { "bug_id": "f2-b1", "desc": "rbac.ts calls db.users.findById(userId).select('role') and reads userRole.role, but findById returns a row (not a chainable builder), so .select is not a function or role is read off the wrong object.", "off_axis": false },
+        { "bug_id": "f2-b2", "desc": "The migration adds role with DEFAULT 'viewer' but no route grants viewers access and there is no path to assign admin/editor, so after deploy every existing user is locked out of the newly-protected mutating routes.", "off_axis": false },
+        { "bug_id": "f2-b3", "desc": "rbac.ts reads req.user?.id and sets req.userRole, but the Express Request type declares neither a role-aware user nor a userRole property (no module augmentation) — a TypeScript compile error.", "off_axis": false },
+        { "bug_id": "f2-b4", "desc": "Existing tests mock authMiddleware to set req.user as {id,email} with no DB role row, so requireRole's find('role') returns nothing and the now-403'd requests break previously-passing admin/content tests.", "off_axis": false },
+        { "bug_id": "f2-b5", "desc": "The role column is a bare VARCHAR(20) with no CHECK/enum constraint, so a typo or injected role value is stored and silently fails the includes() check — weak role validation.", "off_axis": true },
+        { "bug_id": "f2-b6", "desc": "rbac.ts has no try/catch around db.users.findById, so a transient DB error throws an unhandled rejection and the request fails unpredictably instead of returning a 500.", "off_axis": true }
+      ]
+    },
+    {
+      "id": 3,
+      "bugs": [
+        { "bug_id": "f3-b1", "desc": "paginate.ts assumes integer ids (parseInt(cursor), where id > cursor) but orders.ts paginates the UUID-keyed orders table, so parseInt yields NaN and the cursor WHERE clause returns wrong rows.", "off_axis": true },
+        { "bug_id": "f3-b2", "desc": "users.ts and orders.ts now return { data, nextCursor } instead of a flat array, breaking the frontend and existing integration tests that assert res.body is an array.", "off_axis": false },
+        { "bug_id": "f3-b3", "desc": "parsePaginationParams uses parseInt(String(query.limit)) || 20 so limit=0 silently becomes 20, and a malformed cursor passes String() into parseInt producing NaN in the SQL comparison — unvalidated pagination inputs.", "off_axis": true },
+        { "bug_id": "f3-b4", "desc": "paginate orders by id asc, but the orders table id is a non-numeric UUID, so Postgres orders it lexicographically and keyset pages come back in an unstable/incorrect order.", "off_axis": true },
+        { "bug_id": "f3-b5", "desc": "nextCursor is derived from data[data.length-1].id assuming a monotonic integer key; on the UUID orders table this can skip or duplicate rows across pages — a page-stability facet of the integer-id assumption.", "off_axis": true },
+        { "bug_id": "f3-b6", "desc": "tests/utils/paginate.test.ts exercises the helper against in-memory SQLite with integer ids while production orders use Postgres UUIDs, giving false confidence that pagination works for orders.", "off_axis": false }
+      ]
+    }
+  ]
+}

--- a/skills/inquisitor/evals/ground-truth-bugs.provenance.md
+++ b/skills/inquisitor/evals/ground-truth-bugs.provenance.md
@@ -1,0 +1,280 @@
+<!-- AUDIT ARTIFACT (#424, S4). The EXACT text fed to the blind ground-truth
+authoring subagent: the diff blocks + factual existing-codebase context extracted
+from each fixture's `prompt` field, with the skill-naming opener ("Run the
+inquisitor against...") neutralized. The evals.json `expected_output` and
+`expectations` fields were WITHHELD from the subagent — they live in separate JSON
+fields and appear nowhere below. scripts/check_ground_truth_provenance.py asserts
+this file contains NONE of those expectation strings, proving the blind boundary
+held. Do not edit by hand to match the bug list; this records what was actually fed. -->
+
+# Ground-truth blind-authoring provenance (#424)
+
+This is the verbatim input handed to the blind subagent that authored
+`ground-truth-bugs.json`. Expectation prose was never shown to it.
+
+
+## Fixture 1 — blind input
+
+Feature under review: a new 'Scheduled Notifications' feature. The feature adds scheduled notification support to our Express/PostgreSQL app.
+
+```diff
+// NEW FILE: src/services/scheduler.ts
++import { NotificationPayload } from './types';
++
++export class NotificationScheduler {
++  private jobs: Map<string, NodeJS.Timeout> = new Map();
++
++  schedule(id: string, payload: NotificationPayload, delayMs: number): void {
++    const timer = setTimeout(async () => {
++      await this.execute(payload);
++      this.jobs.delete(id);
++    }, delayMs);
++    this.jobs.set(id, timer);
++  }
++
++  cancel(id: string): boolean {
++    const timer = this.jobs.get(id);
++    if (timer) {
++      clearTimeout(timer);
++      this.jobs.delete(id);
++      return true;
++    }
++    return false;
++  }
++
++  private async execute(payload: NotificationPayload): Promise<void> {
++    const { sendNotification } = require('./notifier');
++    await sendNotification(payload);
++  }
++}
+```
+
+```diff
+// NEW FILE: src/services/notifier.ts
++import { db } from '../db';
++import { NotificationPayload } from './types';
++
++export async function sendNotification(payload: NotificationPayload): Promise<void> {
++  const user = await db.users.findById(payload.userId);
++  if (!user) return; // silently skip
++
++  await fetch(payload.webhookUrl, {
++    method: 'POST',
++    headers: { 'Content-Type': 'application/json' },
++    body: JSON.stringify({ message: payload.message, recipient: user.email }),
++  });
++
++  await db.notifications.create({
++    userId: payload.userId,
++    message: payload.message,
++    sentAt: Date.now(),  // returns number (epoch ms)
++  });
++}
+```
+
+```diff
+// NEW FILE: src/services/types.ts
++export interface NotificationPayload {
++  userId: string;
++  message: string;
++  webhookUrl: string;
++  scheduledAt: Date;
++}
+```
+
+```diff
+// MODIFIED: src/routes/notifications.ts
++import { NotificationScheduler } from '../services/scheduler';
++
++const scheduler = new NotificationScheduler();
++
++router.post('/notifications/schedule', async (req, res) => {
++  const { userId, message, webhookUrl, scheduledAt } = req.body;
++  const delay = new Date(scheduledAt).getTime() - Date.now();
++  const id = crypto.randomUUID();
++  scheduler.schedule(id, { userId, message, webhookUrl, scheduledAt }, delay);
++  res.status(201).json({ id, scheduledAt });
++});
++
++router.delete('/notifications/schedule/:id', async (req, res) => {
++  const cancelled = scheduler.cancel(req.params.id);
++  res.json({ cancelled });
++});
+```
+
+```diff
+// MODIFIED: src/app.ts
+ import notificationRoutes from './routes/notifications';
+ // ... existing setup ...
+ // No new initialization code for NotificationScheduler
+```
+
+The existing codebase has:
+- `src/db.ts` — Knex-based database module, `notifications` table has `sent_at` column of type `TIMESTAMP`
+- `src/services/` — existing notification services
+- `src/routes/notifications.ts` — existing CRUD routes for notifications
+
+
+## Fixture 2 — blind input
+
+Feature under review: adding Role-Based Access Control (RBAC) to our Express API.
+
+```diff
+// NEW FILE: src/middleware/rbac.ts
++import { Request, Response, NextFunction } from 'express';
++import { db } from '../db';
++
++export function requireRole(...roles: string[]) {
++  return async (req: Request, res: Response, next: NextFunction) => {
++    const userId = req.user?.id;  // set by auth middleware
++    if (!userId) return res.status(401).json({ error: 'Not authenticated' });
++
++    const userRole = await db.users.findById(userId).select('role');
++    if (!userRole || !roles.includes(userRole.role)) {
++      return res.status(403).json({ error: 'Insufficient permissions' });
++    }
++    req.userRole = userRole.role;
++    next();
++  };
++}
+```
+
+```diff
+// MODIFIED: src/routes/admin.ts
++import { requireRole } from '../middleware/rbac';
++
+-router.get('/admin/users', authMiddleware, async (req, res) => {
++router.get('/admin/users', authMiddleware, requireRole('admin'), async (req, res) => {
+   const users = await db.users.findAll();
+   res.json(users);
+ });
+
+-router.delete('/admin/users/:id', authMiddleware, async (req, res) => {
++router.delete('/admin/users/:id', authMiddleware, requireRole('admin'), async (req, res) => {
+   await db.users.deleteById(req.params.id);
+   res.json({ deleted: true });
+ });
+```
+
+```diff
+// MODIFIED: src/routes/content.ts
++import { requireRole } from '../middleware/rbac';
++
+ router.get('/articles', authMiddleware, async (req, res) => {
+   const articles = await db.articles.findAll();
+   res.json(articles);
+ });
+
+-router.post('/articles', authMiddleware, async (req, res) => {
++router.post('/articles', authMiddleware, requireRole('admin', 'editor'), async (req, res) => {
+   const article = await db.articles.create(req.body);
+   res.json(article);
+ });
+
+-router.put('/articles/:id', authMiddleware, async (req, res) => {
++router.put('/articles/:id', authMiddleware, requireRole('admin', 'editor'), async (req, res) => {
+   const article = await db.articles.update(req.params.id, req.body);
+   res.json(article);
+ });
+
+-router.delete('/articles/:id', authMiddleware, async (req, res) => {
++router.delete('/articles/:id', authMiddleware, requireRole('admin'), async (req, res) => {
+   await db.articles.deleteById(req.params.id);
+   res.json({ deleted: true });
+ });
+```
+
+```diff
+// MODIFIED: src/db/migrations/20240320_add_roles.sql
++ALTER TABLE users ADD COLUMN role VARCHAR(20) DEFAULT 'viewer';
+```
+
+Existing codebase context:
+- Auth middleware at `src/middleware/auth.ts` sets `req.user` from JWT
+- `req.user` type is `{ id: string; email: string }` — does NOT include a `role` field
+- No `req.userRole` property exists on the Express Request type
+- The `users` table currently has no `role` column (that's what the migration adds)
+- Existing tests in `tests/routes/admin.test.ts` and `tests/routes/content.test.ts` mock `authMiddleware` to set `req.user`
+
+
+## Fixture 3 — blind input
+
+Feature under review: adding cursor-based pagination to our API.
+
+```diff
+// NEW FILE: src/utils/paginate.ts
++import { Knex } from 'knex';
++
++interface PaginationParams {
++  cursor?: string;
++  limit: number;
++}
++
++interface PaginatedResult<T> {
++  data: T[];
++  nextCursor: string | null;
++}
++
++export function parsePaginationParams(query: Record<string, unknown>): PaginationParams {
++  const limit = Math.min(Math.max(parseInt(String(query.limit)) || 20, 1), 100);
++  const cursor = query.cursor ? String(query.cursor) : undefined;
++  return { cursor, limit };
++}
++
++export async function paginate<T extends { id: number }>(
++  queryBuilder: Knex.QueryBuilder,
++  params: PaginationParams
++): Promise<PaginatedResult<T>> {
++  let query = queryBuilder.orderBy('id', 'asc').limit(params.limit + 1);
++  if (params.cursor) {
++    query = query.where('id', '>', parseInt(params.cursor));
++  }
++  const rows = await query;
++  const hasMore = rows.length > params.limit;
++  const data = hasMore ? rows.slice(0, params.limit) : rows;
++  const nextCursor = hasMore ? String(data[data.length - 1].id) : null;
++  return { data, nextCursor };
++}
+```
+
+```diff
+// MODIFIED: src/routes/users.ts
++import { parsePaginationParams, paginate } from '../utils/paginate';
++
+-router.get('/users', authMiddleware, async (req, res) => {
+-  const users = await db.users.findAll();
+-  res.json(users);
++router.get('/users', authMiddleware, async (req, res) => {
++  const params = parsePaginationParams(req.query);
++  const result = await paginate(db('users'), params);
++  res.json(result);
+ });
+```
+
+```diff
+// MODIFIED: src/routes/orders.ts
++import { parsePaginationParams, paginate } from '../utils/paginate';
++
+-router.get('/orders', authMiddleware, async (req, res) => {
+-  const orders = await db.orders.findAll({ userId: req.user.id });
+-  res.json(orders);
++router.get('/orders', authMiddleware, async (req, res) => {
++  const params = parsePaginationParams(req.query);
++  const query = db('orders').where('user_id', req.user.id);
++  const result = await paginate(query, params);
++  res.json(result);
+ });
+```
+
+```diff
+// NEW FILE: tests/utils/paginate.test.ts
++import { parsePaginationParams, paginate } from '../../src/utils/paginate';
++// ... tests using in-memory SQLite
+```
+
+Existing codebase context:
+- Knex with PostgreSQL
+- The `orders` table has a UUID `id` column (not integer)
+- The `users` table has auto-incrementing integer `id`
+- Frontend currently calls GET /users and GET /orders expecting a flat array response
+- There are existing integration tests that assert `res.body` is an array

--- a/skills/inquisitor/evals/inquisitor-dimension-prompt-eval.md
+++ b/skills/inquisitor/evals/inquisitor-dimension-prompt-eval.md
@@ -1,0 +1,182 @@
+<!-- DISPATCH: disk-mediated | This template is written to a dispatch file,
+     not pasted into the Agent tool prompt. See shared/dispatch-convention.md -->
+<!-- EVAL VARIANT of ../inquisitor-prompt.md (#424). Surgical S1 changes only:
+     the 5 dimension lenses + Steps 1-3 + ranking are preserved verbatim; the
+     run-and-record half (Step 4 wording, Step 5, Report-Format counts) is stubbed
+     toward a describe-don't-execute framing because the eval fixtures are text-only
+     (`files: []`) with no runner. This file is the SINGLE SOURCE of lens content —
+     `stage` fills the WITH per-dimension renders AND the MID all-lenses render from
+     the `## Dimension Reference` blocks below (no lens text is duplicated elsewhere). -->
+
+# Inquisitor Dimension Prompt Template — Eval Variant (execution stubbed)
+
+Use this template when staging each of the 5 inquisitor dimension subagents in the
+eval harness. `stage` fills the dimension-specific slots from the matching
+`## Dimension Reference` block.
+
+```
+Task tool (general-purpose, model: opus):
+  description: "Inquisitor [DIMENSION_NAME] dimension"
+  prompt: |
+    You are an inquisitor — a relentless hunter of cross-component bugs. Your
+    assigned dimension is **[DIMENSION_NAME]**. You are NOT reviewing code
+    quality. You are hunting for runtime failures that emerge from the
+    interaction of multiple components across the full feature.
+
+    ## Your Dimension: [DIMENSION_NAME]
+
+    **Core question:** [DIMENSION_QUESTION]
+
+    **What you're looking for:**
+    [DIMENSION_FOCUS_AREAS]
+
+    **Test style:** [DIMENSION_TEST_STYLE]
+
+    ## Full Feature Diff
+
+    This is the complete diff of ALL implementation changes — every task
+    combined. This is NOT a single task's diff. Look for interactions
+    BETWEEN components that per-task testing would miss.
+
+    [PASTE: git diff <base-sha>..HEAD — the full feature diff]
+
+    ## Project Test Conventions
+
+    No project test conventions are provided in this eval context.
+
+    ## Your Job
+
+    1. **Read the full diff.** Understand what was built across ALL tasks.
+       Map the new components and how they interact.
+
+    2. **Identify 3-5 attack vectors** specific to your dimension.
+       Think like an attacker. Where would [DIMENSION_NAME] problems hide
+       in the seams between these components?
+
+    3. **Rank by likelihood x impact.**
+       - Likelihood: how easily triggered in normal use (High/Medium/Low)
+       - Impact: severity of consequence if triggered (High/Medium/Low)
+       Select your top 3-5. If fewer than 3 are meaningful, write fewer —
+       don't pad with trivial tests.
+
+    4. **Describe the test (AAA structure: Arrange / Act / Assert) you WOULD
+       write per attack vector and its expected failure mode** — do NOT emit a
+       runnable test and do NOT execute; no runner is available in this eval
+       context. Describe observable behavior, not implementation details, and
+       focus on interactions the per-task adversarial tester COULD NOT have
+       caught (it only saw individual task diffs).
+
+    5. **Describe the expected failure mode; do NOT execute** — no runner is
+       available in this eval context. For each attack vector, state what the
+       described test would expose if the weakness is real.
+
+    6. **Report** using the exact format below.
+
+    ## What You Must NOT Do
+
+    - Do NOT modify production code
+    - Do NOT execute any test or run any code — no runner is available
+    - Do NOT describe more than 5 tests
+    - Do NOT refactor or improve existing tests
+    - Do NOT test internal implementation details — only observable behavior
+    - Do NOT duplicate coverage from per-task adversarial tests or test gap
+      writer (your job is cross-component interactions they missed)
+    - Do NOT attack vectors that belong to a different dimension — stay in
+      your lane
+
+    ## Context Self-Monitoring
+
+    Be aware of your context usage. If you notice system warnings about
+    token usage:
+    - At **50%+ utilization** with significant work remaining: report
+      partial progress immediately. Include attack vectors identified,
+      tests described so far, and what remains.
+    - Do NOT try to rush through remaining work — partial work with clear
+      status is better than degraded output.
+
+    ## Report Format
+
+    When done, report using this EXACT structure:
+
+    ```
+    ## INQUISITOR DIMENSION REPORT: [DIMENSION_NAME]
+
+    ### Summary
+    - Attack vectors identified: N
+    - Attack vectors with a described expected-failure test: N
+
+    ### Attack Vector 1: [Title]
+    - **What was tested:** [specific cross-component concern]
+    - **Likelihood:** High/Medium/Low
+    - **Impact:** High/Medium/Low
+    - **Test (described, AAA — not runnable):** [Arrange / Act / Assert sketch]
+    - **Expected failure mode:** [what the described test would expose]
+    - **If FAIL — fix guidance:** [what to change and in which component]
+
+    [repeat for each attack vector]
+    ```
+```
+
+## Dimension Reference
+
+The orchestrator copies the relevant dimension block into the template above.
+
+### Wiring
+
+- **Core question:** "Is everything actually connected?"
+- **Focus areas:**
+  - New classes/components that exist but are never instantiated or registered
+  - Missing service registrations (DI container bindings)
+  - Missing event subscriptions (published but nobody listens, or listener never subscribed)
+  - Interface implementations that aren't bound
+  - New entry points (menu items, buttons, routes, commands) that don't trigger the new code
+  - Factory methods or builders that don't include new types
+- **Test style:** Instantiate the system and verify new components are reachable and callable through their intended entry points.
+
+### Integration
+
+- **Core question:** "Do the new pieces talk to each other correctly?"
+- **Focus areas:**
+  - Data format mismatches between producer and consumer components
+  - Type assumption mismatches (producer sends int, consumer expects float)
+  - Ordering assumptions (A must happen before B, but nothing enforces it)
+  - Missing data transformations between components
+  - API contracts that don't match between caller and callee
+  - Events published with wrong payload shape or missing fields
+- **Test style:** Set up 2+ new components and verify data flows correctly end-to-end through the interaction chain.
+
+### Edge Cases
+
+- **Core question:** "What happens at the boundaries?"
+- **Focus areas:**
+  - Null/empty inputs at every new public API surface
+  - Zero and negative values where only positives are expected
+  - Maximum values and overflow conditions
+  - Empty collections passed to methods expecting non-empty
+  - Strings with special characters (empty, whitespace-only, extremely long)
+  - Boundary conditions at state transition thresholds
+- **Test style:** Call new APIs with boundary inputs and verify graceful handling (no crash, correct error, or documented behavior).
+
+### State & Lifecycle
+
+- **Core question:** "Is state managed correctly across the feature?"
+- **Focus areas:**
+  - Initialization order dependencies (A must init before B, but nothing enforces it)
+  - Missing disposal/cleanup (IDisposable, Unsubscribe, RemoveListener, event detachment)
+  - Stale references after disposal (use-after-dispose)
+  - State mutations that aren't thread-safe when they should be
+  - Singleton assumptions that don't hold in the actual runtime
+  - State not reset between uses (pooling, recycling, scene transitions)
+- **Test style:** Exercise lifecycle sequences (create, use, dispose, re-create) and verify correct behavior at each stage.
+
+### Regression
+
+- **Core question:** "Did we break anything that used to work?"
+- **Focus areas:**
+  - Existing methods whose return values or side effects changed subtly
+  - Modified base classes affecting derived class behavior
+  - Changed default values, constructor signatures, or parameter ordering
+  - Modified event handling order or priority
+  - Changed error handling (swallowing exceptions that used to propagate, or vice versa)
+  - Moved or renamed things that other code depends on
+- **Test style:** Exercise existing functionality through paths that touch newly modified code, verifying prior behavior is preserved.

--- a/skills/inquisitor/evals/judge-prompt.md
+++ b/skills/inquisitor/evals/judge-prompt.md
@@ -1,0 +1,56 @@
+<!-- DISPATCH: disk-mediated | Staged once by run_evals.py and used BYTE-IDENTICALLY
+     by every judge dispatch across all arms and cells (#424, design S4). It grades a
+     tagged UNION item list (S-1) and emits the per-item verdict record (S2) that
+     run_evals.py `score` parses. The contract below is pinned in CI by
+     scripts/check_judge_prompt_contract.py — keep the `tag`/`primary`/`secondary`
+     references and the `id`+`tag`+`verdict` output record; do NOT reintroduce a
+     "grade each expectation, which arm is better" framing. -->
+
+# Inquisitor Judge Prompt
+
+You are grading ONE arm's review output against a fixed list of items. You are NOT
+deciding which arm is better, and you are NOT comparing one arm's output to another.
+You grade each item on its own.
+
+## The item list you are given
+
+You are given a single **tagged union** item list. It is the union of two pools,
+each item carrying a `tag`:
+
+- `tag` = **`primary`** — a skill-independent ground-truth bug. Its `id` is the
+  ground-truth `bug_id` (e.g. `f1-b1`).
+- `tag` = **`secondary`** — a dimension-bucketed evals.json expectation. Its `id`
+  is that expectation's index/key.
+
+Each item also carries its description. Grade EVERY item — `primary` and
+`secondary` alike — in this one pass. There is no second grading pass.
+
+## How to grade each item
+
+For each item, ask exactly this question:
+
+> **"Is THIS specific issue identified in the arm's output? PASS / FAIL."**
+
+- **PASS** — the output identifies this specific issue. The wording may differ; what
+  matters is that the same underlying bug/expectation is named.
+- **FAIL** — the output does not identify this specific issue.
+
+Grade strictly per item. Do NOT reward a longer or more verbose output — a larger
+report is not "more correct." Only whether each specific item is present matters
+(this controls for verbosity bias between arms with different output volumes).
+
+## Output format
+
+Emit **one JSON object per graded item**, one object per line, each with exactly
+these three fields:
+
+    {"id": "f1-b1", "tag": "primary", "verdict": "PASS"}
+    {"id": "expectation-3", "tag": "secondary", "verdict": "FAIL"}
+
+- **`id`** — echo the item's id verbatim (a `primary` item's id is its ground-truth
+  `bug_id`; a `secondary` item's id is its expectation index/key).
+- **`tag`** — echo the item's tag, `primary` or `secondary`.
+- **`verdict`** — `PASS` or `FAIL`.
+
+Emit exactly one record for every item in the list, and nothing else after them. A
+missing or malformed record for an item is counted as `FAIL` for that item.

--- a/skills/inquisitor/evals/run_evals.py
+++ b/skills/inquisitor/evals/run_evals.py
@@ -1,0 +1,980 @@
+#!/usr/bin/env python3
+"""Inquisitor fan-out eval harness — `stage` + `score` (#424).
+
+Mirrors temper's module *layout* (D5): `_REPO_ROOT` / `_EVALS_DIR` /
+`_EVALS_JSON`, package-relative helper imports, `if __name__ == "__main__":
+sys.exit(main())`. Invoked as a module from repo root:
+
+    python3 -m skills.inquisitor.evals.run_evals stage <run-id> [--trials N] [--fixture ID]
+    python3 -m skills.inquisitor.evals.run_evals score <run-id> [--allow-incomplete]
+
+`stage` renders the three-arm dispatch files (WITH = 5 dimension subagents + 1
+aggregation subagent; MID = 1 all-lenses subagent; WITHOUT = 1 neutral subagent)
+per fixture×trial, plus the two shared deterministic prompt files
+(`aggregation-prompt.md`, `judge-prompt.md`), and writes `stage-manifest.json`.
+There is no `collect` subcommand — collect is the live orchestrator procedure
+documented in README.md. `score` reads the judge verdict files and computes the
+three paired deltas (see the `score` section, added in build-order step 5).
+
+Phase 1 only: identification breadth, execution stubbed. See the gated design
+`docs/plans/2026-06-13-inquisitor-fanout-eval-harness-design.md`.
+"""
+from __future__ import annotations
+import argparse
+import datetime as _dt
+import json
+import math
+import re
+import shutil
+import statistics
+import sys
+from pathlib import Path
+
+from ._dispatch_paths import fixture_sha, resolve_dispatch_dir, template_sha
+from ._runid import validate_run_id
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EVALS_DIR = Path(__file__).resolve().parent
+_EVALS_JSON = _EVALS_DIR / "evals.json"
+_DIM_TEMPLATE = _EVALS_DIR / "inquisitor-dimension-prompt-eval.md"
+_AGG_PROMPT = _EVALS_DIR / "aggregation-prompt.md"
+_JUDGE_PROMPT = _EVALS_DIR / "judge-prompt.md"
+
+# The WITHOUT-arm neutral instruction (design L143). The source-of-truth constant;
+# `stage` writes it (plus the fixture diff) to the staged WITHOUT dispatch.
+WITHOUT_PROMPT = (
+    "Review this diff for cross-component bugs. List each issue you find with a "
+    "specific proposed fix or test."
+)
+
+# The 5 dimension lens titles — the literal set the Dimension Reference parse must
+# yield (S3: count alone is defeatable; the literal-title-set assertion is not).
+DIMENSION_TITLES = ["Wiring", "Integration", "Edge Cases",
+                    "State & Lifecycle", "Regression"]
+
+_DEFAULT_TRIALS = 5  # decision-run default (design "Cost envelope")
+
+# S-2 guard: a rendered WITH dispatch must carry NO residual [DIMENSION_*] slot.
+# Scoped to the [DIMENSION_*] slot class ONLY (NOT arbitrary [...] tokens): the
+# preserved Report-Format markers ([Title], [what to change...]) and bracket tokens
+# inside the embedded fixture diff (fixture-3's [data.length - 1]) are expected.
+_DIMENSION_SLOT_RE = re.compile(r"\[DIMENSION_[A-Z_]*\]")
+
+# S1: a unique non-printable sentinel that stands in for the [PASTE: git diff …]
+# slot WHILE _validate_rendered_prompt scans the slot-filled template. The validator
+# must run on the slot-filled template BEFORE the fixture diff is embedded — a future
+# fixture diff legitimately containing a `[DIMENSION_*]`- or `[PASTE:`-shaped token
+# (plausible in a JS/TS or dispatch/template code-review fixture) would otherwise
+# false-trip the validator and crash stage. The git-diff slot is itself a `[PASTE:`
+# token, so it cannot simply be left in place during validation; it is consumed to
+# this sentinel, validated around, then replaced LAST with the real diff via a literal
+# str.replace (no backreference/escape interpretation — preserves S1's original
+# guarantee). The NUL-wrapped marker cannot collide with any prompt or fixture byte.
+_DIFF_SENTINEL = "\x00FIXTURE_DIFF\x00"
+_DIFF_SLOT_RE = re.compile(r"\[PASTE: git diff[^\]]*\]")
+
+
+# ---------------------------------------------------------------------------
+# Dimension Reference parsing (the single lens source — D3)
+# ---------------------------------------------------------------------------
+
+
+def _dimension_reference_slice(template_text: str) -> str:
+    """Return the text between the '## Dimension Reference' header and the next
+    top-level '## ' header (or EOF). Scoping the lens parse to this slice (rather
+    than a file-wide '### ' split) is the S3 mitigation."""
+    m = re.search(r"^## Dimension Reference[ \t]*$", template_text, re.M)
+    if not m:
+        raise ValueError("template has no '## Dimension Reference' section")
+    start = m.end()
+    nxt = re.search(r"^## ", template_text[start:], re.M)
+    return template_text[start: start + nxt.start()] if nxt else template_text[start:]
+
+
+def parse_dimension_blocks(template_text: str) -> list:
+    """Parse the Dimension Reference slice into exactly 5 (title, block_text)
+    pairs in file order. block_text starts with the title line.
+
+    Raises unless there are exactly 5 '### ' blocks AND their titles equal the
+    literal set DIMENSION_TITLES (S3 — a header-count-preserving rewrite that nets
+    5 headers with one non-dimension block is caught by the title-set assertion)."""
+    sl = _dimension_reference_slice(template_text)
+    raw = re.split(r"^### ", sl, flags=re.M)[1:]
+    blocks = [(rb.splitlines()[0].strip(), rb) for rb in raw]
+    titles = [t for t, _ in blocks]
+    if len(blocks) != 5 or set(titles) != set(DIMENSION_TITLES):
+        raise ValueError(
+            f"Dimension Reference must have exactly 5 blocks titled "
+            f"{DIMENSION_TITLES}; got {titles}"
+        )
+    return blocks
+
+
+def extract_dimension_fields(title: str, block_text: str) -> dict:
+    """Second parse layer (S-2): extract the WITH template's slot values from one
+    '### <Dim>' block — name, core question, focus areas (label + nested bullets),
+    test style."""
+    lines = block_text.splitlines()
+    question = teststyle = None
+    focus_lines: list = []
+    i = 1  # lines[0] is the title
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("- **Core question:**"):
+            question = line[len("- **Core question:**"):].strip().strip('"')
+        elif line.startswith("- **Focus areas:**"):
+            focus_lines = [line]
+            j = i + 1
+            while j < len(lines):
+                nxt = lines[j]
+                # nested bullets are indented; stop at the next top-level
+                # "- **...:**" label or a blank line / block end.
+                if re.match(r"^- \*\*", nxt) or nxt.strip() == "":
+                    break
+                focus_lines.append(nxt)
+                j += 1
+            i = j
+            continue
+        elif line.startswith("- **Test style:**"):
+            teststyle = line[len("- **Test style:**"):].strip()
+        i += 1
+    focus = "\n".join(focus_lines)
+    if not (question and focus and teststyle):
+        raise ValueError(
+            f"dimension {title!r} block is missing a Core question / Focus areas "
+            f"/ Test style field"
+        )
+    return {"name": title, "question": question, "focus": focus,
+            "teststyle": teststyle}
+
+
+# ---------------------------------------------------------------------------
+# Render helpers
+# ---------------------------------------------------------------------------
+
+# S-3: every evals.json fixture `prompt` opens with the skill-naming lead-in
+# "Run the inquisitor against this feature diff for …". Embedded raw, it would
+# prime even the bare WITHOUT baseline with the methodology it is meant to lack —
+# plausibly raising its floor and compressing WITH−WITHOUT toward zero (the
+# false-green direction). The provenance build already neutralized this exact
+# opener for the blind ground-truth author (ground-truth-bugs.provenance.md); the
+# live measurement arms must get the SAME neutralization so the embedded fixture
+# content is identical and skill-neutral across all three arms (the methodology
+# difference comes only from the arm scaffold, not the fixture text).
+_FIXTURE_OPENER = "Run the inquisitor against this feature diff for "
+_FIXTURE_OPENER_NEUTRAL = "Feature under review: "
+
+
+def _neutralize_fixture_opener(text: str) -> str:
+    """Replace the leading skill-naming opener with the neutral provenance framing
+    (anchored at the start only). Mirrors the provenance neutralization exactly:
+    e.g. "Run the inquisitor against this feature diff for a new 'Scheduled
+    Notifications' feature." → "Feature under review: a new 'Scheduled
+    Notifications' feature." Leaves text without the opener untouched."""
+    if text.startswith(_FIXTURE_OPENER):
+        return _FIXTURE_OPENER_NEUTRAL + text[len(_FIXTURE_OPENER):]
+    return text
+
+
+def _template_region(template_text: str) -> str:
+    """The WITH dimension template portion — everything before the Dimension
+    Reference (which is only the lens source, not part of a dispatched prompt)."""
+    m = re.search(r"^## Dimension Reference[ \t]*$", template_text, re.M)
+    return template_text[:m.start()] if m else template_text
+
+
+def _validate_rendered_prompt(rendered: str) -> None:
+    """RAISE on any residual [DIMENSION_*] slot OR any residual `[PASTE:` token in a
+    rendered WITH dimension / MID dispatch (S-2 + S1): a half-filled render fails
+    loudly at stage time rather than dispatching a broken prompt. The `[PASTE:`
+    guard catches any non-dimension placeholder block (e.g. a future template edit
+    re-introducing a Project-Test-Conventions / Module-Context PASTE slot) that the
+    [DIMENSION_*] scope alone would miss — the exact arm-asymmetric confound where
+    WITH/MID carry a dangling unfulfillable PASTE instruction WITHOUT does not.
+
+    NOTE: `render_with_aggregation` legitimately emits a `[PASTE: the 5 WITH
+    dimension reports …]` collect-time slot filled live by the human collector; it
+    does NOT route through this validator, and must not, or that slot would falsely
+    trip this guard."""
+    leftover = _DIMENSION_SLOT_RE.findall(rendered)
+    if leftover:
+        raise ValueError(
+            f"rendered WITH dispatch has unfilled dimension slots: "
+            f"{sorted(set(leftover))}"
+        )
+    if "[PASTE:" in rendered:
+        raise ValueError(
+            "rendered WITH/MID dispatch has a residual [PASTE: …] slot — every "
+            "non-dimension placeholder must be filled or omitted at render time"
+        )
+
+
+def render_with_dimension(template_region: str, fields: dict, fixture: dict) -> str:
+    """Fill the 5 [DIMENSION_*] slots for one dimension + embed the fixture diff."""
+    r = template_region
+    r = r.replace("[DIMENSION_NAME]", fields["name"])
+    r = r.replace("[DIMENSION_QUESTION]", fields["question"])
+    r = r.replace("[DIMENSION_FOCUS_AREAS]", fields["focus"])
+    r = r.replace("[DIMENSION_TEST_STYLE]", fields["teststyle"])
+    # Consume the "full feature diff" [PASTE: git diff …] slot with a sentinel
+    # (regex avoids coupling to the em-dash in the slot text), THEN validate the
+    # slot-filled template, THEN swap the sentinel for the real diff LAST (S1).
+    # Validating before embedding ensures the guard scans only template/slot bytes —
+    # never fixture bytes — so a fixture diff that happens to contain a
+    # `[DIMENSION_*]`- or `[PASTE:`-shaped token cannot false-trip it; it still
+    # catches a genuinely unfilled [DIMENSION_*] slot and any stray non-git-diff
+    # [PASTE: slot. The sentinel is replaced via literal str.replace so the diff is
+    # inserted LITERALLY — a regex replacement argument would interpret
+    # backreferences/escapes (\1, \g<...>, \n) in the diff. The fixture opener is
+    # neutralized first (S-3) so the embedded content is skill-neutral.
+    r = _DIFF_SLOT_RE.sub(lambda _m: _DIFF_SENTINEL, r)
+    _validate_rendered_prompt(r)
+    diff = _neutralize_fixture_opener(fixture["prompt"])
+    r = r.replace(_DIFF_SENTINEL, diff)
+    return r
+
+
+def render_with_aggregation(agg_text: str) -> str:
+    """The WITH 6th aggregation dispatch — the shared aggregation framing
+    (byte-identical substring, T3) + a slot for this cell's 5 dimension reports
+    (produced at collect time)."""
+    return (
+        agg_text
+        + "\n\n## The 5 dimension reports to aggregate\n\n"
+        + "[PASTE: the 5 WITH dimension reports produced for this cell]\n"
+    )
+
+
+# The single-dimension lens block in the WITH procedural shell — from the
+# "## Your Dimension:" header through the "**Test style:**" slot (4-space indented
+# inside the template code fence). MID replaces this one-dimension block with an
+# all-five-dimensions section; the surrounding procedural scaffold (persona, Steps,
+# NOT-do, Report-Format) is kept verbatim so WITH−MID isolates only fan-out.
+_MID_LENS_BLOCK_RE = re.compile(
+    r"^[ \t]*## Your Dimension:.*?\*\*Test style:\*\* \[DIMENSION_TEST_STYLE\]",
+    re.M | re.S,
+)
+
+
+def _all_lenses_section(blocks: list) -> str:
+    """The MID replacement for the WITH single-dimension lens block: the same 5
+    Dimension Reference blocks (the single lens source — D3) under an all-five
+    header, 4-space indented to sit inside the template code fence."""
+    body = "## All Five Dimensions\n\nApply every one of these five dimension lenses:\n\n"
+    body += "\n".join("### " + b.rstrip() + "\n" for _t, b in blocks)
+    # 4-space indent each line to match the surrounding code-fence body.
+    return "\n".join(("    " + ln) if ln else ln for ln in body.splitlines())
+
+
+def render_mid(blocks: list, agg_text: str, template_region: str,
+               fixture: dict) -> str:
+    """The MID dispatch — the SAME WITH per-dimension procedural shell
+    (`_template_region`: relentless-hunter persona, the `## Your Job` steps,
+    `## What You Must NOT Do`, `## Report Format`), but with the one-dimension lens
+    block swapped for all 5 lenses and the residual single-dimension tokens
+    neutralized to cross-dimension phrasing, plus the byte-identical WITH
+    aggregation framing and the fixture diff. One sequential agent holds every lens.
+
+    This holds the per-dimension procedural scaffold + lens content + aggregation
+    framing CONSTANT with WITH; WITH−MID therefore varies ONLY the fan-out delivery
+    mechanism (5 parallel fresh subagents vs 1 sequential agent), not the procedure.
+    The lens text and the procedural text both come from `_template_region` /
+    `blocks` — neither is duplicated as a string literal here (D3)."""
+    r = template_region
+    # Swap the single-dimension lens block for the all-five-dimensions section.
+    r = _MID_LENS_BLOCK_RE.sub(lambda _m: _all_lenses_section(blocks), r, count=1)
+    # Neutralize the remaining single-dimension tokens (persona line, Step 2,
+    # Report header, code-fence description) to cross-dimension phrasing.
+    r = r.replace("[DIMENSION_NAME]", "all five dimensions")
+    # F1: rescope the WITH per-agent output budget to per-dimension / aggregate
+    # scope. WITH's "3-5 vectors" / "top 3-5" / "no more than 5 tests" cap binds
+    # each of 5 parallel agents independently (~25 total flow into aggregation); the
+    # SAME string in MID binds the single all-dimensions agent (~5 total), capping
+    # MID below WITH for reasons orthogonal to the fan-out mechanism WITH−MID
+    # isolates. Rescope so MID's aggregate budget matches WITH's (~5 per dimension ×
+    # 5 ≈ 25), and drop the now-incoherent single-lane line (an all-dimensions agent
+    # cannot "stay in its lane"). Each replace is asserted to have fired (fail-loud,
+    # consistent with _validate_rendered_prompt): an exact-substring no-op would
+    # silently leave MID under-budgeted.
+    _rescope = [
+        ("**Identify 3-5 attack vectors** specific to your dimension.",
+         "**Identify 3-5 attack vectors per dimension (up to ~25 total)** "
+         "specific to each of the five dimensions."),
+        ("Select your top 3-5.",
+         "Select your top 3-5 per dimension (up to ~25 total)."),
+        ("- Do NOT describe more than 5 tests",
+         "- Do NOT describe more than 5 tests per dimension"),
+        ("- Do NOT attack vectors that belong to a different dimension — stay in\n"
+         "      your lane",
+         "- Cross-dimension reasoning is expected — you hold every lens"),
+    ]
+    for old, new in _rescope:
+        if old not in r:
+            raise ValueError(
+                f"render_mid budget-rescope substring not found verbatim in the "
+                f"rendered MID prompt (silent no-op would under-budget MID vs "
+                f"WITH): {old!r}"
+            )
+        r = r.replace(old, new)
+    # Consume the same [PASTE: git diff …] slot WITH uses with a sentinel (NOT the
+    # real diff yet — S1), opener neutralized identically to WITH/WITHOUT (S-3).
+    r = _DIFF_SLOT_RE.sub(lambda _m: _DIFF_SENTINEL, r)
+    # Append the byte-identical WITH aggregation framing AROUND the sentinel.
+    r = r.rstrip() + "\n\n## Aggregation\n\n" + agg_text + "\n"
+    # Validate the fully-assembled template (persona + all-five lens + rescope +
+    # appended agg framing) with the git-diff slot sentinel-consumed, BEFORE the
+    # fixture diff is embedded — so the guard never scans fixture bytes (S1). This
+    # still catches a genuinely unfilled [DIMENSION_*] slot, any stray non-git-diff
+    # [PASTE: slot, AND a future agg-prompt edit that reintroduced such a slot.
+    _validate_rendered_prompt(r)
+    # Swap the sentinel for the real diff LAST via literal str.replace (no
+    # backreference/escape interpretation of the diff — S1).
+    diff = _neutralize_fixture_opener(fixture["prompt"])
+    r = r.replace(_DIFF_SENTINEL, diff)
+    return r
+
+
+def render_without(fixture: dict) -> str:
+    """The WITHOUT dispatch — the neutral instruction + the fixture diff (skill
+    opener neutralized — S-3, identical to WITH/MID)."""
+    return (WITHOUT_PROMPT + "\n\n## Diff\n\n"
+            + _neutralize_fixture_opener(fixture["prompt"]))
+
+
+# ---------------------------------------------------------------------------
+# stage()
+# ---------------------------------------------------------------------------
+
+
+def _slug(title: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+def _load_fixtures() -> list:
+    data = json.loads(_EVALS_JSON.read_text(encoding="utf-8"))
+    return data["evals"]
+
+
+def stage(run_id: str, *, trials: int = _DEFAULT_TRIALS,
+          fixture: int | str | None = None, force: bool = False) -> Path:
+    """Render the three-arm dispatch files + the two shared prompt files; write
+    stage-manifest.json. Returns the dispatch directory path."""
+    validate_run_id(run_id)
+    if trials < 1:
+        raise ValueError(f"--trials must be >= 1 (got {trials})")
+
+    fixtures = _load_fixtures()
+    if fixture is not None:
+        fixtures = [f for f in fixtures if str(f["id"]) == str(fixture)]
+        if not fixtures:
+            raise ValueError(f"--fixture {fixture!r} not found in evals.json")
+    for f in fixtures:
+        if not f.get("prompt", "").strip():
+            raise ValueError(f"fixture {f.get('id')!r} has an empty diff/prompt")
+
+    template_text = _DIM_TEMPLATE.read_text(encoding="utf-8")
+    blocks = parse_dimension_blocks(template_text)            # validates 5 + titles
+    region = _template_region(template_text)
+    agg_text = _AGG_PROMPT.read_text(encoding="utf-8")
+    fields_by_title = {t: extract_dimension_fields(t, b) for t, b in blocks}
+
+    dispatch_dir = resolve_dispatch_dir(run_id)
+    if dispatch_dir.exists():
+        if not force:
+            raise FileExistsError(
+                f"dispatch dir {dispatch_dir} already exists; pass force=True"
+            )
+        shutil.rmtree(dispatch_dir)
+    dispatch_dir.mkdir(parents=True)
+
+    # Two shared deterministic prompt files (S4): byte-identical across all
+    # arms/cells, hashed so the invariant is machine-checkable.
+    (dispatch_dir / "aggregation-prompt.md").write_text(agg_text, encoding="utf-8")
+    judge_text = _JUDGE_PROMPT.read_text(encoding="utf-8")
+    (dispatch_dir / "judge-prompt.md").write_text(judge_text, encoding="utf-8")
+
+    ts = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    cells: list = []
+    for fix in fixtures:
+        fsha = fixture_sha(fix)
+        for trial in range(1, trials + 1):
+            stem = f"f{fix['id']}-t{trial}"
+            # WITH: 5 dimension dispatches + 1 aggregation dispatch
+            with_files = []
+            for n, (title, block) in enumerate(blocks, 1):
+                fname = f"{stem}-with-dim{n}-{_slug(title)}.md"
+                rendered = render_with_dimension(region, fields_by_title[title], fix)
+                (dispatch_dir / fname).write_text(rendered, encoding="utf-8")
+                with_files.append(fname)
+            agg_fname = f"{stem}-with-agg.md"
+            (dispatch_dir / agg_fname).write_text(
+                render_with_aggregation(agg_text), encoding="utf-8")
+            with_files.append(agg_fname)
+            cells.append({
+                "fixture_id": fix["id"], "trial": trial, "arm": "with",
+                "dispatch_files": with_files,
+                "result_file": f"{stem}-with-verdicts.jsonl",
+                "fixture_sha": fsha,
+            })
+            # MID: 1 all-lenses dispatch
+            mid_fname = f"{stem}-mid.md"
+            (dispatch_dir / mid_fname).write_text(
+                render_mid(blocks, agg_text, region, fix), encoding="utf-8")
+            cells.append({
+                "fixture_id": fix["id"], "trial": trial, "arm": "mid",
+                "dispatch_files": [mid_fname],
+                "result_file": f"{stem}-mid-verdicts.jsonl",
+                "fixture_sha": fsha,
+            })
+            # WITHOUT: 1 neutral dispatch
+            wo_fname = f"{stem}-without.md"
+            (dispatch_dir / wo_fname).write_text(
+                render_without(fix), encoding="utf-8")
+            cells.append({
+                "fixture_id": fix["id"], "trial": trial, "arm": "without",
+                "dispatch_files": [wo_fname],
+                "result_file": f"{stem}-without-verdicts.jsonl",
+                "fixture_sha": fsha,
+            })
+
+    manifest = {
+        "run_id": run_id,
+        "stage_timestamp": ts,
+        "trials": trials,
+        "fixtures": len(fixtures),
+        "judge_model": "opus",
+        "template_shas": {
+            "dimension_eval": template_sha(_DIM_TEMPLATE),
+            "aggregation": template_sha(_AGG_PROMPT),
+            "judge": template_sha(_JUDGE_PROMPT),
+        },
+        "shared_files": ["aggregation-prompt.md", "judge-prompt.md"],
+        "cells": cells,
+    }
+    (dispatch_dir / "stage-manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8")
+    return dispatch_dir
+
+
+# ---------------------------------------------------------------------------
+# score()
+# ---------------------------------------------------------------------------
+
+_EPS = 0.05           # beyond_spread magnitude floor (design "Statistical power")
+_Z = 1.96             # fixed no-α constant for mde_heuristic (F2)
+_ARMS = ("with", "mid", "without")
+
+# S-1: the documented secondary pool — 27 total evals.json expectations minus the
+# single fixture-1 #8 exclusion = 26. This is a DIAGNOSTIC reconciliation anchor
+# only; score derives graded_expectations from observed records (round-3 decision)
+# and never gates on it. The static drift guard for these two 26s lives in
+# scripts/check_inquisitor_secondary_count.py (DOCUMENTED_SECONDARY).
+_CONTRACTED_SECONDARY_POOL = 26
+
+
+def _ground_truth_path() -> Path:
+    """Resolved at CALL time from _EVALS_DIR (F1) — NOT a module-load constant, so
+    a test patching _EVALS_DIR actually redirects this read."""
+    return _EVALS_DIR / "ground-truth-bugs.json"
+
+
+def _rate(passes: int, total: int) -> float:
+    return passes / total if total else 0.0
+
+
+def _majority_pass(outcomes: list) -> bool:
+    """Strict-majority collapse across trials; an even-N tie resolves to FAIL (M1)."""
+    return sum(1 for o in outcomes if o) * 2 > len(outcomes)
+
+
+def _parse_verdict_file(path: Path) -> tuple:
+    """Return ({(tag, id): passed_bool}, malformed_line_count, dispatch_failed).
+
+    A line that fails to parse or carries a non-PASS/FAIL verdict is counted
+    malformed and skipped (its item is then absent → graded FAIL by the caller,
+    per the design's malformed-verdict rule + S2).
+
+    Mirrors temper's `_parse_result_file` sentinel handling (surgical, not a
+    wholesale copy): the README collect contract writes each result_file using the
+    `DISPATCH_STATUS: OK\\n\\n<body>` dispatch-health sentinel. If the first
+    non-blank line is that sentinel it is consumed (NOT counted malformed) and the
+    JSONL body parses as today. A `DISPATCH_STATUS: ERROR` first line — or an `OK`
+    sentinel followed by an empty/whitespace body — is a dispatch failure
+    (`dispatch_failed=True`, no parsed records) so S-1's guard can refuse on it.
+    Backward-compatible: a file with NO `DISPATCH_STATUS:` sentinel (pure JSONL, as
+    the unit tests write) parses exactly as before."""
+    parsed: dict = {}
+    malformed = 0
+    if not path.exists():
+        return parsed, malformed, False
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    # Consume an optional leading DISPATCH_STATUS: sentinel (only the first
+    # non-blank line is inspected, so a literal "DISPATCH_STATUS:" substring inside
+    # a later JSONL body cannot collide). The body is the remaining lines.
+    idx = 0
+    while idx < len(lines) and lines[idx].strip() == "":
+        idx += 1
+    if idx < len(lines) and lines[idx].lstrip().startswith("DISPATCH_STATUS:"):
+        sentinel = lines[idx].lstrip()
+        if sentinel.startswith("DISPATCH_STATUS: ERROR"):
+            return parsed, malformed, True
+        if not sentinel.startswith("DISPATCH_STATUS: OK"):
+            # Malformed sentinel — treat as a dispatch failure (no claim on body).
+            return parsed, malformed, True
+        body_lines = lines[idx + 1:]
+        if not any(ln.strip() for ln in body_lines):
+            # OK sentinel but empty/whitespace body → dispatch failure.
+            return parsed, malformed, True
+        lines = body_lines
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+            tag, vid, verdict = rec["tag"], rec["id"], rec["verdict"]
+            if verdict not in ("PASS", "FAIL"):
+                raise ValueError("bad verdict value")
+            if tag not in ("primary", "secondary"):
+                raise ValueError("bad tag value")
+        except Exception:
+            malformed += 1
+            continue
+        parsed[(tag, vid)] = (verdict == "PASS")
+    return parsed, malformed, False
+
+
+def _mde_heuristic(per_trial_deltas: list) -> float | None:
+    """1.96 × sample-stdev(per-trial paired deltas, ddof=1) / sqrt(trials); null
+    when trials < 2 (SE undefined). An explicitly no-α noise-floor figure (F2)."""
+    n = len(per_trial_deltas)
+    if n < 2:
+        return None
+    return _Z * statistics.stdev(per_trial_deltas) / math.sqrt(n)
+
+
+def _beyond_spread(per_trial_deltas: list, mean: float) -> bool:
+    """True iff the per-trial band excludes zero AND |mean| >= ε. Forced False for
+    trials < 3 (S2): a 1-2 trial band is a degenerate point/pair that trivially
+    excludes zero — the very re-run noise the band exists to bound."""
+    if len(per_trial_deltas) < 3:
+        return False
+    lo, hi = min(per_trial_deltas), max(per_trial_deltas)
+    excludes_zero = lo > 0 or hi < 0
+    return excludes_zero and abs(mean) >= _EPS
+
+
+def _delta_block(a_rates: list, b_rates: list, *, with_beyond: bool) -> dict:
+    """Paired-delta block from two arms' per-trial rate lists (index-matched).
+    `paired` = mean of per-trial paired deltas (M-b), NOT a majority-rate diff."""
+    deltas = [a - b for a, b in zip(a_rates, b_rates)]
+    paired = statistics.mean(deltas) if deltas else 0.0
+    block = {
+        "paired": paired,
+        "trial_spread": [min(deltas), max(deltas)] if deltas else [0.0, 0.0],
+        "mde_heuristic": _mde_heuristic(deltas),
+    }
+    if with_beyond:
+        block["beyond_spread"] = _beyond_spread(deltas, paired)
+    return block
+
+
+def score(run_id: str, *, allow_incomplete: bool = False) -> int:
+    """Read stage-manifest.json + judge verdict files; compute the three paired
+    deltas + diagnostics; write last_run.json + results.md. Returns an exit code."""
+    validate_run_id(run_id)
+    dispatch_dir = resolve_dispatch_dir(run_id)
+    manifest_path = dispatch_dir / "stage-manifest.json"
+    if not manifest_path.exists():
+        print(f"[fatal] no stage-manifest.json at {manifest_path}", file=sys.stderr)
+        return 1
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    # .collect-status gating (test 5): refuse without it unless --allow-incomplete.
+    status_file = dispatch_dir / ".collect-status"
+    if not status_file.exists() and not allow_incomplete:
+        print(f"[fatal] no .collect-status in {dispatch_dir}; collect is "
+              f"incomplete (pass --allow-incomplete for a smoke/debug score)",
+              file=sys.stderr)
+        return 1
+    complete = not allow_incomplete
+
+    cells = manifest["cells"]
+    trials = manifest["trials"]
+    fixtures_in_run = sorted({c["fixture_id"] for c in cells})
+
+    # Ground-truth bug list (call-time read, F1) → per-fixture bug ids + off_axis.
+    gt = json.loads(_ground_truth_path().read_text(encoding="utf-8"))
+    gt_fixture_ids = {f["id"] for f in gt["fixtures"]}
+
+    # Coverage guard (S1): every staged run fixture MUST be covered by ground-truth,
+    # and the resulting graded-bug pool must be non-empty. Without this, a
+    # misconfigured run (manifest stages fixture 1, GT lists only fixture 99 → K=0)
+    # or a partial-coverage run (GT covers only a subset of staged fixtures, silently
+    # dropping the rest from K) false-greens as a clean "no methodology effect" null
+    # with complete:true. Assert BEFORE computing any rates / writing last_run.json.
+    uncovered = [fid for fid in fixtures_in_run if fid not in gt_fixture_ids]
+    if uncovered:
+        print(f"[fatal] staged run fixtures {uncovered} are absent from "
+              f"ground-truth ({sorted(gt_fixture_ids)}); refusing to score a "
+              f"partially-covered run (it would silently drop those fixtures and "
+              f"false-green as a null result)", file=sys.stderr)
+        return 1
+
+    bugs_by_fixture: dict = {}
+    bug_off: dict = {}
+    for f in gt["fixtures"]:
+        if f["id"] not in fixtures_in_run:
+            continue
+        for b in f["bugs"]:
+            bugs_by_fixture.setdefault(f["id"], []).append(b["bug_id"])
+            bug_off[b["bug_id"]] = bool(b["off_axis"])
+    all_bugs = [b for fid in fixtures_in_run for b in bugs_by_fixture.get(fid, [])]
+    K = len(all_bugs)
+    if K == 0:
+        print(f"[fatal] graded-bug pool is empty (K=0) for staged fixtures "
+              f"{fixtures_in_run}; ground-truth lists no bugs for them — refusing "
+              f"to score (all deltas would be 0.0, false-greening as a clean null)",
+              file=sys.stderr)
+        return 1
+
+    # Parse every cell's verdicts.
+    # primary[arm][fid][trial] = {bug_id: passed}; secondary[arm][fid][trial] = {sid: passed}
+    primary: dict = {a: {} for a in _ARMS}
+    secondary: dict = {a: {} for a in _ARMS}
+    malformed: dict = {a: 0 for a in _ARMS}
+    secondary_universe: set = set()  # (fid, sid)
+    total_parsed = 0                 # S-1: union of parsed records across all cells
+    bad_cells: list = []             # S-1: cells with missing/empty/failed result_file
+    undergraded_cells: list = []     # F-1/S-1: (rf, gt-matched primary, K) under budget
+    for c in cells:
+        arm, fid, trial = c["arm"], c["fixture_id"], c["trial"]
+        result_path = dispatch_dir / c["result_file"]
+        parsed, mal, dispatch_failed = _parse_verdict_file(result_path)
+        # A cell is "bad" iff its result_file is MISSING, EMPTY (no content lines),
+        # or a DISPATCH_STATUS dispatch failure (S-1 ∩ S-2). A present non-empty file
+        # whose lines are all malformed is NOT bad — the judge ran and emitted
+        # garbage; that is a real (mal-counted, FAIL-by-absence) collection, distinct
+        # from "didn't collect" (which is what this guard refuses).
+        is_empty = not result_path.exists() or not result_path.read_text(
+            encoding="utf-8").strip()
+        if is_empty or dispatch_failed:
+            bad_cells.append(c["result_file"])
+        # F-1: a present, non-empty, non-dispatch-failed cell can still UNDER-emit
+        # its primary records — fewer than the fixture's ground-truth primary count.
+        # The omitted bugs all default to FAIL-by-absence in every arm equally, so
+        # the deltas collapse to 0.0 and the run false-greens as a clean null. Count
+        # emitted records toward the primary budget (parsed primary records + this
+        # cell's malformed lines, giving untaggable garbage the benefit of the doubt
+        # so the round-5 malformed-but-present contract is preserved). A short cell
+        # under-emitted.
+        #
+        # S-1 (id-matched budget): count only primary records whose id is a member of
+        # this fixture's ground-truth bug_id set. A judge that echoes well-formed
+        # primary records under DRIFTED ids (e.g. bug-1 instead of f1-b1) parses
+        # cleanly (mal=0) but every ground-truth bug is looked up by id and found
+        # absent → FAIL-by-absence in all arms equally → deltas collapse to 0.0 with
+        # complete:true, rc 0, malformed 0. Anchoring the count to gt_ids makes
+        # drifted (and cross-fixture, M4) ids stop satisfying the budget; extra
+        # hallucinated ids are harmless (the blind-anchored K ignores them, so only
+        # missing/drifted ids reduce the matched count). Malformed lines still count
+        # toward the budget (round-5 contract preserved). gt_match records how many of
+        # the budget the matched ids cover, for the operator diagnostic below.
+        else:
+            gt_ids = set(bugs_by_fixture.get(fid, []))
+            prim_count = sum(
+                1 for (tag, vid) in parsed if tag == "primary" and vid in gt_ids)
+            if prim_count + mal < len(gt_ids):
+                undergraded_cells.append((c["result_file"], prim_count, len(gt_ids)))
+        total_parsed += len(parsed)
+        malformed[arm] += mal
+        primary[arm].setdefault(fid, {})[trial] = {
+            vid: ok for (tag, vid), ok in parsed.items() if tag == "primary"}
+        sec = {vid: ok for (tag, vid), ok in parsed.items() if tag == "secondary"}
+        secondary[arm].setdefault(fid, {})[trial] = sec
+        for sid in sec:
+            secondary_universe.add((fid, sid))
+
+    # Collection-presence guard (S-1): for a `complete` run (NOT --allow-incomplete),
+    # the .collect-status flag is a content-free human-written stamp — it does not
+    # prove any verdicts were collected. With every result_file missing/empty/failed,
+    # every graded bug defaults to FAIL-by-absence and the run false-greens as a tidy
+    # `complete:true` zero-delta "no methodology effect" null (the headline false-green
+    # this harness exists to prevent). Mirror the K==0 / uncovered-fixture guards
+    # exactly: fail loud BEFORE writing last_run.json, leaving no artifact behind.
+    if complete:
+        # S-1 (manifest cell-grid completeness): every other complete-run guard
+        # iterates over the cells the manifest LISTS and the per-trial loops range
+        # over manifest["trials"]; nothing asserts the cell set covers the full
+        # (arm × fixture × trial) grid. A manifest that under-enumerates cells
+        # (e.g. only the WITH cell for f1-t1) false-greens — the absent arms have
+        # no cells to flag "bad" and primary_outcome defaults False for the whole
+        # pool, yielding a maximal false headline delta with complete:true, rc 0.
+        # An over-stated `trials` injects phantom all-FAIL trials that dilute the
+        # delta; `trials:0` makes range(1,1) empty for an all-zero false-green.
+        # Refuse a degenerate trial count, then assert exactly one cell per
+        # (arm, fid, trial). Manifest-shape check, independent of parsed content;
+        # fail loud BEFORE writing last_run.json (mirror the bad_cells pattern).
+        if trials < 1:
+            print(f"[fatal] manifest trials={trials} is degenerate (< 1) for "
+                  f"{dispatch_dir}; range(1,{trials + 1}) is empty so every per-trial "
+                  f"loop collapses to an all-zero false-green — refusing to score",
+                  file=sys.stderr)
+            return 1
+        realized: dict = {}  # (arm, fid, trial) -> count
+        for c in cells:
+            key = (c["arm"], c["fixture_id"], c["trial"])
+            realized[key] = realized.get(key, 0) + 1
+        expected_grid = {(arm, fid, t)
+                         for arm in _ARMS
+                         for fid in fixtures_in_run
+                         for t in range(1, trials + 1)}
+        missing = sorted(expected_grid - set(realized))
+        duplicates = sorted(k for k, n in realized.items() if n > 1)
+        if missing or duplicates:
+            print(f"[fatal] manifest cell-grid is incomplete for {dispatch_dir}: "
+                  f"expected exactly one cell per (arm × fixture × trial) over "
+                  f"arms {list(_ARMS)} × fixtures {fixtures_in_run} × "
+                  f"trials 1..{trials}; missing={missing} duplicate={duplicates} — "
+                  f"refusing to score (missing cells grade FAIL-by-absence in every "
+                  f"arm with no cell to flag, false-greening a wrong delta as "
+                  f"complete:true)", file=sys.stderr)
+            return 1
+        if total_parsed == 0:
+            print(f"[fatal] no verdict records parsed across any cell in "
+                  f"{dispatch_dir} (.collect-status is present but every result_file "
+                  f"is missing/empty/dispatch-failed); refusing to score — a "
+                  f"complete:true run with zero collected verdicts false-greens as a "
+                  f"clean null", file=sys.stderr)
+            return 1
+        if bad_cells:
+            print(f"[fatal] {len(bad_cells)} cell result_file(s) are "
+                  f"missing/empty/dispatch-failed: {sorted(bad_cells)}; refusing to "
+                  f"score a partially-collected complete run (the absent cells would "
+                  f"grade FAIL-by-absence and bias the delta toward a null)",
+                  file=sys.stderr)
+            return 1
+        # F-1: under-emission guard. A present, non-empty cell that emits fewer
+        # records than its fixture's ground-truth primary budget (parsed primary +
+        # malformed lines) leaves the omitted bugs FAIL-by-absence in ALL arms
+        # equally → deltas collapse to 0.0 with complete:true, rc 0, malformed 0.
+        # That is the toward-null false-green this harness exists to prevent, and no
+        # existing guard flags it. Fail loud BEFORE writing last_run.json (mirror the
+        # bad_cells pattern, separate list + distinct message).
+        if undergraded_cells:
+            detail = ", ".join(
+                f"{rf} (gt-matched primary {m} of {k})"
+                for (rf, m, k) in sorted(undergraded_cells))
+            print(f"[fatal] {len(undergraded_cells)} cell result_file(s) under-emit "
+                  f"OR id-drift their fixture's primary-record budget — parsed "
+                  f"primary ids matching ground-truth fall short of K: {detail}; "
+                  f"refusing to score (omitted OR id-drifted primary bugs grade "
+                  f"FAIL-by-absence in every arm equally, collapsing the deltas to a "
+                  f"false-green null)", file=sys.stderr)
+            return 1
+
+    def primary_outcome(arm, fid, bug, t):
+        return primary[arm].get(fid, {}).get(t, {}).get(bug, False)
+
+    def secondary_outcome(arm, fid, sid, t):
+        return secondary[arm].get(fid, {}).get(t, {}).get(sid, False)
+
+    # Per-trial per-arm primary pass-rate (for the paired deltas).
+    per_trial_rate: dict = {a: [] for a in _ARMS}
+    for arm in _ARMS:
+        for t in range(1, trials + 1):
+            passes = sum(1 for fid in fixtures_in_run
+                         for bug in bugs_by_fixture.get(fid, [])
+                         if primary_outcome(arm, fid, bug, t))
+            per_trial_rate[arm].append(_rate(passes, K))
+
+    # Majority-collapsed per-arm primary rate + per-fixture + off-axis.
+    arm_pass: dict = {a: 0 for a in _ARMS}
+    off_pass: dict = {a: 0 for a in _ARMS}
+    per_fixture_pass: dict = {a: {fid: 0 for fid in fixtures_in_run} for a in _ARMS}
+    off_total = sum(1 for b in all_bugs if bug_off.get(b))
+    for arm in _ARMS:
+        for fid in fixtures_in_run:
+            for bug in bugs_by_fixture.get(fid, []):
+                outs = [primary_outcome(arm, fid, bug, t)
+                        for t in range(1, trials + 1)]
+                if _majority_pass(outs):
+                    arm_pass[arm] += 1
+                    per_fixture_pass[arm][fid] += 1
+                    if bug_off.get(bug):
+                        off_pass[arm] += 1
+
+    # Secondary diagnostic (majority-collapsed over the secondary universe).
+    sec_universe = sorted(secondary_universe)
+    sec_pass: dict = {a: 0 for a in _ARMS}
+    for arm in _ARMS:
+        for (fid, sid) in sec_universe:
+            outs = [secondary_outcome(arm, fid, sid, t)
+                    for t in range(1, trials + 1)]
+            if _majority_pass(outs):
+                sec_pass[arm] += 1
+    graded_expectations = len(sec_universe)
+
+    arm_rates = {a: {"pass": arm_pass[a], "total": K,
+                     "rate": _rate(arm_pass[a], K)} for a in _ARMS}
+
+    deltas = {
+        "_note": ("paired = mean of per-trial deltas; does NOT equal "
+                  "rate_with - rate_without (per-arm rate is the "
+                  "majority-collapsed value)"),
+        "with_without": _delta_block(per_trial_rate["with"],
+                                     per_trial_rate["without"], with_beyond=True),
+        "with_mid": _delta_block(per_trial_rate["with"],
+                                 per_trial_rate["mid"], with_beyond=True),
+        "mid_without": _delta_block(per_trial_rate["mid"],
+                                    per_trial_rate["without"], with_beyond=False),
+    }
+
+    last_run = {
+        "run_id": run_id,
+        "trials": trials,
+        "fixtures": len(fixtures_in_run),
+        "complete": complete,
+        "graded_bugs": K,
+        "with": arm_rates["with"],
+        "mid": arm_rates["mid"],
+        "without": arm_rates["without"],
+        "deltas": deltas,
+        "malformed_verdicts": {a: malformed[a] for a in _ARMS},
+        "per_fixture": [
+            {"id": fid, **{a: _rate(per_fixture_pass[a][fid],
+                                    len(bugs_by_fixture.get(fid, [])))
+                           for a in _ARMS}}
+            for fid in fixtures_in_run
+        ],
+        "secondary_diagnostic": {
+            "graded_expectations": graded_expectations,
+            **{a: _rate(sec_pass[a], graded_expectations) for a in _ARMS},
+            # S-1: reconcile the OBSERVED secondary count against the documented
+            # 26-pool, but ONLY for a complete run over the full fixture set (the
+            # documented 26 = 27 − fixture-1 #8 is a whole-run construction). For a
+            # partial/smoke run the observed count is not the 26-pool, so we do not
+            # assert that provenance (contracted=None). Diagnostic only — never
+            # changes rc; score does NOT gate on the secondary count (round-3).
+            **(
+                {"contracted": _CONTRACTED_SECONDARY_POOL,
+                 "reconciled": graded_expectations == _CONTRACTED_SECONDARY_POOL}
+                if (complete and set(fixtures_in_run) == gt_fixture_ids)
+                else {"contracted": None}
+            ),
+        },
+        "off_axis_diagnostic": {
+            a: {"pass": off_pass[a], "total": off_total,
+                "rate": _rate(off_pass[a], off_total)} for a in _ARMS
+        },
+    }
+
+    (_EVALS_DIR / "last_run.json").write_text(
+        json.dumps(last_run, indent=2), encoding="utf-8")
+    (_EVALS_DIR / "results.md").write_text(_render_results(last_run), encoding="utf-8")
+    return 0
+
+
+def _render_results(lr: dict) -> str:
+    """Human-readable summary mirror of last_run.json (the go/no-go reads from
+    here too, so it carries the rate-vs-paired _note)."""
+    d = lr["deltas"]
+
+    def fmt(b):
+        _mde = b['mde_heuristic']
+        return (f"paired={b['paired']:+.3f} spread={b['trial_spread']} "
+                f"mde={'null' if _mde is None else _mde} "
+                + (f"beyond_spread={b['beyond_spread']}"
+                   if "beyond_spread" in b else ""))
+
+    lines = [
+        f"# Inquisitor eval — run {lr['run_id']}",
+        "",
+        f"- trials: {lr['trials']} · fixtures: {lr['fixtures']} · "
+        f"complete: {lr['complete']} · graded_bugs (K): {lr['graded_bugs']}",
+        "",
+        "## Per-arm pass rate (majority-collapsed)",
+        f"- WITH: {lr['with']['rate']:.3f} ({lr['with']['pass']}/{lr['with']['total']})",
+        f"- MID: {lr['mid']['rate']:.3f} ({lr['mid']['pass']}/{lr['mid']['total']})",
+        f"- WITHOUT: {lr['without']['rate']:.3f} "
+        f"({lr['without']['pass']}/{lr['without']['total']})",
+        "",
+        "## Paired deltas",
+        f"> NOTE: {d['_note']}",
+        f"- WITH-WITHOUT (primary): {fmt(d['with_without'])}",
+        f"- WITH-MID (fan-out): {fmt(d['with_mid'])}",
+        f"- MID-WITHOUT (scaffolding+procedure): {fmt(d['mid_without'])}",
+        "",
+        f"## Malformed verdicts (per arm): {lr['malformed_verdicts']}",
+        "",
+        "## Off-axis diagnostic (off_axis primary bugs only)",
+        f"- WITH: {lr['off_axis_diagnostic']['with']}",
+        f"- MID: {lr['off_axis_diagnostic']['mid']}",
+        f"- WITHOUT: {lr['off_axis_diagnostic']['without']}",
+        "",
+        "## Secondary diagnostic (observed secondary union)",
+        f"- graded_expectations: {_secondary_graded_label(lr)}",
+        f"- WITH/MID/WITHOUT: {lr['secondary_diagnostic']['with']:.3f} / "
+        f"{lr['secondary_diagnostic']['mid']:.3f} / "
+        f"{lr['secondary_diagnostic']['without']:.3f}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _secondary_graded_label(lr: dict) -> str:
+    """S-1: report the OBSERVED graded_expectations and, only when the run carries
+    the documented-pool provenance (a complete full-fixture run → contracted set),
+    surface reconciliation against the 26-pool. Never asserts the 26-provenance when
+    it does not hold (a partial/smoke run shows the bare observed count)."""
+    sd = lr["secondary_diagnostic"]
+    n = sd["graded_expectations"]
+    contracted = sd.get("contracted")
+    if contracted is None:
+        return str(n)
+    state = "reconciled" if sd.get("reconciled") else "MISMATCH"
+    return f"{n} (contracted {contracted}; {state})"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Inquisitor fan-out eval harness.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp_stage = sub.add_parser("stage", help="Render three-arm dispatch files")
+    sp_stage.add_argument("run_id")
+    sp_stage.add_argument("--trials", type=int, default=_DEFAULT_TRIALS)
+    sp_stage.add_argument("--fixture", default=None)
+    sp_stage.add_argument("--force", action="store_true")
+
+    sp_score = sub.add_parser("score", help="Aggregate verdicts + write last_run.json")
+    sp_score.add_argument("run_id")
+    sp_score.add_argument("--allow-incomplete", action="store_true")
+
+    return p.parse_args(argv)
+
+
+def main(argv: list | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    if args.cmd == "stage":
+        dispatch_dir = stage(args.run_id, trials=args.trials,
+                             fixture=args.fixture, force=args.force)
+        print(dispatch_dir)
+        return 0
+    if args.cmd == "score":
+        rc = score(args.run_id, allow_incomplete=args.allow_incomplete)
+        if rc == 0:
+            print((_EVALS_DIR / "last_run.json").read_text(encoding="utf-8"))
+        return rc
+    print(f"[fatal] unknown command {args.cmd!r}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/inquisitor/evals/test_run_evals_score.py
+++ b/skills/inquisitor/evals/test_run_evals_score.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""score() tests for the inquisitor fan-out eval harness (#424).
+
+stdlib unittest (D1). Builds synthetic manifests + judge-verdict files so the math
+is pinned precisely. The ground-truth file is written into the PATCHED _EVALS_DIR
+(F1) — score must resolve it at call time, else test_off_axis would silently read
+the real committed file and go green-but-vacuous.
+"""
+import json
+import math
+import os
+import pathlib
+import statistics
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.inquisitor.evals import run_evals  # noqa: E402
+
+
+class ScoreTestBase(unittest.TestCase):
+    def setUp(self):
+        self._dispatch_tmp = tempfile.TemporaryDirectory()
+        self._evals_tmp = tempfile.TemporaryDirectory()
+        self.evals_dir = pathlib.Path(self._evals_tmp.name)
+        self._env = mock.patch.dict(
+            os.environ,
+            {"XDG_RUNTIME_DIR": self._dispatch_tmp.name, "USER": "tester"})
+        self._env.start()
+        self._evd = mock.patch.object(run_evals, "_EVALS_DIR", self.evals_dir)
+        self._evd.start()
+
+    def tearDown(self):
+        self._evd.stop()
+        self._env.stop()
+        self._dispatch_tmp.cleanup()
+        self._evals_tmp.cleanup()
+
+    def make_run(self, run_id, trials, cells, ground_truth, *, collect=True):
+        """cells: list of (fixture_id, trial, arm, [records]). A record is a dict
+        {id,tag,verdict} (→ JSON line) or a raw str (→ malformed line)."""
+        dd = run_evals.resolve_dispatch_dir(run_id)
+        dd.mkdir(parents=True, exist_ok=True)
+        manifest_cells = []
+        for (fid, trial, arm, records) in cells:
+            rf = f"f{fid}-t{trial}-{arm}.jsonl"
+            lines = [r if isinstance(r, str) else json.dumps(r) for r in records]
+            (dd / rf).write_text(("\n".join(lines) + "\n") if lines else "",
+                                 encoding="utf-8")
+            manifest_cells.append({"fixture_id": fid, "trial": trial,
+                                   "arm": arm, "result_file": rf})
+        (dd / "stage-manifest.json").write_text(json.dumps(
+            {"run_id": run_id, "trials": trials, "cells": manifest_cells}))
+        if collect:
+            (dd / ".collect-status").write_text("complete")
+        (self.evals_dir / "ground-truth-bugs.json").write_text(
+            json.dumps(ground_truth))
+        return dd
+
+    def last_run(self):
+        return json.loads((self.evals_dir / "last_run.json").read_text())
+
+    @staticmethod
+    def prim(bug, verdict):
+        return {"id": bug, "tag": "primary", "verdict": verdict}
+
+    @staticmethod
+    def sec(sid, verdict):
+        return {"id": sid, "tag": "secondary", "verdict": verdict}
+
+
+class TestPairedDeltaMath(ScoreTestBase):
+    def test_paired_is_mean_of_per_trial_not_rate_diff(self):
+        """Test 3 (S1): WITH=[1,1,0], WITHOUT=[1,0,0] over 3 trials, 1 bug →
+        paired == 0.333 (mean of per-trial deltas), NOT 1.0 (majority-rate diff).
+        Also pins the mde_heuristic formula (F2)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        with_v = ["PASS", "PASS", "FAIL"]
+        without_v = ["PASS", "FAIL", "FAIL"]
+        cells = []
+        for t in (1, 2, 3):
+            cells.append((1, t, "with", [self.prim("f1-b1", with_v[t - 1])]))
+            cells.append((1, t, "without", [self.prim("f1-b1", without_v[t - 1])]))
+            cells.append((1, t, "mid", [self.prim("f1-b1", "FAIL")]))
+        rc = run_evals.score(self.make_run("run3", 3, cells, gt) and "run3")
+        self.assertEqual(rc, 0)
+        lr = self.last_run()
+        d = lr["deltas"]["with_without"]
+        self.assertAlmostEqual(d["paired"], 1 / 3, places=9)
+        self.assertNotAlmostEqual(d["paired"], 1.0, places=6)
+        self.assertEqual(d["trial_spread"], [0.0, 1.0])
+        # the majority-collapsed rate diff IS 1.0 (and differs from paired)
+        self.assertEqual(lr["with"]["rate"], 1.0)
+        self.assertEqual(lr["without"]["rate"], 0.0)
+        # mde formula
+        expected_mde = 1.96 * statistics.stdev([0.0, 1.0, 0.0]) / math.sqrt(3)
+        self.assertAlmostEqual(d["mde_heuristic"], expected_mde, places=9)
+        # per-fixture majority rates
+        pf = {row["id"]: row for row in lr["per_fixture"]}
+        self.assertEqual(pf[1]["with"], 1.0)
+        self.assertEqual(pf[1]["without"], 0.0)
+        # the rate-vs-paired note is present (non-optional, S-3)
+        self.assertIn("_note", lr["deltas"])
+
+
+class TestTaggedUnionPartition(ScoreTestBase):
+    def test_single_judge_partition_populates_both(self):
+        """Test 3b (S-1): one verdict file carrying primary + secondary items
+        populates BOTH graded_bugs/deltas AND secondary_diagnostic, with
+        graded_expectations == 26."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        sec_records = [self.sec(f"expectation-{i}",
+                                "PASS" if i % 2 else "FAIL") for i in range(1, 27)]
+        cell_records = [self.prim("f1-b1", "PASS")] + sec_records
+        cells = [(1, 1, "with", cell_records),
+                 (1, 1, "mid", cell_records),
+                 (1, 1, "without", cell_records)]
+        run_evals.score(self.make_run("runb", 1, cells, gt) and "runb")
+        lr = self.last_run()
+        self.assertEqual(lr["graded_bugs"], 1)
+        self.assertEqual(lr["with"]["pass"], 1)              # primary partition
+        self.assertEqual(lr["secondary_diagnostic"]["graded_expectations"], 26)
+        self.assertIn("with", lr["secondary_diagnostic"])    # secondary partition
+
+
+class TestOffAxisDiagnostic(ScoreTestBase):
+    def test_off_axis_partition_over_subset(self):
+        """Test 3c (S-FIND-1 + F1): off_axis_diagnostic totals only the
+        off_axis:true primary bugs, read from the synthetic ground-truth in the
+        PATCHED _EVALS_DIR (not the real committed file)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": True},
+            {"bug_id": "f1-b2", "off_axis": False},
+            {"bug_id": "f1-b3", "off_axis": True}]}]}
+        with_rec = [self.prim("f1-b1", "PASS"), self.prim("f1-b2", "PASS"),
+                    self.prim("f1-b3", "FAIL")]
+        none_rec = [self.prim(b, "FAIL") for b in ("f1-b1", "f1-b2", "f1-b3")]
+        cells = [(1, 1, "with", with_rec),
+                 (1, 1, "mid", none_rec),
+                 (1, 1, "without", none_rec)]
+        run_evals.score(self.make_run("runc", 1, cells, gt) and "runc")
+        oa = self.last_run()["off_axis_diagnostic"]
+        self.assertEqual(oa["with"]["total"], 2)   # only off_axis bugs, NOT 3
+        self.assertEqual(oa["with"]["pass"], 1)    # f1-b1 PASS, f1-b3 FAIL
+        self.assertEqual(oa["with"]["rate"], 0.5)
+        self.assertEqual(oa["without"]["total"], 2)
+
+
+class TestTieRule(ScoreTestBase):
+    def test_even_n_tie_resolves_to_fail(self):
+        """Test 4 (M1): a 1-1 per-bug majority tie over 2 trials → FAIL."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", [self.prim("f1-b1", "PASS")]),
+                 (1, 2, "with", [self.prim("f1-b1", "FAIL")]),
+                 (1, 1, "mid", [self.prim("f1-b1", "FAIL")]),
+                 (1, 2, "mid", [self.prim("f1-b1", "FAIL")]),
+                 (1, 1, "without", [self.prim("f1-b1", "FAIL")]),
+                 (1, 2, "without", [self.prim("f1-b1", "FAIL")])]
+        run_evals.score(self.make_run("runt", 2, cells, gt) and "runt")
+        self.assertEqual(self.last_run()["with"]["rate"], 0.0)  # tie → FAIL
+
+
+class TestCollectStatusGating(ScoreTestBase):
+    def _trivial(self, collect):
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, a, [self.prim("f1-b1", "FAIL")])
+                 for a in ("with", "mid", "without")]
+        return self.make_run("rung", 1, cells, gt, collect=collect)
+
+    def test_refuses_without_status(self):
+        """Test 5: score returns non-zero without .collect-status and no flag."""
+        self._trivial(collect=False)
+        self.assertEqual(run_evals.score("rung", allow_incomplete=False), 1)
+
+    def test_allow_incomplete_stamps_false(self):
+        self._trivial(collect=False)
+        self.assertEqual(run_evals.score("rung", allow_incomplete=True), 0)
+        self.assertFalse(self.last_run()["complete"])
+
+    def test_complete_run_stamps_true(self):
+        self._trivial(collect=True)
+        self.assertEqual(run_evals.score("rung", allow_incomplete=False), 0)
+        self.assertTrue(self.last_run()["complete"])
+
+
+class TestBeyondSpread(ScoreTestBase):
+    def test_beyond_spread_logic_helper(self):
+        """Test 6: beyond_spread iff band excludes zero AND |mean| >= 0.05."""
+        self.assertTrue(run_evals._beyond_spread([1.0, 1.0, 1.0], 1.0))
+        self.assertFalse(run_evals._beyond_spread([1.0, -1.0, 1.0], 1 / 3))  # straddle
+        self.assertFalse(run_evals._beyond_spread([0.04, 0.04, 0.04], 0.04))  # |mean|<eps
+        self.assertFalse(run_evals._beyond_spread([0.0, 0.1, 0.2], 0.1))      # band touches 0
+
+    def test_beyond_spread_end_to_end_positive(self):
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = []
+        for t in (1, 2, 3):
+            cells.append((1, t, "with", [self.prim("f1-b1", "PASS")]))
+            cells.append((1, t, "without", [self.prim("f1-b1", "FAIL")]))
+            cells.append((1, t, "mid", [self.prim("f1-b1", "FAIL")]))
+        run_evals.score(self.make_run("runbs", 3, cells, gt) and "runbs")
+        self.assertTrue(self.last_run()["deltas"]["with_without"]["beyond_spread"])
+
+    def test_trial_count_floor(self):
+        """Test 6b (S2): a 1-trial run forces beyond_spread False even when the
+        single delta >= eps and the degenerate point 'excludes zero', and even
+        though the run is complete:true."""
+        self.assertFalse(run_evals._beyond_spread([1.0], 1.0))
+        self.assertFalse(run_evals._beyond_spread([1.0, 1.0], 1.0))
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", [self.prim("f1-b1", "PASS")]),
+                 (1, 1, "without", [self.prim("f1-b1", "FAIL")]),
+                 (1, 1, "mid", [self.prim("f1-b1", "FAIL")])]
+        run_evals.score(self.make_run("run1", 1, cells, gt) and "run1")
+        lr = self.last_run()
+        self.assertTrue(lr["complete"])
+        self.assertFalse(lr["deltas"]["with_without"]["beyond_spread"])
+        self.assertIsNone(lr["deltas"]["with_without"]["mde_heuristic"])  # trials<2
+
+
+class TestCoverageGuard(ScoreTestBase):
+    """S1: score must refuse a misconfigured/partial-coverage run instead of
+    false-greening it as a clean 'no methodology effect' null with complete:true."""
+
+    def test_uncovered_fixture_returns_nonzero_no_complete(self):
+        """Manifest stages fixture 1; ground-truth lists only fixture 99 → K=0 via
+        zero coverage. score must return non-zero and NOT write a complete:true
+        last_run.json (the original false-green: exit 0, complete:true, all deltas
+        0.0)."""
+        gt = {"fixtures": [{"id": 99, "bugs": [
+            {"bug_id": "f99-b1", "off_axis": False}]}]}
+        cells = [(1, 1, a, [self.prim("f1-b1", "FAIL")])
+                 for a in ("with", "mid", "without")]
+        rc = run_evals.score(self.make_run("runcov", 1, cells, gt) and "runcov")
+        self.assertNotEqual(rc, 0)
+        # no complete:true last_run.json written
+        lr_path = self.evals_dir / "last_run.json"
+        if lr_path.exists():
+            self.assertNotEqual(
+                json.loads(lr_path.read_text()).get("complete"), True)
+
+    def test_partial_coverage_returns_nonzero(self):
+        """Run stages fixtures {1,2}; ground-truth covers only {1} → fixture 2 is
+        uncovered. score must return non-zero (not silently drop fixture 2 from K)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = []
+        for fid in (1, 2):
+            for a in ("with", "mid", "without"):
+                cells.append((fid, 1, a, [self.prim(f"f{fid}-b1", "FAIL")]))
+        rc = run_evals.score(self.make_run("runpart", 1, cells, gt) and "runpart")
+        self.assertNotEqual(rc, 0)
+
+
+class TestMalformedVerdicts(ScoreTestBase):
+    def test_malformed_counted_per_arm_and_graded_fail(self):
+        """A malformed line is counted per arm and the missing item grades FAIL."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", ["{not json"]),
+                 (1, 1, "mid", [self.prim("f1-b1", "FAIL")]),
+                 (1, 1, "without", [self.prim("f1-b1", "FAIL")])]
+        run_evals.score(self.make_run("runm", 1, cells, gt) and "runm")
+        lr = self.last_run()
+        self.assertEqual(lr["malformed_verdicts"]["with"], 1)
+        self.assertEqual(lr["with"]["pass"], 0)  # missing record → FAIL
+
+
+class TestCollectionPresenceGuard(ScoreTestBase):
+    """S-1: score must refuse a `complete` run whose every result_file is
+    missing/empty/dispatch-failed instead of false-greening it as a tidy
+    complete:true zero-delta null (mirror TestCoverageGuard)."""
+
+    def test_all_empty_complete_run_returns_nonzero_no_complete(self):
+        """.collect-status present, but every cell result_file is empty → zero
+        verdicts parsed. score must return non-zero and leave no complete:true
+        last_run.json (the original false-green: exit 0, complete:true, all 0.0)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        # empty record lists → make_run writes empty result files; collect=True
+        # stamps .collect-status.
+        cells = [(1, 1, a, []) for a in ("with", "mid", "without")]
+        rc = run_evals.score(self.make_run("runempty", 1, cells, gt) and "runempty")
+        self.assertNotEqual(rc, 0)
+        lr_path = self.evals_dir / "last_run.json"
+        if lr_path.exists():
+            self.assertNotEqual(
+                json.loads(lr_path.read_text()).get("complete"), True)
+
+    def test_partial_collection_returns_nonzero(self):
+        """One cell collected, the rest empty → partial collection. A complete run
+        must refuse rather than grade the absent cells FAIL-by-absence."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", [self.prim("f1-b1", "PASS")]),
+                 (1, 1, "mid", []),
+                 (1, 1, "without", [])]
+        rc = run_evals.score(self.make_run("runpartcol", 1, cells, gt) and "runpartcol")
+        self.assertNotEqual(rc, 0)
+
+    def test_dispatch_error_cell_returns_nonzero(self):
+        """A cell whose result_file is a DISPATCH_STATUS: ERROR sentinel (S-2) is a
+        dispatch failure — score must refuse the complete run (S-1 ∩ S-2)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", [self.prim("f1-b1", "PASS")]),
+                 (1, 1, "mid", [self.prim("f1-b1", "PASS")]),
+                 (1, 1, "without",
+                  ["DISPATCH_STATUS: ERROR: subagent timed out"])]
+        rc = run_evals.score(self.make_run("runerr", 1, cells, gt) and "runerr")
+        self.assertNotEqual(rc, 0)
+
+    def test_allow_incomplete_does_not_trigger_guard(self):
+        """The presence guard is a `complete`-run assertion; --allow-incomplete
+        (a smoke/debug score) must still run on an all-empty set."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, a, []) for a in ("with", "mid", "without")]
+        self.make_run("runsmoke", 1, cells, gt, collect=False)
+        self.assertEqual(
+            run_evals.score("runsmoke", allow_incomplete=True), 0)
+        self.assertFalse(self.last_run()["complete"])
+
+
+class TestUnderEmissionGuard(ScoreTestBase):
+    """F-1: score must refuse a `complete` run whose cells emit FEWER primary
+    records than the fixture's ground-truth primary budget — every omitted bug
+    grades FAIL-by-absence in all arms equally, collapsing the deltas to a
+    false-green 0.0 null with complete:true (mirror TestCollectionPresenceGuard)."""
+
+    def test_under_emitting_complete_run_returns_nonzero_no_complete(self):
+        """K=3 GT, but each cell carries a single valid primary record → 1 < 3
+        under-emission. score must return non-zero and leave no complete:true
+        last_run.json (the original false-green: rc 0, complete:true, deltas 0.0)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False},
+            {"bug_id": "f1-b2", "off_axis": False},
+            {"bug_id": "f1-b3", "off_axis": False}]}]}
+        cells = [(1, 1, a, [self.prim("f1-b1", "FAIL")])
+                 for a in ("with", "mid", "without")]
+        rc = run_evals.score(self.make_run("rununder", 1, cells, gt) and "rununder")
+        self.assertNotEqual(rc, 0)
+        lr_path = self.evals_dir / "last_run.json"
+        if lr_path.exists():
+            self.assertNotEqual(
+                json.loads(lr_path.read_text()).get("complete"), True)
+
+    def test_malformed_present_round5_case_still_scores(self):
+        """Round-5 contract preserved: a K=1 cell with one malformed line (0 parsed
+        primary, mal=1) is NOT under-emission (0 + 1 >= 1) — it still scores with
+        malformed=1, pass=0. Distinct from didn't-collect."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", ["{not json"]),
+                 (1, 1, "mid", [self.prim("f1-b1", "FAIL")]),
+                 (1, 1, "without", [self.prim("f1-b1", "FAIL")])]
+        rc = run_evals.score(self.make_run("runmal5", 1, cells, gt) and "runmal5")
+        self.assertEqual(rc, 0)
+        lr = self.last_run()
+        self.assertEqual(lr["malformed_verdicts"]["with"], 1)
+        self.assertEqual(lr["with"]["pass"], 0)
+
+
+class TestIdDriftGuard(ScoreTestBase):
+    """S-1: score must refuse a `complete` run whose cells emit well-formed primary
+    records (mal=0) under ids that are NOT members of ground-truth — every
+    ground-truth bug is looked up by id, found absent, and grades FAIL-by-absence in
+    all arms equally, collapsing the deltas to a false-green 0.0 null with
+    complete:true. The under-emission budget counts only gt-id-matched primary
+    records, so id-drift falls short of K and is refused (mirror
+    TestUnderEmissionGuard)."""
+
+    def test_full_id_drift_complete_run_returns_nonzero_no_complete(self):
+        """K=2 GT (f1-b1/f1-b2); WITH judges both PASS, WITHOUT both FAIL (maximal
+        real effect); but the judge echoes bug-1/bug-2. mal=0, records parse cleanly.
+        Pre-fix: paired 0.0, complete:true, rc 0. score must now return non-zero and
+        leave no complete:true last_run.json."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False},
+            {"bug_id": "f1-b2", "off_axis": False}]}]}
+        cells = [
+            (1, 1, "with", [self.prim("bug-1", "PASS"), self.prim("bug-2", "PASS")]),
+            (1, 1, "mid", [self.prim("bug-1", "FAIL"), self.prim("bug-2", "FAIL")]),
+            (1, 1, "without",
+             [self.prim("bug-1", "FAIL"), self.prim("bug-2", "FAIL")])]
+        rc = run_evals.score(self.make_run("rundrift", 1, cells, gt) and "rundrift")
+        self.assertNotEqual(rc, 0)
+        lr_path = self.evals_dir / "last_run.json"
+        if lr_path.exists():
+            self.assertNotEqual(
+                json.loads(lr_path.read_text()).get("complete"), True)
+
+    def test_partial_id_drift_complete_run_returns_nonzero_no_complete(self):
+        """K=2 GT; one correct id (f1-b1) + one drifted (bug-2), mal=0 → gt-matched
+        primary = 1 < 2 → refused (more robust than a bare empty-intersection
+        assert)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False},
+            {"bug_id": "f1-b2", "off_axis": False}]}]}
+        cells = [
+            (1, 1, a, [self.prim("f1-b1", "FAIL"), self.prim("bug-2", "FAIL")])
+            for a in ("with", "mid", "without")]
+        rc = run_evals.score(
+            self.make_run("rundriftp", 1, cells, gt) and "rundriftp")
+        self.assertNotEqual(rc, 0)
+        lr_path = self.evals_dir / "last_run.json"
+        if lr_path.exists():
+            self.assertNotEqual(
+                json.loads(lr_path.read_text()).get("complete"), True)
+
+    def test_extra_hallucinated_id_does_not_refuse(self):
+        """K=2 GT, both correct (f1-b1/f1-b2) + one extra hallucinated id (bug-99),
+        mal=0 → gt-matched primary = 2 >= 2 → NOT refused. Extra ids are harmless:
+        the blind-anchored K ignores them. score returns 0 and stamps complete."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False},
+            {"bug_id": "f1-b2", "off_axis": False}]}]}
+        cells = [(1, 1, a, [self.prim("f1-b1", "PASS"), self.prim("f1-b2", "PASS"),
+                            self.prim("bug-99", "PASS")])
+                 for a in ("with", "mid", "without")]
+        rc = run_evals.score(self.make_run("runextra", 1, cells, gt) and "runextra")
+        self.assertEqual(rc, 0)
+        self.assertTrue(self.last_run()["complete"])
+
+
+class TestGridCompletenessGuard(ScoreTestBase):
+    """S1: score must assert the realized (arm × fixture × trial) cell grid is
+    complete for a `complete` run. A manifest that under-enumerates cells (missing
+    arm/trial), over-states `trials`, or sets `trials:0` false-greens a wrong delta
+    with complete:true — refuse before writing last_run.json. --allow-incomplete is
+    exempt (mirror TestCollectionPresenceGuard)."""
+
+    def test_missing_arm_returns_nonzero_no_false_green(self):
+        """Manifest lists ONLY the WITH cell for f1-t1 (no mid/without). Pre-fix:
+        rc 0, complete:true, WITH−WITHOUT paired=+1.0 maximal false-green. score
+        must now return non-zero and NOT write a complete:true last_run.json."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", [self.prim("f1-b1", "PASS")])]
+        rc = run_evals.score(self.make_run("rungrid1", 1, cells, gt) and "rungrid1")
+        self.assertNotEqual(rc, 0)
+        lr_path = self.evals_dir / "last_run.json"
+        if lr_path.exists():
+            lr = json.loads(lr_path.read_text())
+            self.assertNotEqual(lr.get("complete"), True)
+            # the +1.0 false headline delta must NOT have been produced
+            self.assertNotIn("deltas", lr)
+
+    def test_over_stated_trials_returns_nonzero(self):
+        """trials=3 but only trial-1 cells present → trials 2,3 are missing for
+        every arm. score must refuse (phantom all-FAIL trials would dilute the
+        delta)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, a, [self.prim("f1-b1", "PASS")])
+                 for a in ("with", "mid", "without")]
+        rc = run_evals.score(self.make_run("rungrid2", 3, cells, gt) and "rungrid2")
+        self.assertNotEqual(rc, 0)
+
+    def test_trials_zero_returns_nonzero(self):
+        """trials=0 → range(1,1) empty, _majority_pass([]) False → all-zero
+        false-green. score must refuse the degenerate trial count."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, a, [self.prim("f1-b1", "PASS")])
+                 for a in ("with", "mid", "without")]
+        rc = run_evals.score(self.make_run("rungrid0", 0, cells, gt) and "rungrid0")
+        self.assertNotEqual(rc, 0)
+
+    def test_valid_full_grid_still_scores(self):
+        """Regression guard: a complete full 3-arm × all-trials grid still returns
+        0 with complete:true (the guard must not reject a correctly-staged run)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = []
+        for t in (1, 2):
+            for a in ("with", "mid", "without"):
+                cells.append((1, t, a, [self.prim("f1-b1", "PASS")]))
+        rc = run_evals.score(self.make_run("rungridok", 2, cells, gt) and "rungridok")
+        self.assertEqual(rc, 0)
+        self.assertTrue(self.last_run()["complete"])
+
+    def test_duplicate_cell_returns_nonzero(self):
+        """The same (arm, fid, trial) listed twice is a manifest-shape error → the
+        grid-completeness assertion refuses it."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, a, [self.prim("f1-b1", "PASS")])
+                 for a in ("with", "mid", "without")]
+        cells.append((1, 1, "with", [self.prim("f1-b1", "PASS")]))  # dup WITH cell
+        rc = run_evals.score(self.make_run("rungriddup", 1, cells, gt) and "rungriddup")
+        self.assertNotEqual(rc, 0)
+
+    def test_allow_incomplete_partial_grid_still_scores(self):
+        """The grid guard is a `complete`-run assertion; --allow-incomplete (a
+        smoke/debug score) may legitimately score a partial grid — here only the
+        WITH cell for f1-t1, which would be refused under complete."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        cells = [(1, 1, "with", [self.prim("f1-b1", "PASS")])]
+        self.make_run("rungridsmoke", 1, cells, gt, collect=False)
+        self.assertEqual(
+            run_evals.score("rungridsmoke", allow_incomplete=True), 0)
+        self.assertFalse(self.last_run()["complete"])
+
+
+class TestSecondaryReconciliation(ScoreTestBase):
+    """S-1: a full-fixture complete run whose observed secondary count differs from
+    the documented 26-pool stamps a visible reconciliation (contracted/reconciled)
+    in last_run.json — diagnostic only, rc stays 0 (score does NOT gate on it)."""
+
+    def test_under_26_secondary_stamps_mismatch_but_returns_zero(self):
+        """A full-fixture (single-fixture GT, fully covered) complete run grading
+        fewer than 26 secondary records stamps contracted=26 + reconciled=False and
+        STILL returns 0 — the secondary count is a diagnostic, not a gate."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        sec_records = [self.sec(f"expectation-{i}", "PASS") for i in range(1, 4)]
+        cell_records = [self.prim("f1-b1", "PASS")] + sec_records  # 3 secondary < 26
+        cells = [(1, 1, a, cell_records) for a in ("with", "mid", "without")]
+        rc = run_evals.score(self.make_run("runrec", 1, cells, gt) and "runrec")
+        self.assertEqual(rc, 0)                                   # diagnostic, not a gate
+        sd = self.last_run()["secondary_diagnostic"]
+        self.assertEqual(sd["graded_expectations"], 3)
+        self.assertEqual(sd["contracted"], run_evals._CONTRACTED_SECONDARY_POOL)
+        self.assertFalse(sd["reconciled"])
+
+
+class TestDispatchStatusSentinel(ScoreTestBase):
+    """S-2: the README collect contract writes each result_file using the
+    `DISPATCH_STATUS: OK\\n\\n<body>` sentinel. _parse_verdict_file must consume the
+    sentinel without counting it malformed (the documented file shape the unit
+    tests bypass)."""
+
+    def test_ok_sentinel_parses_with_zero_malformed(self):
+        """A result file in the documented DISPATCH_STATUS: OK\\n\\n<JSONL> shape
+        parses its verdicts with malformed == 0 (the sentinel line is consumed,
+        NOT counted malformed — the per-cell inflation the README contract caused)."""
+        gt = {"fixtures": [{"id": 1, "bugs": [
+            {"bug_id": "f1-b1", "off_axis": False}]}]}
+        # Build cells normally, then overwrite each result_file with the documented
+        # DISPATCH_STATUS: OK sentinel prefix in front of the JSONL body.
+        cells = [(1, 1, a, [self.prim("f1-b1", "PASS")])
+                 for a in ("with", "mid", "without")]
+        dd = self.make_run("runok", 1, cells, gt)
+        manifest = json.loads((dd / "stage-manifest.json").read_text())
+        for c in manifest["cells"]:
+            rf = dd / c["result_file"]
+            body = rf.read_text()
+            rf.write_text("DISPATCH_STATUS: OK\n\n" + body, encoding="utf-8")
+        rc = run_evals.score("runok")
+        self.assertEqual(rc, 0)
+        lr = self.last_run()
+        # sentinel consumed, not counted malformed
+        self.assertEqual(lr["malformed_verdicts"],
+                         {"with": 0, "mid": 0, "without": 0})
+        # the real verdict still parsed (PASS)
+        self.assertEqual(lr["with"]["pass"], 1)
+
+    def test_plain_jsonl_still_parses_unchanged(self):
+        """Backward-compat: a file with NO DISPATCH_STATUS sentinel (pure JSONL, as
+        make_run writes) still parses exactly as before — the sentinel handling is
+        consume-if-present, never require."""
+        p = pathlib.Path(self._dispatch_tmp.name) / "plain.jsonl"
+        p.write_text('{"id":"f1-b1","tag":"primary","verdict":"PASS"}\n',
+                     encoding="utf-8")
+        parsed, mal, failed = run_evals._parse_verdict_file(p)
+        self.assertEqual(mal, 0)
+        self.assertFalse(failed)
+        self.assertEqual(parsed[("primary", "f1-b1")], True)
+
+    def test_error_sentinel_is_dispatch_failure(self):
+        """A DISPATCH_STATUS: ERROR first line → dispatch failure (no records, the
+        flag S-1's guard refuses on), with no malformed inflation."""
+        p = pathlib.Path(self._dispatch_tmp.name) / "err.jsonl"
+        p.write_text("DISPATCH_STATUS: ERROR: timed out\n", encoding="utf-8")
+        parsed, mal, failed = run_evals._parse_verdict_file(p)
+        self.assertTrue(failed)
+        self.assertEqual(parsed, {})
+        self.assertEqual(mal, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/inquisitor/evals/test_run_evals_stage.py
+++ b/skills/inquisitor/evals/test_run_evals_stage.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""stage() tests for the inquisitor fan-out eval harness (#424).
+
+stdlib unittest (D1 — pytest cannot gate in this repo). Invoked as a bare script
+by scripts/run_tests.sh, so bootstrap repo-root onto sys.path before importing the
+package (sys.path[0] is the script dir, not repo root).
+"""
+import os
+import pathlib
+import re
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.inquisitor.evals import run_evals  # noqa: E402
+
+
+class StageTestBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        # resolve_dispatch_dir uses XDG_RUNTIME_DIR (or /tmp) + USER; pin both so
+        # the dispatch dir lands inside the temp dir and is isolated per test.
+        self._env = mock.patch.dict(
+            os.environ, {"XDG_RUNTIME_DIR": self._tmp.name, "USER": "tester"})
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+        self._tmp.cleanup()
+
+
+class TestStageManifestCount(StageTestBase):
+    def test_manifest_count_3arm(self):
+        """Test 1: (6+1+1) per-cell dispatch files × fixtures × trials, plus the
+        two shared prompt files; the manifest enumerates the same per-cell count."""
+        trials = 2
+        dd = run_evals.stage("run-count", trials=trials)
+        import json
+        manifest = json.loads((dd / "stage-manifest.json").read_text())
+        n_fixtures = manifest["fixtures"]
+        self.assertEqual(manifest["trials"], trials)
+
+        cells = manifest["cells"]
+        # 3 arms per (fixture, trial)
+        self.assertEqual(len(cells), 3 * n_fixtures * trials)
+        with_cells = [c for c in cells if c["arm"] == "with"]
+        mid_cells = [c for c in cells if c["arm"] == "mid"]
+        wo_cells = [c for c in cells if c["arm"] == "without"]
+        self.assertTrue(all(len(c["dispatch_files"]) == 6 for c in with_cells))
+        self.assertTrue(all(len(c["dispatch_files"]) == 1 for c in mid_cells))
+        self.assertTrue(all(len(c["dispatch_files"]) == 1 for c in wo_cells))
+
+        per_cell_total = sum(len(c["dispatch_files"]) for c in cells)
+        self.assertEqual(per_cell_total, (6 + 1 + 1) * n_fixtures * trials)
+
+        # shared files present + on disk
+        self.assertEqual(manifest["shared_files"],
+                         ["aggregation-prompt.md", "judge-prompt.md"])
+        self.assertTrue((dd / "aggregation-prompt.md").exists())
+        self.assertTrue((dd / "judge-prompt.md").exists())
+
+        # .md dispatch files on disk = per-cell files + the 2 shared files
+        md_files = {p.name for p in dd.glob("*.md")}
+        self.assertEqual(len(md_files), per_cell_total + 2)
+
+
+class TestNeutralization(StageTestBase):
+    def test_without_instruction_is_neutral(self):
+        """Test 2: the WITHOUT instruction carries no dimension name, no fan-out."""
+        instr = run_evals.WITHOUT_PROMPT
+        for title in run_evals.DIMENSION_TITLES:
+            self.assertNotIn(title, instr)
+        self.assertNotIn("fan-out", instr.lower())
+
+        dd = run_evals.stage("run-neutral", trials=1, fixture=1)
+        wo = (dd / "f1-t1-without.md").read_text()
+        self.assertTrue(wo.startswith(instr))
+
+    def test_mid_has_all_lenses_and_aggregation(self):
+        """Test 2: the MID dispatch carries all 5 dimension names + the shared
+        aggregation framing."""
+        dd = run_evals.stage("run-mid", trials=1, fixture=1)
+        mid = (dd / "f1-t1-mid.md").read_text()
+        for title in run_evals.DIMENSION_TITLES:
+            self.assertIn(title, mid)
+        # the byte-identical aggregation framing is embedded
+        agg = run_evals._AGG_PROMPT.read_text()
+        self.assertIn("consolidated", agg)  # marker exists in the shared prompt
+        self.assertIn(agg.strip(), mid)
+
+    def test_mid_carries_with_procedural_scaffold(self):
+        """S1: the MID dispatch must carry the SAME per-dimension procedural
+        scaffold the WITH agents get (reused from _template_region), so WITH−MID
+        isolates ONLY the fan-out delivery mechanism — not the procedural prompt.
+        Asserts the persona, the `## Your Job` steps, the NOT-do guard, the
+        Report-Format marker, all 5 dimension titles, the aggregation framing, and
+        NO residual [DIMENSION_*] slot."""
+        dd = run_evals.stage("run-mid-scaffold", trials=1, fixture=1)
+        mid = (dd / "f1-t1-mid.md").read_text()
+        # procedural scaffold reused from the WITH template region
+        self.assertIn("relentless hunter", mid)            # persona
+        self.assertIn("## Your Job", mid)                  # 6-step procedure
+        self.assertIn("## What You Must NOT Do", mid)      # NOT-do guard
+        self.assertIn("## Report Format", mid)             # report shell
+        self.assertIn("INQUISITOR DIMENSION REPORT", mid)  # report header
+        # all 5 lens titles present (the all-five-dimensions swap)
+        for title in run_evals.DIMENSION_TITLES:
+            self.assertIn(title, mid)
+        # aggregation framing byte-identical to WITH's embedding
+        agg = run_evals._AGG_PROMPT.read_text()
+        self.assertIn(agg.strip(), mid)
+        # the single-dimension lens block was SWAPPED, not appended
+        self.assertNotIn("## Your Dimension:", mid)
+        # no residual single-dimension slot survives
+        self.assertEqual(run_evals._DIMENSION_SLOT_RE.findall(mid), [])
+
+    def test_mid_budget_is_per_dimension_scoped_and_with_unchanged(self):
+        """F1: WITH−MID must isolate ONLY the fan-out delivery mechanism, so the two
+        arms must carry EQUAL AGGREGATE output budget against the K-bug primary pool.
+
+        WITH's "3-5 vectors" / "no more than 5 tests" cap binds each of 5 parallel
+        agents (≈25 total); the SAME string copied verbatim into MID's single
+        all-dimensions agent caps it at ≈5 total — confounding the delta with a 5×
+        per-arm budget asymmetry. The rescoped MID expresses the cap PER DIMENSION
+        (per-dimension cap × 5 dimensions == WITH's 5 × per-agent cap), and drops
+        the incoherent single-agent "stay in your lane" line. WITH must keep its
+        per-agent cap unchanged (regression guard the fix did not bleed into WITH)."""
+        dd = run_evals.stage("run-mid-budget", trials=1, fixture=1)
+        mid = (dd / "f1-t1-mid.md").read_text()
+        # MID carries per-dimension / aggregate-scoped budget phrasing on both the
+        # attack-vector and the test-count budget lines.
+        self.assertIn("3-5 attack vectors per dimension", mid)
+        self.assertIn("up to ~25 total", mid)
+        self.assertIn("Do NOT describe more than 5 tests per dimension", mid)
+        # MID does NOT carry the bare single-agent stay-in-your-lane line.
+        self.assertNotIn("stay in", mid)
+        self.assertIn("Cross-dimension reasoning is expected", mid)
+
+        # WITH keeps the per-agent cap unchanged — the fix is render_mid-only.
+        wd = (dd / "f1-t1-with-dim1-wiring.md").read_text()
+        self.assertIn("**Identify 3-5 attack vectors** specific to your dimension",
+                      wd)
+        self.assertIn("Do NOT describe more than 5 tests", wd)
+        self.assertNotIn("per dimension", wd)  # WITH cap is NOT rescoped
+        self.assertIn("stay in", wd)           # WITH keeps its single-lane guard
+
+
+class TestSliceScopedParse(StageTestBase):
+    def setUp(self):
+        super().setUp()
+        self.template = run_evals._DIM_TEMPLATE.read_text()
+
+    def test_stray_header_outside_slice_ignored(self):
+        """Test 2b: a stray '### ' header OUTSIDE the Dimension Reference slice
+        does not perturb the parse — still exactly 5 blocks, correct titles."""
+        injected = self.template.replace(
+            "## Dimension Reference",
+            "### Stray Report-Format Header\n\nnoise\n\n## Dimension Reference", 1)
+        blocks = run_evals.parse_dimension_blocks(injected)
+        self.assertEqual([t for t, _ in blocks], run_evals.DIMENSION_TITLES)
+
+    def test_extra_block_inside_slice_raises(self):
+        """A 6th '### ' block INSIDE the slice fails the count assertion."""
+        injected = self.template.rstrip() + "\n\n### Bogus Dimension\n\n- noise\n"
+        with self.assertRaises(ValueError):
+            run_evals.parse_dimension_blocks(injected)
+
+    def test_count_preserving_title_swap_raises(self):
+        """A header-count-preserving rename (still 5 blocks, wrong title set) is
+        caught by the literal-title-set assertion (S3)."""
+        injected = self.template.replace("### Wiring", "### Plumbing", 1)
+        with self.assertRaises(ValueError):
+            run_evals.parse_dimension_blocks(injected)
+
+
+class TestWithRenderSlots(StageTestBase):
+    def test_no_residual_dimension_slot_and_question_matches(self):
+        """Test 2c: each rendered WITH dimension dispatch has no residual
+        [DIMENSION_*] slot, and its question matches the source Core question."""
+        dd = run_evals.stage("run-slots", trials=1, fixture=1)
+        blocks = run_evals.parse_dimension_blocks(
+            run_evals._DIM_TEMPLATE.read_text())
+        slot_re = re.compile(r"\[DIMENSION_[A-Z_]*\]")
+        for n, (title, block) in enumerate(blocks, 1):
+            slug = run_evals._slug(title)
+            text = (dd / f"f1-t1-with-dim{n}-{slug}.md").read_text()
+            self.assertEqual(slot_re.findall(text), [],
+                             f"residual slot in dim {title}")
+            fields = run_evals.extract_dimension_fields(title, block)
+            self.assertIn(fields["question"], text)
+            # the dimension name appears (report header + dimension section)
+            self.assertIn(title, text)
+
+    def test_validate_raises_on_underfilled_render(self):
+        """Test 2c: the _validate_rendered_prompt guard RAISES on a leftover slot."""
+        with self.assertRaises(ValueError):
+            run_evals._validate_rendered_prompt(
+                "a render with a leftover [DIMENSION_NAME] slot")
+        # a residual non-dimension [PASTE: slot also raises (S1)
+        with self.assertRaises(ValueError):
+            run_evals._validate_rendered_prompt(
+                "a render with a leftover [PASTE: project test conventions]")
+        # a fully-filled render does not raise
+        run_evals._validate_rendered_prompt("no slots here, all filled")
+
+    def test_no_residual_paste_slot_in_with_or_mid(self):
+        """S1: no unfilled [PASTE: slot survives into a WITH dimension render or
+        the MID render (an arm-asymmetric prompt confound — WITH/MID carrying a
+        dangling unfulfillable PASTE instruction the WITHOUT baseline lacks)."""
+        dd = run_evals.stage("run-paste", trials=1, fixture=1)
+        mid = (dd / "f1-t1-mid.md").read_text()
+        self.assertNotIn("[PASTE:", mid)
+        blocks = run_evals.parse_dimension_blocks(
+            run_evals._DIM_TEMPLATE.read_text())
+        for n, (title, _block) in enumerate(blocks, 1):
+            slug = run_evals._slug(title)
+            text = (dd / f"f1-t1-with-dim{n}-{slug}.md").read_text()
+            self.assertNotIn("[PASTE:", text,
+                             f"residual [PASTE: slot in dim {title}")
+
+
+class TestFixtureDiffWithSlotShapedTokens(StageTestBase):
+    """S1: _validate_rendered_prompt validates the slot-filled template BEFORE the
+    fixture diff is embedded (sentinel-consumed git-diff slot), so a fixture diff
+    that legitimately CONTAINS a `[DIMENSION_*]`- or `[PASTE:`-shaped token (plausible
+    in JS/TS or dispatch/template code-review fixtures) stages successfully instead of
+    false-tripping the residual-slot guard — and those tokens survive verbatim into
+    the rendered WITH-dimension and MID prompts (they are fixture content, not slots).
+    """
+
+    SYNTH = {
+        "id": "synth-slotshaped",
+        "prompt": (
+            "Feature under review: a config lookup.\n"
+            "+ const k = obj[DIMENSION_KEY];  // bracket-key access\n"
+            "+ // doc note: [PASTE: something] is a literal token here\n"
+        ),
+    }
+
+    def test_fixture_with_slot_shaped_tokens_stages_and_survives_verbatim(self):
+        with mock.patch.object(run_evals, "_load_fixtures",
+                               return_value=[self.SYNTH]):
+            # Must NOT raise (pre-fix this crashed with a misleading residual-slot
+            # / residual-[PASTE: error because the guard scanned the fixture bytes).
+            dd = run_evals.stage("run-slotshaped", trials=1, fixture="synth-slotshaped")
+
+        # the fixture's slot-shaped tokens survive verbatim in every WITH dim render
+        blocks = run_evals.parse_dimension_blocks(
+            run_evals._DIM_TEMPLATE.read_text())
+        for n, (title, _b) in enumerate(blocks, 1):
+            slug = run_evals._slug(title)
+            text = (dd / f"fsynth-slotshaped-t1-with-dim{n}-{slug}.md").read_text()
+            self.assertIn("obj[DIMENSION_KEY]", text)
+            self.assertIn("[PASTE: something]", text)
+            # no residual REAL git-diff slot remains (the sentinel round-tripped)
+            self.assertNotIn("[PASTE: git diff", text)
+
+        mid = (dd / "fsynth-slotshaped-t1-mid.md").read_text()
+        self.assertIn("obj[DIMENSION_KEY]", mid)
+        self.assertIn("[PASTE: something]", mid)
+        self.assertNotIn("[PASTE: git diff", mid)
+
+
+class TestFixtureOpenerNeutralized(StageTestBase):
+    """S-3: the evals.json skill-naming opener "Run the inquisitor against this
+    feature diff for …" must be neutralized in the embedded fixture content of ALL
+    THREE arms, so the methodology difference comes only from the arm scaffold and
+    the WITHOUT baseline is not primed with the methodology it is meant to lack."""
+
+    def test_helper_mirrors_provenance_neutralization(self):
+        """The helper reproduces the provenance build's exact substitution."""
+        self.assertEqual(
+            run_evals._neutralize_fixture_opener(
+                "Run the inquisitor against this feature diff for a new "
+                "'Scheduled Notifications' feature."),
+            "Feature under review: a new 'Scheduled Notifications' feature.")
+        # text without the opener is left untouched
+        self.assertEqual(
+            run_evals._neutralize_fixture_opener("Feature under review: x"),
+            "Feature under review: x")
+
+    def test_no_arm_names_the_inquisitor_and_without_is_neutral(self):
+        """No rendered arm (WITH dims, MID, WITHOUT) carries the skill-naming
+        opener, and the WITHOUT diff opens with the neutral framing."""
+        dd = run_evals.stage("run-opener", trials=1, fixture=1)
+        blocks = run_evals.parse_dimension_blocks(
+            run_evals._DIM_TEMPLATE.read_text())
+        rendered = []
+        for n, (title, _b) in enumerate(blocks, 1):
+            slug = run_evals._slug(title)
+            rendered.append((dd / f"f1-t1-with-dim{n}-{slug}.md").read_text())
+        rendered.append((dd / "f1-t1-mid.md").read_text())
+        wo = (dd / "f1-t1-without.md").read_text()
+        rendered.append(wo)
+        for text in rendered:
+            self.assertNotIn("Run the inquisitor", text)
+        # WITHOUT embeds the neutral framing (after the bare instruction + ## Diff)
+        self.assertIn("Feature under review: ", wo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/inquisitor/evals/test_runid.py
+++ b/skills/inquisitor/evals/test_runid.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""run-id validation re-assertion for the inquisitor eval harness (#424, test 7).
+
+stdlib unittest (D1). The validator is the copied _runid.validate_run_id; this
+re-asserts its I-9 behavior in inquisitor's own gating suite (the drift check pins
+the body, this pins the behavior).
+"""
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.inquisitor.evals import run_evals  # noqa: E402
+from skills.inquisitor.evals._runid import validate_run_id  # noqa: E402
+
+
+class TestRunIdValidation(unittest.TestCase):
+    def test_accepts_well_formed_ids(self):
+        for ok in ("run1", "2026-06-14T22-57-26", "abc_DEF-123", "_x"):
+            validate_run_id(ok)  # must not raise
+
+    def test_rejects_flag_like_and_traversal_unsafe(self):
+        for bad in ("-rf", "--force", "../escape", "a/b", "has space",
+                    "x" * 40, "", "a.b"):
+            with self.assertRaises(ValueError):
+                validate_run_id(bad)
+
+    def test_stage_rejects_bad_run_id(self):
+        with self.assertRaises(ValueError):
+            run_evals.stage("../escape")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes part of #424 (Phase 1 — identification breadth). Adds the inquisitor fan-out eval harness: a `with` / `mid` / `without` A/B measurement of whether the 5-parallel-dimension fan-out (+ aggregation) finds more cross-component bugs than a single sequential agent (`mid`) or no methodology (`without`). Mirrors temper's `stage`/`score` split.

## What this delivers (acceptance #1 staged, #2 mechanics, #5 tests)
- **stage** — renders the three arms from the real inquisitor prompt: `WITH` (5 single-dimension agents + 1 aggregation), `MID` (one agent, all 5 lenses, same procedural scaffold + aggregation framing), `WITHOUT` (neutral). Lens content single-sourced from the template (no duplication).
- **score** — ground-truth-anchored primary delta (blind-authored `ground-truth-bugs.json` + provenance) + paired / MDE / trial-spread + secondary & off-axis diagnostics.
- **4 CI guards** with selftest-proven teeth: helper-drift, judge-prompt contract, ground-truth provenance, secondary-count arithmetic.
- stdlib `unittest` suites wired into `scripts/run_tests.sh` (the CI source of truth).

## Quality gate: clean PASS after 11 rounds
Score trajectory `2,1,2,2,3,3,4,1,2,1,→0`. The gate caught **2 Fatals + several Significants** that would otherwise have shipped silently — all measurement-integrity defects. The toward-null false-green family (the harness's reason to exist) is now guarded in depth, each fail-loud before any artifact write and each unit-tested:
- arm-symmetry: `WITH−MID` isolates only the fan-out mechanism (MID's per-dimension output budget rescoped to match WITH's aggregate; fixture skill-opener neutralized across all arms);
- K==0 / uncovered / partial coverage; zero/partial/dispatch-failed collection; judge record **under-emission**; judge **id-drift** (id-matched budget); manifest **cell-grid completeness**;
- render validation runs pre-embed (sentinel) so fixture content can't trip it; judge-contract guard pins the non-comparative grading discipline.

## Deferred to post-merge (ratified split: mechanics now, numbers post-merge)
These require live Opus fan-out dispatches and are **not** in this PR:
- the live multi-arm run (populated deltas);
- recording the primary delta in `docs/evals.md` (#3);
- the #424 Phase-2 go/no-go log (#4).

A known architectural note for the go/no-go write-up: off-axis bugs are ~47% of the primary pool and dilute the headline full-pool `WITH−WITHOUT` delta toward zero — `score` already surfaces `off_axis_diagnostic` for decomposition, and the deferred `docs/evals.md` should report the on-axis/off-axis split prominently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)