### PR TITLE
feat(inquisitor): #424 Phase-1b execution-eval harness (4-arm, leave-one-out oracle, blind seeded fixtures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # The inquisitor Phase-1b eval harness (#424) shells out to `python3 -m
+      # pytest` from its oracle/fixture checks, so a clean CI env must provision
+      # pytest. Pinned to the version the harness was authored/validated against
+      # for reproducibility of the measurement instrument.
+      - run: python3 -m pip install "pytest==9.0.3"
       # Single source of truth: scripts/run_tests.sh runs the same suite
       # locally and in CI, so the two can never drift. Add suites there.
       - run: bash scripts/run_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,14 @@ tests/
 !skills/build/evals/fixtures/**/src/**
 !skills/build/evals/fixtures/**/tests/
 !skills/build/evals/fixtures/**/tests/**
+# Inquisitor Phase-1b evals likewise ship seeded repos whose src/ + tests/ ARE
+# the eval substrate (the oracle scores producer tests against them). Without
+# this exception the global src/ + tests/ ignores silently drop them and the
+# harness is empty on a clean checkout (CI red).
+!skills/inquisitor/evals/fixtures/**/src/
+!skills/inquisitor/evals/fixtures/**/src/**
+!skills/inquisitor/evals/fixtures/**/tests/
+!skills/inquisitor/evals/fixtures/**/tests/**
 # Vestigial Node scaffolding from the original `npm init`. Crucible has no
 # JS/TS source — tests are Python + bash via scripts/run_tests.sh. Do NOT
 # un-ignore these; `npm test` is not the gate (see CLAUDE.md "Running & testing").

--- a/scripts/check_fixture_gt_provenance.py
+++ b/scripts/check_fixture_gt_provenance.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Blind-boundary provenance check for the Phase-1b seeded-repo ground truth (#424, §3/§9).
+
+Invocation (from repo root):
+    python3 scripts/check_fixture_gt_provenance.py            # check the fixtures
+    python3 scripts/check_fixture_gt_provenance.py --selftest # built-in logic tests
+
+This is a NEW checker, distinct from scripts/check_ground_truth_provenance.py: the
+Phase-1 check hardcodes evals.json and asserts no-evals.json-prose, which is
+irrelevant to the Phase-1b seeded repos (they have no relationship to evals.json).
+The Phase-1b blind boundary is "blind to the **dimension taxonomy**" — a different
+leak set entirely. For each fixtures/<repo>/ this asserts:
+
+  (a) the provenance file leaks NONE of the lensed dimension titles or the four
+      arm/treatment names (the blind boundary held);
+  (b) every GT bug_id has a matching fixes/<id>.patch and exemplars/<id>.py, GT
+      fix_patch points at that patch, and GT bug_ids == manifest bug_ids;
+  (c) the off_axis tagging is recorded as a POST-BLIND pass by a DISJOINT role.
+
+Leak set (matched case-sensitively — these are the exact taxonomy/treatment
+spellings; ordinary lowercase prose like "with"/"integration" is NOT a leak):
+  dimension titles: Wiring / Integration / Edge Cases / State & Lifecycle / Regression
+  arm names:        WITH / POOL / MID / WITHOUT
+
+Stdlib only. Exit 0 clean / 1 on any violation.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+from skills.inquisitor.evals import _fixtures  # noqa: E402
+
+FIXTURES_DIR = ROOT / "skills/inquisitor/evals/fixtures"
+
+_DIM_TITLES = ("Wiring", "Integration", "Edge Cases", "State & Lifecycle", "Regression")
+_ARM_RE = re.compile(r"\b(WITH|WITHOUT|POOL|MID)\b")
+# (c): markers that record the post-blind, disjoint-role off_axis pass
+_POSTBLIND_MARKERS = ("off_axis", "post-blind", "disjoint")
+
+
+def leak_tokens(text: str) -> list:
+    """Return the dimension-taxonomy / arm-treatment tokens that leaked."""
+    found = [t for t in _DIM_TITLES if t in text]
+    found += sorted(set(_ARM_RE.findall(text)))
+    return found
+
+
+def check_provenance_text(text: str) -> list:
+    """(a) leak scan + (c) post-blind off_axis recording, over provenance text."""
+    violations = []
+    leaked = leak_tokens(text)
+    if leaked:
+        violations.append("blind boundary leaked taxonomy/treatment tokens: "
+                          + ", ".join(repr(t) for t in leaked))
+    missing = [m for m in _POSTBLIND_MARKERS if m not in text]
+    if missing:
+        violations.append("off_axis pass not recorded as post-blind/disjoint "
+                          f"(missing markers: {missing})")
+    return violations
+
+
+def check_correspondence(repo_dir) -> list:
+    """(b) GT bug_id <-> patch <-> exemplar <-> manifest correspondence."""
+    repo_dir = pathlib.Path(repo_dir)
+    violations = []
+    try:
+        manifest = _fixtures.load_manifest(repo_dir)
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as e:
+        return [f"manifest invalid: {e}"]
+    gt = json.loads((repo_dir / "ground-truth-bugs.json").read_text())
+    gt_ids = [b["bug_id"] for b in gt["bugs"]]
+    if gt_ids != manifest["bug_ids"]:
+        violations.append(f"GT bug_ids {gt_ids} != manifest bug_ids "
+                          f"{manifest['bug_ids']}")
+    for b in gt["bugs"]:
+        bid = b["bug_id"]
+        if not (repo_dir / "fixes" / f"{bid}.patch").exists():
+            violations.append(f"{bid}: missing fixes/{bid}.patch")
+        if not (repo_dir / "exemplars" / f"{bid}.py").exists():
+            violations.append(f"{bid}: missing exemplars/{bid}.py")
+        if b.get("fix_patch") != f"fixes/{bid}.patch":
+            violations.append(f"{bid}: GT fix_patch={b.get('fix_patch')!r} "
+                              f"!= 'fixes/{bid}.patch'")
+    return violations
+
+
+def check_repo(repo_dir) -> list:
+    repo_dir = pathlib.Path(repo_dir)
+    prov = repo_dir / "ground-truth-bugs.provenance.md"
+    gt = repo_dir / "ground-truth-bugs.json"
+    if not prov.exists():
+        return [f"missing {prov.name}"]
+    if not gt.exists():
+        return [f"missing {gt.name}"]
+    return check_provenance_text(prov.read_text()) + check_correspondence(repo_dir)
+
+
+def main() -> int:
+    repos = sorted(p for p in FIXTURES_DIR.glob("*")
+                   if (p / "manifest.json").exists()) if FIXTURES_DIR.exists() else []
+    if not repos:
+        print(f"OK — no seeded fixtures under {FIXTURES_DIR.relative_to(ROOT)} yet.")
+        return 0
+    any_fail = False
+    for repo in repos:
+        v = check_repo(repo)
+        if v:
+            any_fail = True
+            print(f"FAIL — {repo.name}:")
+            for s in v:
+                print(f"  - {s}")
+        else:
+            print(f"PASS — {repo.name} (blind boundary held; GT correspondence OK)")
+    return 1 if any_fail else 0
+
+
+def selftest() -> int:
+    import tempfile
+    failures = []
+
+    clean_prov = (
+        "Authored blind to the lensed dimension taxonomy and arm/treatment names.\n"
+        "off_axis flags applied in a post-blind pass by a disjoint role.\n")
+    if check_provenance_text(clean_prov):
+        failures.append(f"clean provenance should pass, got {check_provenance_text(clean_prov)}")
+
+    # leak: an arm token (uppercase, word-boundary)
+    if not leak_tokens(clean_prov + "the WITHOUT arm is the baseline\n"):
+        failures.append("WITHOUT leak not caught")
+    # leak: a dimension title (Title-case)
+    if "Wiring" not in leak_tokens(clean_prov + "this is a Wiring defect\n"):
+        failures.append("Wiring leak not caught")
+    # ordinary lowercase prose is NOT a leak
+    if leak_tokens("a job sent without a channel; integration of two modules\n"):
+        failures.append("lowercase prose falsely flagged as leak")
+    # (c): missing post-blind markers fails
+    if not check_provenance_text("authored from source only\n"):
+        failures.append("missing post-blind markers should fail")
+
+    # (b): synthetic repo correspondence
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = pathlib.Path(tmp) / "r"
+        (repo / "fixes").mkdir(parents=True)
+        (repo / "exemplars").mkdir(parents=True)
+        (repo / "fixes" / "x1.patch").write_text("")
+        (repo / "exemplars" / "x1.py").write_text("")
+        (repo / "manifest.json").write_text(json.dumps(
+            {"repo_id": "r", "pkg": "r", "test_dir": "tests",
+             "runner_cmd": ["python3", "-m", "pytest", "-q"],
+             "bug_ids": ["x1"], "n": 1}))
+        (repo / "ground-truth-bugs.json").write_text(json.dumps(
+            {"_provenance": "x", "bugs": [
+                {"bug_id": "x1", "desc": "d", "off_axis": False,
+                 "fix_patch": "fixes/x1.patch"}], "interacting_sets": []}))
+        if check_correspondence(repo):
+            failures.append(f"matching repo should pass (b), got {check_correspondence(repo)}")
+        # break correspondence: GT references a missing patch/exemplar
+        (repo / "ground-truth-bugs.json").write_text(json.dumps(
+            {"_provenance": "x", "bugs": [
+                {"bug_id": "x2", "desc": "d", "off_axis": False,
+                 "fix_patch": "fixes/x2.patch"}], "interacting_sets": []}))
+        if not check_correspondence(repo):
+            failures.append("mismatched bug_id should fail (b)")
+
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("SELFTEST OK — leak scan catches arm/dimension tokens (not lowercase "
+          "prose), post-blind markers required, GT correspondence enforced.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/check_fixture_independence.py
+++ b/scripts/check_fixture_independence.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Fixture behavioral-independence + patch-composition checker (#424 Phase 1b, §3/§9).
+
+Invocation (from repo root):
+    python3 scripts/check_fixture_independence.py            # check the real fixtures
+    python3 scripts/check_fixture_independence.py --selftest # built-in logic tests (toy repos)
+
+The load-bearing fixture invariant (design §3, S-A): for every seeded repo, every
+bug Bᵢ's exemplar test is
+
+    GREEN on all-fixed,  RED on the full-buggy base,
+    RED on its own all-fixed-minus-Bᵢ,  and
+    GREEN on every *other* all-fixed-minus-Bⱼ (j≠i)   [no co-violable pairs]
+
+plus the patch-composition invariants (M4): each fixes/<bug_id>.patch applies
+cleanly to base, all-fixed composes, every all-fixed-minus-Bᵢ applies cleanly, and
+each patch touches only its own bug's base lines (pairwise-disjoint hunk ranges).
+
+A genuinely co-violable pair that fixture construction could not avoid MUST be
+registered as an `interacting_set` in ground-truth; registered set-mates are
+exempted from the green-on-other-minus rule (only among themselves).
+
+Stdlib only. Exit 0 clean / 1 on any violation.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import re
+import shutil
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+from skills.inquisitor.evals import _fixtures  # noqa: E402
+
+FIXTURES_DIR = ROOT / "skills/inquisitor/evals/fixtures"
+
+_HUNK_RE = re.compile(r"@@ -(\d+)(?:,(\d+))? \+")
+
+
+def patch_touched_lines(patch_text: str) -> dict:
+    """Map each file -> set of base (old-side) line numbers the patch's hunks touch.
+
+    Presupposes patches are authored against the committed base (A3 HARD rule), so
+    the raw `@@ -s,l @@` ranges are directly comparable across patches (M4).
+    """
+    touched: dict = {}
+    cur = None
+    for line in patch_text.splitlines():
+        if line.startswith("+++ "):
+            path = line[4:].strip().split("\t")[0]
+            if path[:2] in ("a/", "b/"):
+                path = path[2:]
+            cur = path
+            touched.setdefault(cur, set())
+        elif line.startswith("@@") and cur is not None:
+            m = _HUNK_RE.search(line)
+            if m:
+                start = int(m.group(1))
+                length = int(m.group(2)) if m.group(2) else 1
+                touched[cur].update(range(start, start + length))
+    return touched
+
+
+def _mates(interacting_sets) -> dict:
+    """bug_id -> set of co-registered interacting-set mates."""
+    mate: dict = {}
+    for s in interacting_sets or ():
+        for b in s:
+            mate.setdefault(b, set()).update(x for x in s if x != b)
+    return mate
+
+
+def _run_matrix(repo_dir, manifest, exemplar) -> dict:
+    """Materialize each variant once, run every exemplar in it.
+
+    Returns {(variant_label, bug_id): verdict}; variant_label in
+    {"all-fixed", "base", "minus:<bid>"}. Raises on a patch-application failure
+    (surfaced as a violation by the caller).
+    """
+    bug_ids = manifest["bug_ids"]
+    verdicts: dict = {}
+    with _fixtures.variant(repo_dir, apply=bug_ids) as d:
+        for b in bug_ids:
+            verdicts[("all-fixed", b)] = _fixtures.run_test_in_dir(d, exemplar[b], manifest)
+    with _fixtures.variant(repo_dir, apply=[]) as d:
+        for b in bug_ids:
+            verdicts[("base", b)] = _fixtures.run_test_in_dir(d, exemplar[b], manifest)
+    for k in bug_ids:
+        with _fixtures.variant(repo_dir, apply=bug_ids, exclude=[k]) as d:
+            for b in bug_ids:
+                verdicts[(f"minus:{k}", b)] = _fixtures.run_test_in_dir(d, exemplar[b], manifest)
+    return verdicts
+
+
+def check_repo(repo_dir) -> list:
+    """Return a list of human-readable violation strings ([] == clean)."""
+    repo_dir = pathlib.Path(repo_dir)
+    violations: list = []
+    try:
+        manifest = _fixtures.load_manifest(repo_dir)
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as e:
+        return [f"manifest invalid: {e}"]
+    bug_ids = manifest["bug_ids"]
+
+    gt_path = repo_dir / "ground-truth-bugs.json"
+    gt = json.loads(gt_path.read_text()) if gt_path.exists() else {}
+    mate = _mates(gt.get("interacting_sets", []))
+
+    # exemplar + patch presence
+    exemplar = {}
+    for b in bug_ids:
+        ex = repo_dir / "exemplars" / f"{b}.py"
+        patch = repo_dir / "fixes" / f"{b}.patch"
+        if not ex.exists():
+            violations.append(f"missing exemplar: exemplars/{b}.py")
+        if not patch.exists():
+            violations.append(f"missing patch: fixes/{b}.patch")
+        exemplar[b] = ex
+    if violations:
+        return violations
+
+    # M4: each patch touches only its own bug's base lines (pairwise disjoint)
+    touched = {b: patch_touched_lines((repo_dir / "fixes" / f"{b}.patch").read_text())
+               for b in bug_ids}
+    for i in range(len(bug_ids)):
+        for j in range(i + 1, len(bug_ids)):
+            bi, bj = bug_ids[i], bug_ids[j]
+            for f in set(touched[bi]) & set(touched[bj]):
+                overlap = touched[bi][f] & touched[bj][f]
+                if overlap:
+                    violations.append(
+                        f"patch line overlap: {bi} and {bj} both touch "
+                        f"{f} lines {sorted(overlap)} (cross-bug coupling)")
+
+    # patch-composition: each patch applies to base; all-fixed + every minus compose
+    try:
+        for b in bug_ids:
+            d = _fixtures.materialize_variant(repo_dir, apply=[b]); _rm(d)
+        d = _fixtures.materialize_variant(repo_dir, apply=bug_ids); _rm(d)
+        for k in bug_ids:
+            d = _fixtures.materialize_variant(repo_dir, apply=bug_ids, exclude=[k]); _rm(d)
+    except (RuntimeError, FileNotFoundError) as e:
+        return violations + [f"patch composition failed: {e}"]
+
+    # behavioral matrix
+    try:
+        verdicts = _run_matrix(repo_dir, manifest, exemplar)
+    except (RuntimeError, FileNotFoundError) as e:
+        return violations + [f"variant materialization failed during matrix: {e}"]
+
+    for bi in bug_ids:
+        if verdicts[("all-fixed", bi)] != "GREEN":
+            violations.append(f"{bi}: exemplar not GREEN on all-fixed "
+                              f"(got {verdicts[('all-fixed', bi)]})")
+        if verdicts[("base", bi)] != "RED":
+            violations.append(f"{bi}: exemplar not RED on full-buggy base "
+                              f"(got {verdicts[('base', bi)]})")
+        if verdicts[(f"minus:{bi}", bi)] != "RED":
+            violations.append(f"{bi}: exemplar not RED on its own all-fixed-minus "
+                              f"(got {verdicts[(f'minus:{bi}', bi)]})")
+        for bj in bug_ids:
+            if bj == bi:
+                continue
+            if bj in mate.get(bi, set()):
+                continue  # registered interacting set-mate: exempt
+            if verdicts[(f"minus:{bj}", bi)] != "GREEN":
+                violations.append(
+                    f"co-violable pair ({bi}, {bj}): {bi}'s exemplar is "
+                    f"{verdicts[(f'minus:{bj}', bi)]} on all-fixed-minus-{bj} "
+                    f"(expected GREEN; register as an interacting_set if unavoidable)")
+    return violations
+
+
+def _rm(d):
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def main() -> int:
+    repos = sorted(p for p in FIXTURES_DIR.glob("*")
+                   if (p / "manifest.json").exists()) if FIXTURES_DIR.exists() else []
+    if not repos:
+        print(f"OK — no seeded fixtures under {FIXTURES_DIR.relative_to(ROOT)} yet.")
+        return 0
+    any_fail = False
+    for repo in repos:
+        violations = check_repo(repo)
+        if violations:
+            any_fail = True
+            print(f"FAIL — {repo.name}:")
+            for v in violations:
+                print(f"  - {v}")
+        else:
+            print(f"PASS — {repo.name} ({_fixtures.load_manifest(repo)['n']} "
+                  "independent bugs)")
+    return 1 if any_fail else 0
+
+
+# --------------------------------------------------------------------------- #
+# selftest — toy repos built inline (no real fixture)                          #
+# --------------------------------------------------------------------------- #
+
+_CONFTEST = (
+    "import pathlib, sys\n"
+    "sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / 'src'))\n"
+)
+
+
+def _diff(path, before_text, after_text):
+    """Generate a fuzz-0-applicable unified diff (real `diff -u`, a/ b/ headers)."""
+    import subprocess
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        a = pathlib.Path(d) / "a"
+        b = pathlib.Path(d) / "b"
+        a.write_text(before_text)
+        b.write_text(after_text)
+        out = subprocess.run(["diff", "-u", str(a), str(b)],
+                             capture_output=True, text=True).stdout
+    lines = out.splitlines()
+    return "\n".join([f"--- a/{path}", f"+++ b/{path}"] + lines[2:]) + "\n"
+
+
+def _build_repo(root: pathlib.Path, files: dict, fixes: dict, exemplars: dict,
+                manifest: dict, gt: dict):
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    (root / "tests").mkdir(exist_ok=True)
+    (root / "tests" / "conftest.py").write_text(_CONFTEST)
+    (root / "fixes").mkdir(exist_ok=True)
+    for bid, patch in fixes.items():
+        (root / "fixes" / f"{bid}.patch").write_text(patch)
+    (root / "exemplars").mkdir(exist_ok=True)
+    for bid, ex in exemplars.items():
+        (root / "exemplars" / f"{bid}.py").write_text(ex)
+    (root / "manifest.json").write_text(json.dumps(manifest))
+    (root / "ground-truth-bugs.json").write_text(json.dumps(gt))
+
+
+def selftest() -> int:
+    import tempfile
+    failures = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = pathlib.Path(tmp)
+
+        # --- GOOD repo: 2 independent bugs in disjoint files ---
+        good = tmp / "good"
+        _build_repo(
+            good,
+            files={
+                "src/toy/__init__.py": "",
+                "src/toy/m1.py": "def f():\n    return 1\n",
+                "src/toy/m2.py": "def g():\n    return 2\n",
+            },
+            fixes={
+                "b1": _diff("src/toy/m1.py", "def f():\n    return 1\n",
+                            "def f():\n    return 10\n"),
+                "b2": _diff("src/toy/m2.py", "def g():\n    return 2\n",
+                            "def g():\n    return 20\n"),
+            },
+            exemplars={
+                "b1": "from toy.m1 import f\n\ndef test_f():\n    assert f() == 10\n",
+                "b2": "from toy.m2 import g\n\ndef test_g():\n    assert g() == 20\n",
+            },
+            manifest={"repo_id": "good", "pkg": "toy", "test_dir": "tests",
+                      "runner_cmd": ["python3", "-m", "pytest", "-q"],
+                      "bug_ids": ["b1", "b2"], "n": 2},
+            gt={"bugs": [], "interacting_sets": []},
+        )
+        v = check_repo(good)
+        if v:
+            failures.append(f"GOOD repo should PASS, got violations: {v}")
+
+        # --- BAD repo: co-violable pair (one assertion fails if either unfixed).
+        #     base_a / base_b are deliberately well-SEPARATED so their patch hunks
+        #     are line-disjoint (M4 clean) — the only fault is behavioral. ---
+        _PAD = "_p1 = 0\n_p2 = 0\n_p3 = 0\n_p4 = 0\n_p5 = 0\n_p6 = 0\n"
+        combo_base = ("def base_a():\n    return 1\n\n" + _PAD +
+                      "\ndef base_b():\n    return 2\n\n"
+                      "def total():\n    return base_a() + base_b()\n")
+        combo_a = combo_base.replace("    return 1\n", "    return 10\n", 1)
+        combo_b = combo_base.replace("    return 2\n", "    return 20\n", 1)
+        bad_files = {"src/toy/__init__.py": "", "src/toy/combo.py": combo_base}
+        bad_fixes = {
+            "b3a": _diff("src/toy/combo.py", combo_base, combo_a),
+            "b3b": _diff("src/toy/combo.py", combo_base, combo_b),
+        }
+        coviolable_ex = {
+            "b3a": "from toy.combo import total\n\ndef test_a():\n    assert total() == 30\n",
+            "b3b": "from toy.combo import total\n\ndef test_b():\n    assert total() == 30\n",
+        }
+        bad = tmp / "bad"
+        _build_repo(bad, bad_files, bad_fixes, coviolable_ex,
+                    {"repo_id": "bad", "pkg": "toy", "test_dir": "tests",
+                     "runner_cmd": ["python3", "-m", "pytest", "-q"],
+                     "bug_ids": ["b3a", "b3b"], "n": 2},
+                    {"bugs": [], "interacting_sets": []})
+        v = check_repo(bad)
+        named = any("b3a" in s and "b3b" in s for s in v)
+        if not v or not named:
+            failures.append(f"BAD repo should FAIL naming (b3a,b3b), got: {v}")
+
+        # --- BAD repo, but pair REGISTERED as interacting_set -> PASS ---
+        reg = tmp / "reg"
+        _build_repo(reg, bad_files, bad_fixes, coviolable_ex,
+                    {"repo_id": "reg", "pkg": "toy", "test_dir": "tests",
+                     "runner_cmd": ["python3", "-m", "pytest", "-q"],
+                     "bug_ids": ["b3a", "b3b"], "n": 2},
+                    {"bugs": [], "interacting_sets": [["b3a", "b3b"]]})
+        v = check_repo(reg)
+        if v:
+            failures.append(f"REGISTERED interacting pair should PASS, got: {v}")
+
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("SELFTEST OK — independent pair PASSES, co-violable pair FAILS (named), "
+          "registered interacting_set is exempted.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/check_fixture_independence.py
+++ b/scripts/check_fixture_independence.py
@@ -176,9 +176,28 @@ def _rm(d):
     shutil.rmtree(d, ignore_errors=True)
 
 
+def _arg(flag):
+    args = sys.argv[1:]
+    if flag in args:
+        i = args.index(flag)
+        if i + 1 < len(args):
+            return args[i + 1]
+    return None
+
+
 def main() -> int:
-    repos = sorted(p for p in FIXTURES_DIR.glob("*")
-                   if (p / "manifest.json").exists()) if FIXTURES_DIR.exists() else []
+    only = _arg("--repo")
+    if only is not None:
+        repo = pathlib.Path(only)
+        if not (repo / "manifest.json").exists():
+            repo = FIXTURES_DIR / only
+        repos = [repo] if (repo / "manifest.json").exists() else []
+        if not repos:
+            print(f"FAIL — no manifest.json under {only!r}")
+            return 1
+    else:
+        repos = sorted(p for p in FIXTURES_DIR.glob("*")
+                       if (p / "manifest.json").exists()) if FIXTURES_DIR.exists() else []
     if not repos:
         print(f"OK — no seeded fixtures under {FIXTURES_DIR.relative_to(ROOT)} yet.")
         return 0

--- a/scripts/check_fixture_producer_blind.py
+++ b/scripts/check_fixture_producer_blind.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Producer-blindness CI guard for the Phase-1b seeded repos (#424, F1+F2).
+
+Invocation (from repo root):
+    python3 scripts/check_fixture_producer_blind.py            # check real fixtures
+    python3 scripts/check_fixture_producer_blind.py --selftest # built-in logic tests
+
+The score the live decision run produces is only meaningful if every producer arm
+is BLIND to the seeded-bug identities. Two leaks (both Fatal, both passing the
+GT-author provenance checker) would otherwise hand every arm the answer key and
+ceiling the WITH−WITHOUT delta:
+
+  F1 — the committed fixture `src/` annotates each bug with its id + a
+       plain-language description of the defect AND its fix (`# BUG nt-b8: …`,
+       `(nt-b1)`, `# … The fix coerces None to 0 …`); the prompts tell the agent
+       to read `src/`. Hiding only the id TOKEN (round-1) still handed every arm
+       the bug+fix in prose — the deeper, ceiling-inducing leak.
+  F2 — the old `copy_for` copytree'd the WHOLE fixture dir into the agent's
+       sandbox: `exemplars/` (passing tests per bug), `fixes/*.patch` (the exact
+       fixes), `ground-truth-bugs.json` (the blind bug list), `manifest.json`.
+
+`_fixtures.copy_repo_for_producer` is the fix: it copies only `src/` + `tests/`
+and strips ALL comments and docstrings from every copied producer-visible `*.py`
+(both subtrees, not `src/` alone — the complete F1 rule). This guard materializes a
+real producer copy for every seeded repo and asserts:
+  - (`_fixtures._assert_no_leak`) no answer-key path (`exemplars/`, `fixes/`,
+    `manifest.json`, `ground-truth-*`) survives, no bug-identity leak TOKEN survives
+    in any copied producer-visible `*.py` (`src/` AND `tests/`), and the copied
+    `tests/` holds nothing but `conftest.py` (the documented invariant); AND
+  - (`_fixtures.assert_no_description_leak`, ADVERSARIAL) no bug-DESCRIPTION prose
+    survives — loaded from each repo's `ground-truth-bugs.json`, it asserts no
+    >=N-word window of any bug `desc`, and no literal `"The fix"`, appears in any
+    copied producer-visible source (`src/` AND `tests/`). This check does NOT re-use
+    the strip's own regex (the round-1 circularity, S-1), so it independently FAILS
+    on the prose leak if the strip were reverted.
+It ALSO asserts the strip is behavior-preserving: every stripped `src/**/*.py`
+still imports/compiles (so de-annotation never changed code).
+
+This is the producer-side complement to check_fixture_gt_provenance.py (which only
+checks the GT *author*'s blindness). Stdlib only. Exit 0 clean / 1 on violation.
+"""
+from __future__ import annotations
+import ast
+import compileall
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import tokenize
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+from skills.inquisitor.evals import _fixtures  # noqa: E402
+
+FIXTURES_DIR = ROOT / "skills/inquisitor/evals/fixtures"
+
+
+def _gt_descs(repo_dir) -> list:
+    gt_path = pathlib.Path(repo_dir) / "ground-truth-bugs.json"
+    if not gt_path.exists():
+        return []
+    gt = json.loads(gt_path.read_text(encoding="utf-8"))
+    return [b["desc"] for b in gt.get("bugs", []) if b.get("desc")]
+
+
+def _runtime_string_leak_tokens(repo_dir) -> list:
+    """M-3 guard: a leak token (`_LEAK_RE`) inside a NON-docstring STRING literal in
+    the committed `src/` is a hazard — the strip deliberately does NOT rewrite
+    runtime strings (they are data), so such a token would survive into the copy
+    AND the strip would have no safe way to scrub it without changing behavior.
+    Today there are none (the leak prose lives only in comments/docstrings); this
+    fails loud if a future fixture introduces one. Returns a list of violations."""
+    violations = []
+    for py in sorted((pathlib.Path(repo_dir) / "src").rglob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        docstring_spans = _fixtures._docstring_spans(text)
+        for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+            if (tok.type == tokenize.STRING
+                    and not _fixtures._in_docstring_span(tok.start, docstring_spans)
+                    and _fixtures._LEAK_RE.search(tok.string)):
+                violations.append(
+                    f"leak token in a NON-docstring string literal {tok.string!r} "
+                    f"in {py.relative_to(repo_dir)} (the strip won't scrub it — M-3)")
+    return violations
+
+
+def check_repo(repo_dir) -> list:
+    repo_dir = pathlib.Path(repo_dir)
+    violations: list = _runtime_string_leak_tokens(repo_dir)
+    with tempfile.TemporaryDirectory() as tmp:
+        copy = pathlib.Path(tmp) / "repo_copy"
+        _fixtures.copy_repo_for_producer(repo_dir, copy)
+        try:
+            _fixtures._assert_no_leak(copy)
+        except AssertionError as e:
+            violations.append(str(e))
+        # ADVERSARIAL (S-1): the bug DESCRIPTIONS — not just the id token — must be
+        # absent. Loaded from the source repo's GT (the copy excludes it), checked
+        # WITHOUT _LEAK_RE so the guard is independent of the strip mechanism.
+        try:
+            _fixtures.assert_no_description_leak(copy, _gt_descs(repo_dir))
+        except AssertionError as e:
+            violations.append(str(e))
+        # behavior-preserving: every stripped source file still compiles
+        if not compileall.compile_dir(str(copy / "src"), quiet=1, force=True):
+            violations.append(f"stripped src/ no longer compiles: {repo_dir.name}")
+    return violations
+
+
+def main() -> int:
+    repos = sorted(p for p in FIXTURES_DIR.glob("*")
+                   if (p / "manifest.json").exists()) if FIXTURES_DIR.exists() else []
+    if not repos:
+        print(f"OK — no seeded fixtures under {FIXTURES_DIR.relative_to(ROOT)} yet.")
+        return 0
+    any_fail = False
+    for repo in repos:
+        v = check_repo(repo)
+        if v:
+            any_fail = True
+            print(f"FAIL — {repo.name}:")
+            for s in v:
+                print(f"  - {s}")
+        else:
+            print(f"PASS — {repo.name} (producer copy blind: no answer-key path, "
+                  f"no leak token, no GT-description prose, src/ still compiles)")
+    return 1 if any_fail else 0
+
+
+# A GT description whose prose is embedded verbatim in the src comment (the F-1
+# leak shape: the comment paraphrases the answer key). The id token is also
+# present, so a token-only strip would still leak this prose.
+_SELFTEST_DESC = "a None or negative delay is passed straight through to the job"
+
+
+def selftest() -> int:
+    failures = []
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = pathlib.Path(tmp) / "r"
+        (repo / "src" / "pkg").mkdir(parents=True)
+        (repo / "src" / "pkg" / "__init__.py").write_text("")
+        # leak prose lives in a comment + docstring (as in real fixtures): both the
+        # id token AND a verbatim GT-desc window AND a "The fix" sentence.
+        (repo / "src" / "pkg" / "m.py").write_text(
+            '"""seam exercised here (nt-b1)."""\n'
+            'X = 1  # BUG nt-b3: ' + _SELFTEST_DESC + '. The fix clamps it.\n'
+            'LABEL = "delay"  # a runtime string literal that must stay intact\n'
+            'def f():\n    """' + _SELFTEST_DESC + '"""\n    return X\n')
+        # S-2: an IMPLICITLY-CONCATENATED docstring (one logical string, multiple
+        # STRING tokens). The id token (`nt-b1`/`BUG`) lives in the 2nd part and the
+        # GT-desc prose is SPLIT across the concatenation boundary so no single part
+        # holds a 5-word window. A start-position-only strip would leave parts 2+
+        # verbatim — both the token guard AND the description guard must still catch
+        # it. (`_SELFTEST_DESC` = "a None or negative delay is passed straight
+        # through to the job"; split after "negative".)
+        (repo / "src" / "pkg" / "concat.py").write_text(
+            'def g():\n'
+            '    ("a None or negative "\n'
+            '     "delay is passed straight through to the job "\n'
+            '     "BUG nt-b1 leaked in part two")\n'
+            '    return 1\n')
+        (repo / "tests").mkdir()
+        (repo / "tests" / "conftest.py").write_text("")
+        (repo / "exemplars").mkdir()
+        (repo / "exemplars" / "nt-b1.py").write_text("# answer key\n")
+        (repo / "fixes").mkdir()
+        (repo / "fixes" / "nt-b1.patch").write_text("--- a\n+++ b\n")
+        (repo / "manifest.json").write_text("{}")
+        (repo / "ground-truth-bugs.json").write_text(json.dumps(
+            {"bugs": [{"bug_id": "nt-b3", "desc": _SELFTEST_DESC}]}))
+
+        copy = pathlib.Path(tmp) / "copy"
+        _fixtures.copy_repo_for_producer(repo, copy)
+
+        m_txt = (copy / "src" / "pkg" / "m.py").read_text()
+        if "nt-b" in m_txt or "BUG" in m_txt:
+            failures.append(f"strip left a leak token: {m_txt!r}")
+        # the bug-describing PROSE (comment + docstring) is gone (F-1)
+        if _SELFTEST_DESC in m_txt or "The fix" in m_txt:
+            failures.append(f"strip left bug-description prose: {m_txt!r}")
+        # code preserved: assignment + function body intact
+        if "X = 1" not in m_txt or "return X" not in m_txt:
+            failures.append(f"strip changed code: {m_txt!r}")
+        # M-3: a NON-docstring string literal (`"delay"`) is NOT touched — it is
+        # runtime data, not a comment/docstring. (The strip only removes COMMENT
+        # tokens + docstring nodes; it never rewrites a runtime STRING.)
+        if 'LABEL = "delay"' not in m_txt:
+            failures.append(f"strip altered a non-docstring string literal: {m_txt!r}")
+        # S-2: the implicitly-concatenated docstring is removed in FULL — no
+        # concatenated part (id token OR split prose) survives, and the function
+        # body (`return 1`) is preserved.
+        c_txt = (copy / "src" / "pkg" / "concat.py").read_text()
+        if "nt-b" in c_txt or "BUG" in c_txt:
+            failures.append(f"strip left a concat-docstring leak token: {c_txt!r}")
+        if "passed straight through" in c_txt or "negative" in c_txt:
+            failures.append(f"strip left concat-docstring prose: {c_txt!r}")
+        if "return 1" not in c_txt:
+            failures.append(f"strip changed concat-docstring fn code: {c_txt!r}")
+        for forbidden in ("exemplars", "fixes", "manifest.json",
+                          "ground-truth-bugs.json"):
+            if (copy / forbidden).exists():
+                failures.append(f"answer-key path {forbidden} leaked into copy")
+        # _assert_no_leak passes on the clean copy
+        try:
+            _fixtures._assert_no_leak(copy)
+        except AssertionError as e:
+            failures.append(f"_assert_no_leak false-positive on clean copy: {e}")
+        # ADVERSARIAL: assert_no_description_leak passes on the clean copy ...
+        try:
+            _fixtures.assert_no_description_leak(copy, [_SELFTEST_DESC])
+        except AssertionError as e:
+            failures.append(f"description guard false-positive on clean copy: {e}")
+        # ... and FAILS if the bug-description prose is re-introduced (this is the
+        # check that, had it existed, would have caught the round-1 F-1 leak —
+        # independent of _LEAK_RE, so it is not circular with the strip).
+        (copy / "src" / "pkg" / "prose.py").write_text(
+            "Y = 2\n# " + _SELFTEST_DESC + "\n")
+        try:
+            _fixtures.assert_no_description_leak(copy, [_SELFTEST_DESC])
+            failures.append("description guard missed re-introduced bug-desc prose")
+        except AssertionError:
+            pass
+        # ... and FAILS on a re-introduced "The fix" phrase
+        (copy / "src" / "pkg" / "prose.py").write_text("Y = 2\n# The fix does X\n")
+        try:
+            _fixtures.assert_no_description_leak(copy, [])
+            failures.append("description guard missed re-introduced 'The fix' phrase")
+        except AssertionError:
+            pass
+        (copy / "src" / "pkg" / "prose.py").unlink()
+        # _assert_no_leak FAILS when a leak token is re-introduced
+        (copy / "src" / "pkg" / "leak.py").write_text("# BUG nt-b9: x\n")
+        try:
+            _fixtures._assert_no_leak(copy)
+            failures.append("_assert_no_leak missed a re-introduced leak token")
+        except AssertionError:
+            pass
+        (copy / "src" / "pkg" / "leak.py").unlink()
+
+        # S-1: the producer-visible tests/ subtree is in scope of BOTH guards. Drop
+        # an ANNOTATED test file (leak token + a GT-desc prose window SPLIT across a
+        # comment boundary so no single line holds it via the strip + "The fix"
+        # marker) into the copy's tests/ and assert both guards now catch it (proving
+        # the tests/-scope hole is closed and a strip/guard regression to src/-only
+        # would re-open it). The materialized copy strips tests/ too (real path), so
+        # we write POST-strip directly into the copy to exercise the guard scope.
+        (copy / "tests" / "test_seam.py").write_text(
+            "# BUG nt-b3: leak token in a producer-visible test file\n"
+            "# " + _SELFTEST_DESC + "\n"
+            "# The fix clamps it.\n"
+            "def test_x():\n    assert True\n")
+        try:
+            _fixtures._assert_no_leak(copy)
+            failures.append(
+                "_assert_no_leak missed a leak token in a tests/ file (S-1 scope hole)")
+        except AssertionError as e:
+            if "leaks bug-identity token" not in str(e):
+                failures.append(
+                    f"_assert_no_leak caught tests/ file but NOT via the token guard "
+                    f"(scope-widening unproven): {e}")
+        try:
+            _fixtures.assert_no_description_leak(copy, [_SELFTEST_DESC])
+            failures.append(
+                "assert_no_description_leak missed GT-desc prose in a tests/ file "
+                "(S-1 scope hole)")
+        except AssertionError:
+            pass
+        (copy / "tests" / "test_seam.py").unlink()
+
+        # S-1 belt-and-suspenders: the documented "tests/ = empty dir + conftest.py"
+        # invariant is machine-checked — a substantive (non-conftest) tests/ file is
+        # flagged by _assert_no_leak even when it carries NO leak token.
+        (copy / "tests" / "test_clean.py").write_text(
+            "def test_clean():\n    assert 1 + 1 == 2\n")
+        try:
+            _fixtures._assert_no_leak(copy)
+            failures.append(
+                "_assert_no_leak missed a non-conftest tests/ file "
+                "(tests/-empty-except-conftest invariant unenforced)")
+        except AssertionError as e:
+            if "non-conftest file" not in str(e):
+                failures.append(
+                    f"_assert_no_leak flagged a clean tests/ file but not via the "
+                    f"tests/-invariant check: {e}")
+        (copy / "tests" / "test_clean.py").unlink()
+        # ... and a copy whose tests/ holds only conftest.py still passes the guard.
+        try:
+            _fixtures._assert_no_leak(copy)
+        except AssertionError as e:
+            failures.append(
+                f"_assert_no_leak false-positive on tests/ = conftest.py only: {e}")
+
+    # isolated forbidden-path check
+    with tempfile.TemporaryDirectory() as tmp:
+        c = pathlib.Path(tmp) / "c"
+        (c / "src").mkdir(parents=True)
+        (c / "fixes").mkdir()
+        try:
+            _fixtures._assert_no_leak(c)
+            failures.append("_assert_no_leak missed a forbidden fixes/ path")
+        except AssertionError:
+            pass
+
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("SELFTEST OK — copy strips comments+docstrings (code + non-docstring "
+          "strings preserved), excludes answer-key paths, and both the token guard "
+          "(_assert_no_leak) and the adversarial description guard "
+          "(assert_no_description_leak) catch re-introduced leaks in EVERY "
+          "producer-visible subtree (src/ AND tests/), with the "
+          "tests/-empty-except-conftest invariant machine-checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/check_inquisitor_phase1b_invariants.py
+++ b/scripts/check_inquisitor_phase1b_invariants.py
@@ -22,6 +22,7 @@ Stdlib only. Exit 0 clean / 1 on any violation.
 from __future__ import annotations
 import os
 import pathlib
+import re
 import sys
 import tempfile
 
@@ -41,8 +42,13 @@ def framing_removed(without_text: str, neutral_text: str, marker: str) -> bool:
 
 
 def budget_ok(text: str) -> bool:
-    """Carries the uniform 5-test per-agent budget and NO per-arm 25 ceiling."""
-    return "5 tests" in text and "25" not in text
+    """Carries the uniform 5-test per-agent budget and NO per-arm 25 ceiling.
+
+    M-2: match the standalone token ``25`` (a per-arm ceiling) via a word-boundary
+    regex rather than the brittle ``"25" in text`` substring, so an incidental byte
+    sequence like a line number or ``2025`` can't false-fail the guard.
+    """
+    return "5 tests" in text and not re.search(r"\b25\b", text)
 
 
 # --- repo checks ----------------------------------------------------------

--- a/scripts/check_inquisitor_phase1b_invariants.py
+++ b/scripts/check_inquisitor_phase1b_invariants.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Structural CI guard for the inquisitor Phase-1b exec harness (#424, design §9).
+
+Invocation (from repo root):
+    python3 scripts/check_inquisitor_phase1b_invariants.py            # check the repo
+    python3 scripts/check_inquisitor_phase1b_invariants.py --selftest # logic tests
+
+Static assertions over the staged-prompt files + a dry exec/pilot stage:
+  - POOL prompt byte-identical to WITHOUT (hash equality).
+  - MID scaffold hash == WITH dimension scaffold hash (scaffold parity, S1).
+  - Neutral-proxy hash != WITH-scaffold AND != WITHOUT byte-hash (S4) PLUS a
+    positive "framing removed" check (contains the shared exec body, does NOT
+    contain the cross-component framing WITHOUT carries).
+  - Uniform per-agent 5-test budget in every execution prompt; NO per-arm 25 ceiling.
+  - `stage --pilot` emits neutral-proxy-only; full exec stage emits all four arms.
+  - Every fixture bug_id has exactly one fixes/<id>.patch referenced by GT fix_patch;
+    the patches compose into all-fixed.
+  - The §7 KEEP statistic is `beyond_spread`, NOT `trial_spread` (score module).
+
+Stdlib only. Exit 0 clean / 1 on any violation.
+"""
+from __future__ import annotations
+import os
+import pathlib
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+from skills.inquisitor.evals import run_evals  # noqa: E402
+from skills.inquisitor.evals import _fixtures  # noqa: E402
+
+
+# --- pure predicates (selftest-covered) -----------------------------------
+
+def framing_removed(without_text: str, neutral_text: str, marker: str) -> bool:
+    """Neutral proxy drops the cross-component framing but keeps the exec body."""
+    shared = "pytest"
+    return (marker in without_text and marker not in neutral_text
+            and shared in without_text and shared in neutral_text)
+
+
+def budget_ok(text: str) -> bool:
+    """Carries the uniform 5-test per-agent budget and NO per-arm 25 ceiling."""
+    return "5 tests" in text and "25" not in text
+
+
+# --- repo checks ----------------------------------------------------------
+
+def _dry_stage_arms(pilot: bool) -> list:
+    """Run a minimal exec/pilot stage in an isolated dispatch dir; return arms."""
+    with tempfile.TemporaryDirectory() as tmp:
+        env = dict(os.environ, XDG_RUNTIME_DIR=tmp, USER="invariant-check")
+        old = {k: os.environ.get(k) for k in ("XDG_RUNTIME_DIR", "USER")}
+        os.environ.update(env)
+        try:
+            trials = run_evals._PILOT_MIN_TRIALS if pilot else 1
+            dd = run_evals.stage("phase1b-invariant-check",
+                                 repo="notify", trials=trials, pilot=pilot, force=True)
+            import json
+            m = json.loads((dd / "stage-manifest.json").read_text())
+            return m["arms"], m["prompt_shas"]
+        finally:
+            for k, v in old.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+
+def check_repo() -> list:
+    v = []
+    ev = ROOT / "skills/inquisitor/evals"
+    without = (ev / "without-prompt-eval.md").read_text()
+    pool = (ev / "pool-prompt-eval.md").read_text()
+    neutral = (ev / "neutral-proxy-prompt-eval.md").read_text()
+
+    # framing-removed (positive) + budget on the bare exec prompts
+    if not framing_removed(without, neutral, run_evals._FRAMING_MARKER):
+        v.append("neutral-proxy framing-removed check failed (must drop "
+                 f"{run_evals._FRAMING_MARKER!r}, keep the exec body)")
+    for name, text in (("without", without), ("pool", pool),
+                       ("neutral-proxy", neutral),
+                       ("with-scaffold", run_evals._EXEC_SCAFFOLD)):
+        if not budget_ok(text):
+            v.append(f"{name} prompt fails the 5-test/no-25-ceiling budget check")
+
+    # hash relationships via a dry exec stage
+    arms, ph = _dry_stage_arms(pilot=False)
+    if arms != ["with", "pool", "mid", "without"]:
+        v.append(f"exec stage arms != 4-arm set: {arms}")
+    if ph["pool"] != ph["without"]:
+        v.append("POOL prompt hash != WITHOUT hash (parity broken)")
+    if ph["with_scaffold"] != ph["mid_scaffold"]:
+        v.append("MID scaffold hash != WITH scaffold hash (parity broken)")
+    if ph["neutral_proxy"] in (ph["without"], ph["with_scaffold"]):
+        v.append("neutral-proxy hash collides with WITHOUT or WITH-scaffold")
+
+    pilot_arms, _ = _dry_stage_arms(pilot=True)
+    if pilot_arms != ["neutral-proxy"]:
+        v.append(f"pilot stage arms != ['neutral-proxy']: {pilot_arms}")
+
+    # fixture bug_id <-> patch <-> GT fix_patch + composition into all-fixed
+    import json
+    fix_dir = ev / "fixtures"
+    for repo in sorted(p.name for p in fix_dir.glob("*")
+                       if (p / "manifest.json").exists()):
+        rd = fix_dir / repo
+        man = _fixtures.load_manifest(rd)
+        gt = json.loads((rd / "ground-truth-bugs.json").read_text())
+        gt_fix = {b["bug_id"]: b["fix_patch"] for b in gt["bugs"]}
+        for bid in man["bug_ids"]:
+            if not (rd / "fixes" / f"{bid}.patch").exists():
+                v.append(f"{repo}: missing fixes/{bid}.patch")
+            if gt_fix.get(bid) != f"fixes/{bid}.patch":
+                v.append(f"{repo}: GT fix_patch for {bid} != fixes/{bid}.patch")
+        try:  # patches compose into all-fixed (zero-fuzz)
+            d = _fixtures.all_fixed(rd)
+            import shutil
+            shutil.rmtree(d, ignore_errors=True)
+        except Exception as e:  # noqa: BLE001
+            v.append(f"{repo}: patches do not compose into all-fixed: {e}")
+
+    # KEEP statistic is beyond_spread, not trial_spread (score module text)
+    src = (ev / "run_evals.py").read_text()
+    if '"statistic": "beyond_spread"' not in src:
+        v.append("score_exec KEEP statistic is not pinned to beyond_spread")
+    if "trial_spread is explicitly REJECTED" not in src:
+        v.append("score_exec does not record trial_spread as the rejected gate")
+    return v
+
+
+def selftest() -> int:
+    failures = []
+    if not framing_removed("uses cross-component framing; run pytest",
+                           "run pytest only", "cross-component"):
+        failures.append("framing_removed should pass when marker dropped, body kept")
+    if framing_removed("cross-component; pytest", "cross-component; pytest",
+                       "cross-component"):
+        failures.append("framing_removed should fail when marker NOT dropped")
+    if framing_removed("cross-component; pytest", "no body here", "cross-component"):
+        failures.append("framing_removed should fail when shared exec body dropped")
+    if not budget_ok("at most 5 tests per agent"):
+        failures.append("budget_ok should pass for a 5-test prompt")
+    if budget_ok("up to 25 tests per arm"):
+        failures.append("budget_ok should fail on a per-arm 25 ceiling")
+    if budget_ok("no budget stated"):
+        failures.append("budget_ok should fail when no 5-test budget present")
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("SELFTEST OK — framing-removed and budget predicates behave.")
+    return 0
+
+
+def main() -> int:
+    v = check_repo()
+    if v:
+        print("FAIL — Phase-1b invariants:")
+        for s in v:
+            print(f"  - {s}")
+        return 1
+    print("PASS — Phase-1b structural invariants hold "
+          "(POOL/scaffold/neutral hashes, budget, arms, fixtures, KEEP stat).")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -85,6 +85,8 @@ run python3 skills/inquisitor/evals/test_runid.py
 run python3 skills/inquisitor/evals/test_fixtures.py
 run python3 scripts/check_fixture_independence.py --selftest
 run python3 scripts/check_fixture_independence.py
+run python3 scripts/check_fixture_gt_provenance.py --selftest
+run python3 scripts/check_fixture_gt_provenance.py
 
 # --- Catalog unit suite ---
 run python3 scripts/test_catalog.py

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -81,6 +81,10 @@ run python3 scripts/check_inquisitor_secondary_count.py
 run python3 skills/inquisitor/evals/test_run_evals_stage.py
 run python3 skills/inquisitor/evals/test_run_evals_score.py
 run python3 skills/inquisitor/evals/test_runid.py
+# --- Phase 1b: seeded-repo fixtures + variant materialization (#424) ---
+run python3 skills/inquisitor/evals/test_fixtures.py
+run python3 scripts/check_fixture_independence.py --selftest
+run python3 scripts/check_fixture_independence.py
 
 # --- Catalog unit suite ---
 run python3 scripts/test_catalog.py

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -90,6 +90,8 @@ run python3 scripts/check_fixture_independence.py --selftest
 run python3 scripts/check_fixture_independence.py
 run python3 scripts/check_fixture_gt_provenance.py --selftest
 run python3 scripts/check_fixture_gt_provenance.py
+run python3 scripts/check_fixture_producer_blind.py --selftest
+run python3 scripts/check_fixture_producer_blind.py
 run python3 scripts/check_inquisitor_phase1b_invariants.py --selftest
 run python3 scripts/check_inquisitor_phase1b_invariants.py
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -84,6 +84,7 @@ run python3 skills/inquisitor/evals/test_runid.py
 # --- Phase 1b: seeded-repo fixtures + variant materialization + oracle (#424) ---
 run python3 skills/inquisitor/evals/test_fixtures.py
 run python3 skills/inquisitor/evals/test_oracle.py
+run python3 skills/inquisitor/evals/test_run_evals_exec.py
 run python3 scripts/check_fixture_independence.py --selftest
 run python3 scripts/check_fixture_independence.py
 run python3 scripts/check_fixture_gt_provenance.py --selftest

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -81,8 +81,9 @@ run python3 scripts/check_inquisitor_secondary_count.py
 run python3 skills/inquisitor/evals/test_run_evals_stage.py
 run python3 skills/inquisitor/evals/test_run_evals_score.py
 run python3 skills/inquisitor/evals/test_runid.py
-# --- Phase 1b: seeded-repo fixtures + variant materialization (#424) ---
+# --- Phase 1b: seeded-repo fixtures + variant materialization + oracle (#424) ---
 run python3 skills/inquisitor/evals/test_fixtures.py
+run python3 skills/inquisitor/evals/test_oracle.py
 run python3 scripts/check_fixture_independence.py --selftest
 run python3 scripts/check_fixture_independence.py
 run python3 scripts/check_fixture_gt_provenance.py --selftest

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -85,10 +85,13 @@ run python3 skills/inquisitor/evals/test_runid.py
 run python3 skills/inquisitor/evals/test_fixtures.py
 run python3 skills/inquisitor/evals/test_oracle.py
 run python3 skills/inquisitor/evals/test_run_evals_exec.py
+run python3 skills/inquisitor/evals/test_build_collect_args.py
 run python3 scripts/check_fixture_independence.py --selftest
 run python3 scripts/check_fixture_independence.py
 run python3 scripts/check_fixture_gt_provenance.py --selftest
 run python3 scripts/check_fixture_gt_provenance.py
+run python3 scripts/check_inquisitor_phase1b_invariants.py --selftest
+run python3 scripts/check_inquisitor_phase1b_invariants.py
 
 # --- Catalog unit suite ---
 run python3 scripts/test_catalog.py

--- a/skills/inquisitor/evals/README.md
+++ b/skills/inquisitor/evals/README.md
@@ -1,16 +1,24 @@
-# Inquisitor fan-out eval harness (#424, Phase 1)
+# Inquisitor fan-out eval harness (#424, Phase 1 + Phase 1b)
 
-A bespoke **three-arm** harness that fires inquisitor's real 5-way fan-out
-**structure** over the existing `evals.json` fixtures with the **execution half
-stubbed** (real dimension lenses + test *reasoning*; tests are *described*, not
-run), and records a true **identification-breadth** delta. It mirrors temper's
-`stage` / `score` split — Python owns deterministic mechanics; the live
-orchestrator agent owns the two things Python can't do (dispatch + judgement).
+A bespoke harness that fires inquisitor's real fan-out **structure** over seeded
+fixtures and records a delta. It mirrors temper's `stage` / `score` split — Python
+owns deterministic mechanics; the live orchestrator agent owns the two things Python
+can't do (dispatch + judgement). **Two phases live behind the manifest `mode`
+field** (the Phase-1 path is byte-untouched):
 
-Implements the gated design
-`docs/plans/2026-06-13-inquisitor-fanout-eval-harness-design.md`. **Phase 1 only:**
-identification breadth; the execution axis is unmeasured (a non-positive delta is
-*inconclusive*, not condemning — see the design's go/no-go).
+- **Phase 1** (`mode` absent) — the **three-arm** identification-breadth measurement
+  with the **execution half stubbed** (real dimension lenses + test *reasoning*;
+  tests are *described*, not run). See
+  `docs/plans/2026-06-13-inquisitor-fanout-eval-harness-design.md`. A non-positive
+  delta here is *inconclusive*, not condemning (the design's go/no-go).
+- **Phase 1b** (`mode:"phase1b-exec"` / `mode:"pilot"`) — the terminal **detection-
+  axis** measurement: real write-AND-run execution against hermetic seeded repos,
+  scored by a deterministic differential oracle (no LLM judge). 4 arms + an
+  oracle; see the "Phase 1b" section below and
+  `docs/plans/2026-06-15-inquisitor-phase1b-execution-eval-design.md`.
+
+The sections that follow describe the **Phase-1** three-arm path; the **Phase-1b**
+four-arm execution path is documented in its own section near the end.
 
 ## The three arms
 
@@ -184,6 +192,17 @@ python3 -m skills.inquisitor.evals.run_evals score <run-id> [--allow-incomplete]
 `--pilot` stages the hash-pinned neutral proxy only (≥3-trial floor) for the §5
 fixture-difficulty calibration band (40–70%).
 
+**Collect-output contract (C4 — what the human collector writes per cell).** Each
+cell's `result_file` (named `<key>-tests.json` in `stage-manifest.json`) is a JSON
+object the collector writes after the producer agent finishes. `_exec_cell_caught`
+hard-depends on two fields and **fails loud** on either:
+- `"dispatch_status": "OK"` — anything else aborts `score` for that run.
+- `"test_files": [...]` — the producer's harvested test files as **ABSOLUTE**
+  paths. A relative path is a fatal error (the oracle runs each file against
+  pristine variants from a different cwd, so a relative path would silently miss).
+The oracle harvests only these test files; it ignores any agent source edits or
+self-reported pass/fail.
+
 **Files:**
 
 - `fixtures/<repo>/` — 3 hermetic seeded Python repos (`notify`, `rbac`,
@@ -194,9 +213,15 @@ fixture-difficulty calibration band (40–70%).
   `all-fixed-minus-Bᵢ`, zero-fuzz `patch -p1`) + the shared `run_test_in_dir` +
   `rc_to_verdict` (rc 5 = ERROR).
 - `_oracle.py` — the leave-one-out + mandatory-red-on-base scorer (no specificity
-  gate; broad test credited to EACH independent bug; twice-run flake guard;
+  gate — the `minus-Bᵢ` *variant* has only Bᵢ unfixed, so any RED there is Bᵢ's; a
+  broad test is credited to EACH independent bug; twice-run flake guard;
   registered-`interacting_set` escape). Harvests test files only → runs on pristine
-  variants, so agent source edits / self-reported pass-fail are irrelevant.
+  variants, so agent source edits / self-reported pass-fail are irrelevant. The
+  scoring unit is the FILE (one over-strict/flaky/import-erroring function sinks the
+  file); discards are surfaced as `flaky_discards` + `errored_discards` (all-fixed
+  anchor) + `errored_minus_discards` (a stable ERROR on a minus-Bᵢ variant — every
+  discard channel observable), and the prompts ask for one self-contained test per
+  file so the penalty is arm-uniform.
 - `without-prompt-eval.md` — the bare execution prompt, the **single source**:
   `pool-prompt-eval.md` is byte-identical; `neutral-proxy-prompt-eval.md` is it with
   the cross-component framing removed.
@@ -206,13 +231,21 @@ fixture-difficulty calibration band (40–70%).
 
 **CI guards (in `run_tests.sh`):** `check_fixture_independence.py` (the green/red
 leave-one-out matrix + patch disjointness), `check_fixture_gt_provenance.py` (blind
-boundary + post-blind off_axis), `check_inquisitor_phase1b_invariants.py` (POOL/
-scaffold/neutral hashes, 5-test budget, arm sets, KEEP statistic = `beyond_spread`).
+boundary + post-blind off_axis), `check_fixture_producer_blind.py` (the producer
+copy is blind: no answer-key path, no leak token, no GT-description prose — incl.
+a concatenated-docstring `--selftest`; stripped `src/` still compiles),
+`check_inquisitor_phase1b_invariants.py` (POOL/scaffold/neutral hashes, 5-test
+budget, arm sets, KEEP statistic = `beyond_spread`).
 
 **KEEP statistic:** the §7 go/no-go reads `beyond_spread` on `with_without` (NOT
 `trial_spread`) + positive sign on ≥2/3 repos, with a **WITHOUT-keyed** ceiling
 check. `score_exec` surfaces these inputs in `last_run.json`; it emits no
 keep/condemn verdict (the human reads the §7 branches).
+
+**Local-dev note (M-2):** the oracle shells `python3 -m pytest` and maps the rc via
+`_fixtures.rc_to_verdict` (0→GREEN, 1→RED, else→ERROR). CI pins `pytest==9.0.3`; run
+local fixture/oracle checks against the **same pin** so the rc→verdict mapping (esp.
+the rc-5 "no tests collected"→ERROR convention) matches CI.
 
 **Deferred (explicit opt-in, NOT in this build):** the ~180-agent live decision
 run (and the cheap neutral-proxy pilot before it), recording the result in

--- a/skills/inquisitor/evals/README.md
+++ b/skills/inquisitor/evals/README.md
@@ -153,3 +153,67 @@ significance test.
 **Deferred (post-merge, not in CI):** the live integration run that produces the
 actual delta (dispatches live Opus agents), recording it in `docs/evals.md`, and the
 Phase-2 go/no-go log on #424.
+
+## Phase 1b — seeded-repo execution measurement (4 arms + a deterministic oracle)
+
+Phase 1 measured *identification breadth* with the run step stubbed and a 100%
+ceiling. Phase 1b is the terminal **detection-axis** measurement: real
+write-AND-run execution against hermetic seeded repos, scored by a deterministic
+differential oracle (no LLM judge). See
+`docs/plans/2026-06-15-inquisitor-phase1b-execution-eval-design.md`.
+
+It is **forked behind the manifest `mode` field** so the Phase-1 path above is
+byte-untouched: a manifest with no `mode` runs the 3-arm judge `score`; a
+`mode:"phase1b-exec"` / `mode:"pilot"` manifest runs `score_exec` (the oracle).
+
+**Arms (4):** WITH (5 lensed agents), POOL (5 bare agents — the pooling-only
+control), MID (1 all-lenses agent), WITHOUT (1 bare agent). `WITH−WITHOUT` is the
+primary; `WITH−POOL` isolates lenses; `POOL−WITHOUT` isolates pooling; `WITH−MID`
+parallel-vs-sequential. Per-**agent** 5-test budget (no per-arm 25 ceiling — the
+per-arm scaling IS the pooling treatment).
+
+**CLI:**
+
+```
+python3 -m skills.inquisitor.evals.run_evals stage <run-id> --exec [--repo ID] [--trials N]
+python3 -m skills.inquisitor.evals.run_evals stage <run-id> --pilot [--repo ID] [--trials N>=3]
+python3 -m skills.inquisitor.evals.run_evals score <run-id> [--allow-incomplete]
+```
+
+`--exec` stages all 4 arms over the seeded repos (one repo copy per producer);
+`--pilot` stages the hash-pinned neutral proxy only (≥3-trial floor) for the §5
+fixture-difficulty calibration band (40–70%).
+
+**Files:**
+
+- `fixtures/<repo>/` — 3 hermetic seeded Python repos (`notify`, `rbac`,
+  `paginate`), ~8 behaviorally-independent cross-component seam bugs each, with
+  per-bug `fixes/<id>.patch` + `exemplars/<id>.py` + blind `ground-truth-bugs.json`
+  (+ provenance). Format spec in `fixtures/README.md`.
+- `_fixtures.py` — variant materialization (`base` / `all-fixed` /
+  `all-fixed-minus-Bᵢ`, zero-fuzz `patch -p1`) + the shared `run_test_in_dir` +
+  `rc_to_verdict` (rc 5 = ERROR).
+- `_oracle.py` — the leave-one-out + mandatory-red-on-base scorer (no specificity
+  gate; broad test credited to EACH independent bug; twice-run flake guard;
+  registered-`interacting_set` escape). Harvests test files only → runs on pristine
+  variants, so agent source edits / self-reported pass-fail are irrelevant.
+- `without-prompt-eval.md` — the bare execution prompt, the **single source**:
+  `pool-prompt-eval.md` is byte-identical; `neutral-proxy-prompt-eval.md` is it with
+  the cross-component framing removed.
+- `_build_collect_args.py` — the no-judge producer dispatch list for collect.
+- `test_fixtures.py`, `test_oracle.py`, `test_run_evals_exec.py`,
+  `test_build_collect_args.py` — gating unit tests.
+
+**CI guards (in `run_tests.sh`):** `check_fixture_independence.py` (the green/red
+leave-one-out matrix + patch disjointness), `check_fixture_gt_provenance.py` (blind
+boundary + post-blind off_axis), `check_inquisitor_phase1b_invariants.py` (POOL/
+scaffold/neutral hashes, 5-test budget, arm sets, KEEP statistic = `beyond_spread`).
+
+**KEEP statistic:** the §7 go/no-go reads `beyond_spread` on `with_without` (NOT
+`trial_spread`) + positive sign on ≥2/3 repos, with a **WITHOUT-keyed** ceiling
+check. `score_exec` surfaces these inputs in `last_run.json`; it emits no
+keep/condemn verdict (the human reads the §7 branches).
+
+**Deferred (explicit opt-in, NOT in this build):** the ~180-agent live decision
+run (and the cheap neutral-proxy pilot before it), recording the result in
+`docs/evals.md` / #424.

--- a/skills/inquisitor/evals/_build_collect_args.py
+++ b/skills/inquisitor/evals/_build_collect_args.py
@@ -21,6 +21,11 @@ from pathlib import Path
 def build(dispatch_dir) -> dict:
     disp = Path(dispatch_dir).resolve()
     manifest = json.loads((disp / "stage-manifest.json").read_text(encoding="utf-8"))
+    if manifest.get("mode") not in ("phase1b-exec", "pilot"):
+        raise SystemExit(
+            "build_collect_args is exec/pilot-only "
+            f"(manifest mode={manifest.get('mode')!r}; "
+            "point it at a phase1b-exec or pilot stage-manifest.json)")
     units = []
     for cell in manifest["cells"]:
         for p in cell["producers"]:

--- a/skills/inquisitor/evals/_build_collect_args.py
+++ b/skills/inquisitor/evals/_build_collect_args.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Build the producer dispatch list for the Phase-1b exec collect (NO judges).
+
+Reads the exec/pilot `stage-manifest.json` and emits a self-contained JSON object
+the orchestrator fans out: one work-unit per producer (WITH 5 + POOL 5 + MID 1 +
+WITHOUT 1 per repo×trial; or 1 neutral-proxy per cell in pilot mode). Each unit
+carries the absolute dispatch-file path, the absolute repo-copy path the agent
+writes/runs its tests in, and the cell's result_file (where collect writes the
+harvested `*-tests.json` per the C4 contract).
+
+Phase 1b has NO judge agents — `_oracle` scores mechanically — so this drops the
+Phase-1 judge inputs (dim_paths/mid_path/without_path/items/judge_prompt) entirely.
+The harvest *output* shape (the `*-tests.json` the oracle reads) is the C4 collect
+contract, defined/tested separately; this builds only the dispatch *args*.
+"""
+import json
+import sys
+from pathlib import Path
+
+
+def build(dispatch_dir) -> dict:
+    disp = Path(dispatch_dir).resolve()
+    manifest = json.loads((disp / "stage-manifest.json").read_text(encoding="utf-8"))
+    units = []
+    for cell in manifest["cells"]:
+        for p in cell["producers"]:
+            units.append({
+                "repo_id": cell["repo_id"],
+                "trial": cell["trial"],
+                "arm": cell["arm"],
+                "agent": p["agent"],
+                "dispatch_file": str(disp / p["dispatch_file"]),
+                "repo_copy": str(disp / p["repo_copy"]),
+                "result_file": str(disp / cell["result_file"]),
+            })
+    return {
+        "dispatch_dir": str(disp),
+        "mode": manifest["mode"],
+        "arms": manifest["arms"],
+        "units": units,
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(build(sys.argv[1])))

--- a/skills/inquisitor/evals/_fixtures.py
+++ b/skills/inquisitor/evals/_fixtures.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Variant materialization for the Phase-1b seeded repos (#424).
+
+Pure plumbing shared by the differential oracle (`_oracle.py`) and the
+fixture-build invariant checker (`scripts/check_fixture_independence.py`). Given
+a fixture repo dir, materialize the `base` / `all-fixed` / `all-fixed-minus-Bᵢ`
+variant classes (design §3, §4) by copying the tree and applying the per-bug
+`fixes/<bug_id>.patch` files.
+
+Patches are authored against the committed base and touch disjoint files / base
+line-ranges (the §3 HARD rule), so they compose order-independently and
+zero-fuzz. We apply with `patch -p1 -F0` (fuzz disabled) and fail loud on any
+reject — never apply with offset/fuzz, which would silently corrupt attribution.
+`patch` (not `git apply`) so the temp copy needs no git repo.
+"""
+import contextlib
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+_MANIFEST_KEYS = ("repo_id", "pkg", "test_dir", "runner_cmd", "bug_ids", "n")
+
+
+def load_manifest(repo_dir) -> dict:
+    """Read + validate `<repo_dir>/manifest.json`."""
+    repo_dir = Path(repo_dir)
+    manifest = json.loads((repo_dir / "manifest.json").read_text())
+    for key in _MANIFEST_KEYS:
+        if key not in manifest:
+            raise ValueError(f"manifest missing key: {key!r} ({repo_dir})")
+    if len(manifest["bug_ids"]) != manifest["n"]:
+        raise ValueError(
+            f"manifest n={manifest['n']} != len(bug_ids)="
+            f"{len(manifest['bug_ids'])} ({repo_dir})")
+    return manifest
+
+
+def materialize_variant(repo_dir, *, apply=None, exclude=None) -> str:
+    """Copy `repo_dir` to a fresh temp dir and apply (set(apply) - set(exclude))
+    of the per-bug patches, in deterministic manifest `bug_ids` order.
+
+    Returns the temp dir path; the caller owns cleanup (or use `variant(...)`).
+    Raises on an unknown bug_id (not in the manifest) or any patch reject.
+    """
+    repo_dir = Path(repo_dir)
+    manifest = load_manifest(repo_dir)
+    bug_ids = manifest["bug_ids"]
+
+    surviving = set(apply or ()) - set(exclude or ())
+    unknown = surviving - set(bug_ids)
+    if unknown:
+        raise ValueError(f"unknown bug_id(s): {sorted(unknown)} ({repo_dir})")
+    # deterministic order = manifest bug_ids order
+    ordered = [b for b in bug_ids if b in surviving]
+
+    tmp = tempfile.mkdtemp(prefix=f"variant-{manifest['repo_id']}-")
+    shutil.copytree(repo_dir, tmp, dirs_exist_ok=True)
+
+    for bid in ordered:
+        patch_path = repo_dir / "fixes" / f"{bid}.patch"
+        if not patch_path.exists():
+            raise FileNotFoundError(f"missing patch for {bid}: {patch_path}")
+        proc = subprocess.run(
+            ["patch", "-p1", "-F0", "-i", str(patch_path)],
+            cwd=tmp, capture_output=True, text=True)
+        if proc.returncode != 0:
+            shutil.rmtree(tmp, ignore_errors=True)
+            raise RuntimeError(
+                f"patch {bid} failed (rc={proc.returncode}) in {repo_dir.name}:\n"
+                f"{proc.stdout}\n{proc.stderr}")
+    return tmp
+
+
+def base(repo_dir) -> str:
+    """Materialize the as-committed base (every seeded bug live)."""
+    return materialize_variant(repo_dir, apply=[])
+
+
+def all_fixed(repo_dir) -> str:
+    """Materialize base + every patch (the fully-corrected repo)."""
+    return materialize_variant(repo_dir, apply=load_manifest(repo_dir)["bug_ids"])
+
+
+def all_fixed_minus(repo_dir, bug_id) -> str:
+    """Materialize base + every patch EXCEPT bug_id's (only bug_id live)."""
+    return materialize_variant(
+        repo_dir, apply=load_manifest(repo_dir)["bug_ids"], exclude=[bug_id])
+
+
+@contextlib.contextmanager
+def variant(repo_dir, *, apply=None, exclude=None):
+    """Context-manager form of materialize_variant: yields the dir, then removes it."""
+    d = materialize_variant(repo_dir, apply=apply, exclude=exclude)
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)

--- a/skills/inquisitor/evals/_fixtures.py
+++ b/skills/inquisitor/evals/_fixtures.py
@@ -13,15 +13,42 @@ zero-fuzz. We apply with `patch -p1 -F0` (fuzz disabled) and fail loud on any
 reject — never apply with offset/fuzz, which would silently corrupt attribution.
 `patch` (not `git apply`) so the temp copy needs no git repo.
 """
+import ast
 import contextlib
+import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
+import tokenize
 from pathlib import Path
 
 _MANIFEST_KEYS = ("repo_id", "pkg", "test_dir", "runner_cmd", "bug_ids", "n")
+
+# S3: hard wall-clock bound on every subprocess that runs model-written test code
+# (and on `patch`). A hung/runaway test (`while True:`, a blocking network call)
+# would otherwise wedge `score` indefinitely after the expensive collect. A
+# timeout maps to ERROR (non-eligible, never credited) — see run_test_in_dir.
+_SUBPROCESS_TIMEOUT_S = 60
+
+# F1 (Strategy B): the committed fixture `src/` annotates each seeded bug with its
+# id AND a plain-language description of the defect+fix, in comments and docstrings
+# (build scaffolding for the maintainer/oracle). NONE of that prose may reach a
+# producer agent — an arm that reads the answer key (the bug, not just its numeric
+# id) ceilings the WITH−WITHOUT delta toward null. Round-1 stripped only the id
+# TOKEN, leaving the bug+fix description intact (the F-1 leak). The complete rule:
+# `copy_repo_for_producer` strips ALL comments and ALL docstrings from every copied
+# producer-visible `*.py` (both `src/` AND `tests/`). Comments and docstrings never affect these fixtures' runtime
+# behavior (no code reads `__doc__`; verified in CI), so the producer copy stays
+# behavior-identical to the oracle's pristine committed base — the oracle still
+# materializes/scores from _FIXTURES_DIR, never from the producer copy.
+#
+# `_LEAK_RE` is retained ONLY for the adversarial blindness assertions (it is no
+# longer the strip mechanism): the strip removes whole comment/docstring nodes, so
+# any surviving id token in a producer copy is a strip bug worth flagging.
+_LEAK_RE = re.compile(r"\b(?:BUG)\b|(?:nt|rb|pg)-b[0-9]", re.IGNORECASE)
 
 
 def load_manifest(repo_dir) -> dict:
@@ -45,7 +72,10 @@ def materialize_variant(repo_dir, *, apply=None, exclude=None) -> str:
     Returns the temp dir path; the caller owns cleanup (or use `variant(...)`).
     Raises on an unknown bug_id (not in the manifest) or any patch reject.
     """
-    repo_dir = Path(repo_dir)
+    # M-6: resolve to absolute so the per-bug patch_path (repo_dir/"fixes"/…) is
+    # well-defined; a relative repo_dir would resolve the patch against the variant
+    # `cwd=tmp` and crash with a confusing "can't open patch file".
+    repo_dir = Path(repo_dir).resolve()
     manifest = load_manifest(repo_dir)
     bug_ids = manifest["bug_ids"]
 
@@ -62,10 +92,18 @@ def materialize_variant(repo_dir, *, apply=None, exclude=None) -> str:
     for bid in ordered:
         patch_path = repo_dir / "fixes" / f"{bid}.patch"
         if not patch_path.exists():
+            shutil.rmtree(tmp, ignore_errors=True)
             raise FileNotFoundError(f"missing patch for {bid}: {patch_path}")
-        proc = subprocess.run(
-            ["patch", "-p1", "-F0", "-i", str(patch_path)],
-            cwd=tmp, capture_output=True, text=True)
+        try:
+            proc = subprocess.run(
+                ["patch", "-p1", "-F0", "-i", str(patch_path)],
+                cwd=tmp, capture_output=True, text=True,
+                timeout=_SUBPROCESS_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            shutil.rmtree(tmp, ignore_errors=True)
+            raise RuntimeError(
+                f"patch {bid} timed out after {_SUBPROCESS_TIMEOUT_S}s in "
+                f"{repo_dir.name}")
         if proc.returncode != 0:
             shutil.rmtree(tmp, ignore_errors=True)
             raise RuntimeError(
@@ -143,9 +181,274 @@ def run_test_in_dir(variant_dir, test_file, manifest) -> str:
     env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
     try:
         runner = list(manifest["runner_cmd"])
-        proc = subprocess.run(
-            runner + ["--tb=no", str(probe)],
-            cwd=str(variant_dir), capture_output=True, text=True, env=env)
+        try:
+            proc = subprocess.run(
+                runner + ["--tb=no", str(probe)],
+                cwd=str(variant_dir), capture_output=True, text=True, env=env,
+                timeout=_SUBPROCESS_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            # A hung/runaway model-written test never collects: ERROR is
+            # non-eligible (GREEN on all-fixed is required), so a timeout is
+            # never credited and the score cannot wedge.
+            return "ERROR"
         return rc_to_verdict(proc.returncode)
     finally:
         probe.unlink(missing_ok=True)
+
+
+# --- F1/F2: build the blind producer-visible repo copy ----------------------
+
+# Only these subtrees/files are producer-visible. Everything else in the fixture
+# dir is the ANSWER KEY (exemplars = passing tests per bug, fixes = the exact
+# patches, ground-truth-bugs* = the blind bug list, manifest.json = bug_ids) and
+# must never reach the measured agent's writable sandbox (F2).
+_PRODUCER_VISIBLE = ("src", "tests")
+
+
+def _docstring_spans(py_source: str) -> set:
+    """Return the set of full ((start_row, start_col), (end_row, end_col)) spans of
+    every docstring STRING node — module, class, and function — in `py_source`.
+
+    A docstring is the first statement of a module/class/function body when that
+    statement is a bare string-constant expression (`ast.get_docstring`'s rule).
+    Only these STRING nodes are eligible for removal; every other STRING is a
+    runtime literal and is left untouched (M-3: the strip must never alter a
+    non-docstring string, which is runtime data).
+
+    S-2: the span covers the WHOLE Constant node (start..end), not just its first
+    token. An implicitly-concatenated docstring (`"part one" "part two"` — one
+    logical string in Python) emits MULTIPLE STRING tokens but the AST records one
+    Constant; matching only the start position left the 2nd+ parts in the copy. The
+    end position (`end_lineno`/`end_col_offset`, py3.8+) lets `_in_docstring_span`
+    catch every concatenated part.
+    """
+    spans = set()
+    tree = ast.parse(py_source)
+
+    def record(node):
+        body = getattr(node, "body", None)
+        if not body:
+            return
+        first = body[0]
+        if (isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)):
+            v = first.value
+            spans.add(((v.lineno, v.col_offset), (v.end_lineno, v.end_col_offset)))
+
+    record(tree)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            record(node)
+    return spans
+
+
+def _in_docstring_span(tok_start, spans) -> bool:
+    """True if a STRING token starting at `tok_start` (row, col) falls within any
+    docstring span in `spans` (the ((start),(end)) tuples from `_docstring_spans`).
+
+    Covers every part of an implicitly-concatenated docstring: each concatenated
+    STRING token starts at-or-after the node start and before the node end (S-2)."""
+    for (s_start, s_end) in spans:
+        if s_start <= tok_start < s_end:
+            return True
+    return False
+
+
+def _strip_comments_and_docstrings(py_source: str) -> str:
+    """Remove ALL comments and ALL docstrings from a .py source, keeping executable
+    code behavior-identical (F1, the complete blindness rule).
+
+    The seeded `src/` annotates each bug with a plain-language description of the
+    defect AND its fix, in comments and docstrings. Redacting only the id token
+    (round-1) left that prose answer-key intact. This strips the whole comment and
+    the whole docstring node instead, so no bug-describing prose can reach the
+    producer. Comments and docstrings carry no runtime semantics for these fixtures
+    (no code reads `__doc__`; CI-verified), so the copy stays behavior-identical to
+    the oracle's pristine base.
+
+    Token-aware + AST-scoped: COMMENT tokens are removed; STRING tokens are removed
+    ONLY when they are a docstring node (per `_docstring_spans`) — a non-docstring
+    string literal (runtime data) is never touched (M-3).
+    """
+    docstring_spans = _docstring_spans(py_source)
+    out_lines = []
+    last_lineno = 0
+    last_col = 0
+    comment_rows = set()
+    for tok in tokenize.generate_tokens(io.StringIO(py_source).readline):
+        ttype = tok.type
+        s_row, s_col = tok.start
+        e_row, e_col = tok.end
+        # Preserve inter-token whitespace/newlines exactly by emitting the gap
+        # between tokens; then emit (or drop) the token text.
+        if ttype == tokenize.COMMENT:
+            text = ""
+            comment_rows.add(s_row)
+        elif (ttype == tokenize.STRING
+              and _in_docstring_span((s_row, s_col), docstring_spans)):
+            # Drop the docstring's text but keep its line/column footprint as a
+            # placeholder so the statement (`"""…"""`) stays syntactically present
+            # and line numbers don't shift unexpectedly — emit an empty string lit.
+            text = '""'
+        else:
+            text = tok.string
+        out_lines.append(((s_row, s_col), (e_row, e_col), text))
+
+    # Reconstruct from the raw source so all original spacing is preserved, only
+    # replacing the spans we chose to rewrite (comments -> "", docstrings -> '""').
+    line_start = [0]
+    for line in py_source.splitlines(keepends=True):
+        line_start.append(line_start[-1] + len(line))
+
+    def off(row, col):
+        return line_start[row - 1] + col
+
+    edits = []
+    for (s_row, s_col), (e_row, e_col), text in out_lines:
+        # Only record an edit where the emitted text differs from the original
+        # token text (comments and docstrings).
+        orig = py_source[off(s_row, s_col):off(e_row, e_col)]
+        if text != orig:
+            edits.append((off(s_row, s_col), off(e_row, e_col), text))
+    result = py_source
+    for s, e, text in sorted(edits, reverse=True):
+        result = result[:s] + text + result[e:]
+
+    # Removing a trailing comment leaves the preceding inter-token gap behind
+    # (e.g. `    return x  \n`). Trim trailing whitespace only on lines a comment
+    # was removed from — cosmetic, behavior-irrelevant; never reflow code.
+    if comment_rows:
+        out = result.splitlines(keepends=True)
+        for row in comment_rows:
+            if 1 <= row <= len(out):
+                line = out[row - 1]
+                nl = line[len(line.rstrip("\r\n")):]
+                out[row - 1] = line.rstrip() + nl
+        result = "".join(out)
+    return result
+
+
+def copy_repo_for_producer(repo_dir, dst) -> None:
+    """Materialize the BLIND producer-visible copy of a fixture repo at `dst`.
+
+    Copies ONLY the producer-visible subset (`src/` + `tests/`) — never
+    `exemplars/`, `fixes/`, `ground-truth-bugs*`, or `manifest.json` (F2) — and
+    strips ALL comments and docstrings from every copied producer-visible `*.py`
+    (every `_PRODUCER_VISIBLE` subtree: `src/` AND `tests/`) (F1), so no
+    bug-describing prose (id OR plain-language description+fix) reaches the agent.
+    The committed fixture and the oracle's _FIXTURES_DIR scoring path are
+    untouched; only the agent's sandbox is narrowed + de-annotated.
+    """
+    repo_dir = Path(repo_dir)
+    dst = Path(dst)
+    dst.mkdir(parents=True, exist_ok=True)
+    for name in _PRODUCER_VISIBLE:
+        src = repo_dir / name
+        if not src.exists():
+            continue
+        shutil.copytree(src, dst / name)
+    # Strip every producer-visible subtree, not just src/: tests/ is equally
+    # producer-visible (`_PRODUCER_VISIBLE`), so an annotated test file would
+    # otherwise carry the answer key into the sandbox verbatim (S-1).
+    for sub in _PRODUCER_VISIBLE:
+        for py in (dst / sub).rglob("*.py"):
+            text = py.read_text(encoding="utf-8")
+            stripped = _strip_comments_and_docstrings(text)
+            if stripped != text:
+                py.write_text(stripped, encoding="utf-8")
+
+
+def _assert_no_leak(repo_copy) -> None:
+    """Raise if a producer repo_copy still carries the answer key — a leak token
+    in any producer-visible `*.py` (every `_PRODUCER_VISIBLE` subtree: `src/` AND
+    `tests/`), or any forbidden answer-key path. Used as a stage-time assertion and
+    by the CI guard / unit tests (F1+F2).
+
+    Scanning every producer-visible subtree (not just `src/`) closes the S-1
+    `tests/`-scope hole: `tests/` reaches the agent verbatim too, so a leak token
+    in a `tests/test_*.py` file would otherwise hand every arm the answer key.
+
+    This is the path+token guard; the bug-DESCRIPTION-prose guard is the separate
+    adversarial `assert_no_description_leak` (it cannot live here — `repo_copy` by
+    construction excludes `ground-truth-bugs.json`, so the GT descriptions must be
+    passed in from the source repo)."""
+    repo_copy = Path(repo_copy)
+    for forbidden in ("exemplars", "fixes", "manifest.json",
+                      "ground-truth-bugs.json", "ground-truth-bugs.provenance.md"):
+        if (repo_copy / forbidden).exists():
+            raise AssertionError(
+                f"producer repo_copy leaks answer-key path {forbidden!r}: {repo_copy}")
+    for sub in _PRODUCER_VISIBLE:
+        for py in (repo_copy / sub).rglob("*.py"):
+            m = _LEAK_RE.search(py.read_text(encoding="utf-8"))
+            if m:
+                raise AssertionError(
+                    f"producer repo_copy leaks bug-identity token {m.group(0)!r} in "
+                    f"{py.relative_to(repo_copy)}: {repo_copy}")
+    # Belt-and-suspenders: pin the documented `tests/` invariant ("empty dir +
+    # conftest.py; arms/oracle write test files here") as a machine-checked fact.
+    # The token/prose guards above already cover any annotated tests/ file; this
+    # additionally flags the convention being broken at all, so a future fixture
+    # that drops a substantive file into tests/ is surfaced even if it carries no
+    # leak token (S-1).
+    tests_copy = repo_copy / "tests"
+    if tests_copy.exists():
+        unexpected = sorted(
+            str(p.relative_to(repo_copy)) for p in tests_copy.rglob("*")
+            if p.is_file() and p.name != "conftest.py")
+        if unexpected:
+            raise AssertionError(
+                f"producer repo_copy tests/ holds non-conftest file(s) {unexpected} "
+                f"(the fixture convention is tests/ = empty dir + conftest.py): "
+                f"{repo_copy}")
+
+
+# Minimum contiguous word-run from a GT `desc` that, if it survives verbatim in a
+# producer copy, is treated as a description leak. 5 words is long enough that an
+# incidental overlap with ordinary code identifiers is implausible, short enough
+# that any real sentence fragment from the answer key trips it.
+_DESC_LEAK_MIN_WORDS = 5
+_WORD_RE = re.compile(r"[A-Za-z0-9_']+")
+
+
+def assert_no_description_leak(repo_copy, gt_descs) -> None:
+    """Adversarial blindness guard (S-1): assert that NONE of the bug DESCRIPTIONS
+    survive in the producer copy — independent of the strip mechanism.
+
+    `gt_descs` is the list of `desc` strings from the source repo's
+    `ground-truth-bugs.json`. For each desc, every contiguous `_DESC_LEAK_MIN_WORDS`-
+    word window must be absent from the (whitespace-normalized) text of every copied
+    producer-visible `*.py` (every `_PRODUCER_VISIBLE` subtree: `src/` AND `tests/`);
+    the literal phrase `"The fix"` (the round-1 leak's fix-description marker) must
+    also be absent. Scanning `tests/` too closes the S-1 hole — a GT-desc paraphrase
+    in a `tests/` file is just as much an answer-key leak as one in `src/`. This does
+    NOT re-use `_LEAK_RE`, so it catches any prose channel the strip might miss — it
+    FAILS on the round-1 prose leak if the comment/docstring strip were reverted."""
+    repo_copy = Path(repo_copy)
+    # whitespace-normalized concatenation of every copied producer-visible file
+    blobs = {}
+    for sub in _PRODUCER_VISIBLE:
+        for py in (repo_copy / sub).rglob("*.py"):
+            blobs[py] = " ".join(py.read_text(encoding="utf-8").split())
+    for py, blob in blobs.items():
+        if "The fix" in blob:
+            raise AssertionError(
+                f"producer repo_copy leaks fix-description phrase 'The fix' in "
+                f"{py.relative_to(repo_copy)}: {repo_copy}")
+    for desc in gt_descs:
+        words = _WORD_RE.findall(desc)
+        # M-5: a desc SHORTER than _DESC_LEAK_MIN_WORDS would otherwise yield zero
+        # windows and lose its prose backstop entirely (only the "The fix" literal
+        # would guard it). Fall back to the whole desc as a single window so a terse
+        # desc still gets a prose backstop.
+        n = min(_DESC_LEAK_MIN_WORDS, len(words)) or 1
+        windows = {" ".join(words[i:i + n]) for i in range(0, max(0, len(words) - n + 1))}
+        for py, blob in blobs.items():
+            norm = " ".join(_WORD_RE.findall(blob))
+            for w in windows:
+                if w and w in norm:
+                    raise AssertionError(
+                        f"producer repo_copy leaks GT bug-description prose "
+                        f"{w!r} (from desc {desc!r}) in "
+                        f"{py.relative_to(repo_copy)}: {repo_copy}")

--- a/skills/inquisitor/evals/_fixtures.py
+++ b/skills/inquisitor/evals/_fixtures.py
@@ -15,6 +15,7 @@ reject — never apply with offset/fuzz, which would silently corrupt attributio
 """
 import contextlib
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -97,3 +98,54 @@ def variant(repo_dir, *, apply=None, exclude=None):
         yield d
     finally:
         shutil.rmtree(d, ignore_errors=True)
+
+
+# --- Test runner against a materialized variant (shared by the oracle and the
+#     fixture-independence checker) --------------------------------------------
+
+def rc_to_verdict(rc: int) -> str:
+    """Canonical pytest rc -> verdict mapping (design §4 / M2 truth table).
+
+        0 -> GREEN   (all tests pass)
+        1 -> RED     (a test failed = a bug was caught)
+        2,3,4,5,* -> ERROR   (interrupted / internal / usage / NO TESTS COLLECTED)
+
+    rc 5 (no tests collected — an empty/mis-named harvested file) is ERROR, NOT
+    green: an empty test catches nothing, and counting it green would silently
+    credit a WITHOUT failure mode. ERROR is distinct from both GREEN and RED.
+    """
+    if rc == 0:
+        return "GREEN"
+    if rc == 1:
+        return "RED"
+    return "ERROR"
+
+
+def run_test_in_dir(variant_dir, test_file, manifest) -> str:
+    """Run a single pytest `test_file` against an ALREADY-materialized variant.
+
+    Copies the file into the variant's `test_dir` as a probe (the variant's
+    conftest puts `src/` on sys.path), runs `runner_cmd --tb=no <probe>` with
+    cwd=variant, and maps the rc via `rc_to_verdict`. The caller owns the
+    variant lifecycle (materialize once, run many tests, clean up), so the
+    oracle can re-use one `all-fixed` / `minus-Bᵢ` copy across many tests.
+    """
+    variant_dir = Path(variant_dir)
+    test_dir = variant_dir / manifest["test_dir"]
+    test_dir.mkdir(parents=True, exist_ok=True)
+    # Unique probe name per run: reusing one name lets Python load a STALE .pyc
+    # for the next probe (mtime-granularity collision), silently running the
+    # previous test. Unique names + no-bytecode keep each run hermetic.
+    fd, probe_path = tempfile.mkstemp(suffix=".py", prefix="test_probe_", dir=str(test_dir))
+    os.close(fd)
+    probe = Path(probe_path)
+    shutil.copyfile(test_file, probe)
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
+    try:
+        runner = list(manifest["runner_cmd"])
+        proc = subprocess.run(
+            runner + ["--tb=no", str(probe)],
+            cwd=str(variant_dir), capture_output=True, text=True, env=env)
+        return rc_to_verdict(proc.returncode)
+    finally:
+        probe.unlink(missing_ok=True)

--- a/skills/inquisitor/evals/_oracle.py
+++ b/skills/inquisitor/evals/_oracle.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Differential leave-one-out oracle for Phase-1b (#424, design §4).
+
+Deterministic, no LLM anywhere in the scoring path. Given an arm's harvested test
+file(s) and a seeded fixture repo, decide which seeded bugs the tests CAUGHT, by
+re-running the tests against pristine materialized variants:
+
+    caught(Bᵢ) ⟺ ∃ test t such that ALL of:
+        (1) t is GREEN on all-fixed                 (passes when nothing is broken)
+        (2) t is RED   on the full-buggy base       (MANDATORY — catches a real bug)
+        (3) t is RED   on all-fixed-minus-Bᵢ        (removing only Bᵢ's fix re-breaks it)
+
+No specificity gate: under the §3 behavioral-independence invariant a test red on
+`minus-Bᵢ` can only be red because Bᵢ is the sole unfixed bug there, so a broad test
+red on several `minus-Bᵢ` is correctly credited to EACH of those independent bugs
+(arm-neutral). ERROR/collection-failure is NOT green and NOT red (rc table in
+`_fixtures.rc_to_verdict`). Every (test, variant) verdict is twice-run flake-guarded,
+including the all-fixed / base anchors. The oracle harvests ONLY the test files and
+runs them on pristine variants, so agent source edits / self-reported pass-fail are
+irrelevant.
+
+A registered `interacting_set` (the rare audited escape for a genuinely co-violable
+pair) is credited once via the set's combined `minus`-variant; its members are
+excluded from the per-bug leave-one-out so the set isn't double-counted.
+"""
+from pathlib import Path
+
+from . import _fixtures
+
+GREEN, RED, ERROR = "GREEN", "RED", "ERROR"
+
+
+def _stable(variant_dir, test_file, manifest):
+    """Twice-run flake guard: the verdict if stable across two runs, else None."""
+    v1 = _fixtures.run_test_in_dir(variant_dir, test_file, manifest)
+    v2 = _fixtures.run_test_in_dir(variant_dir, test_file, manifest)
+    return v1 if v1 == v2 else None
+
+
+def caught_bugs(test_files, repo_dir, *, interacting_sets=()):
+    """Return {"caught": set, "broad_test_catches": dict, "flaky_discards": int}.
+
+    `caught` holds the bug_ids the tests caught (plus one "+"-joined id per
+    registered interacting set credited). `broad_test_catches` maps each crediting
+    test path -> how many bugs it isolated (reported, NOT gating). `flaky_discards`
+    counts tests discarded for an unstable (test, variant) verdict.
+    """
+    repo_dir = Path(repo_dir)
+    manifest = _fixtures.load_manifest(repo_dir)
+    bug_ids = list(manifest["bug_ids"])
+    sets = [sorted(s) for s in (interacting_sets or [])]
+    members = {b for s in sets for b in s}
+    non_set = [b for b in bug_ids if b not in members]
+
+    test_files = [Path(t) for t in test_files]
+    caught = set()
+    broad = {}
+    flaky = 0
+
+    # --- eligibility: GREEN on all-fixed AND RED on base (anchors twice-run) ---
+    eligible = []
+    with _fixtures.variant(repo_dir, apply=bug_ids) as af, \
+         _fixtures.variant(repo_dir, apply=[]) as base:
+        for t in test_files:
+            va = _stable(af, t, manifest)
+            if va is None:
+                flaky += 1
+                continue
+            if va != GREEN:
+                continue  # fails even fully-corrected -> pinned to no seeded bug
+            vb = _stable(base, t, manifest)
+            if vb is None:
+                flaky += 1
+                continue
+            if vb != RED:
+                continue  # catches no real bug (nothing to expose)
+            eligible.append(t)
+
+    if not eligible:
+        return {"caught": caught, "broad_test_catches": broad, "flaky_discards": flaky}
+
+    # --- minus-variant matrix (cost opt: only eligible tests reach the minuses) ---
+    matrix = {}  # key -> {test_path: verdict-or-None};  key = bug_id | ("set", tuple)
+    for b in non_set:
+        with _fixtures.variant(repo_dir, apply=bug_ids, exclude=[b]) as mv:
+            matrix[b] = {t: _stable(mv, t, manifest) for t in eligible}
+    for s in sets:
+        with _fixtures.variant(repo_dir, apply=bug_ids, exclude=s) as mv:
+            matrix[("set", tuple(s))] = {t: _stable(mv, t, manifest) for t in eligible}
+
+    # --- per-test crediting; a test flaky on ANY minus is discarded entirely ---
+    for t in eligible:
+        if any(matrix[k][t] is None for k in matrix):
+            flaky += 1
+            continue
+        isolated = 0
+        for b in non_set:
+            if matrix[b][t] == RED:
+                caught.add(b)
+                isolated += 1
+        for s in sets:
+            if matrix[("set", tuple(s))][t] == RED:
+                caught.add("+".join(s))
+                isolated += 1
+        if isolated:
+            broad[str(t)] = isolated
+
+    return {"caught": caught, "broad_test_catches": broad, "flaky_discards": flaky}

--- a/skills/inquisitor/evals/_oracle.py
+++ b/skills/inquisitor/evals/_oracle.py
@@ -10,14 +10,48 @@ re-running the tests against pristine materialized variants:
         (2) t is RED   on the full-buggy base       (MANDATORY — catches a real bug)
         (3) t is RED   on all-fixed-minus-Bᵢ        (removing only Bᵢ's fix re-breaks it)
 
-No specificity gate: under the §3 behavioral-independence invariant a test red on
-`minus-Bᵢ` can only be red because Bᵢ is the sole unfixed bug there, so a broad test
-red on several `minus-Bᵢ` is correctly credited to EACH of those independent bugs
-(arm-neutral). ERROR/collection-failure is NOT green and NOT red (rc table in
-`_fixtures.rc_to_verdict`). Every (test, variant) verdict is twice-run flake-guarded,
-including the all-fixed / base anchors. The oracle harvests ONLY the test files and
-runs them on pristine variants, so agent source edits / self-reported pass-fail are
-irrelevant.
+No specificity gate: the `minus-Bᵢ` variant has only Bᵢ unfixed (every other bug's
+fix is applied), so under the §3 behavioral-independence invariant any deterministic
+RED there is attributable to Bᵢ's misbehavior — regardless of the test's intent. A
+broad test red on several `minus-Bᵢ` is therefore correctly credited to EACH of those
+independent bugs (arm-neutral). This is a property of the VARIANT, not of the exemplar
+matrix; it transfers to arbitrary producer tests.
+
+S-3 residual (documented, not gated this round): the transfer argument above holds
+*only* under §3 disjointness — that `minus-Bᵢ` has exactly one behavioral fault and
+the patches are behaviorally disjoint. `check_fixture_independence.py` PROVES that
+for the hand-authored EXEMPLARS, but it cannot prove it for an arbitrary producer
+test, which could assert a compound property whose single RED on `minus-Bᵢ` AND
+`minus-Bⱼ` is credited to both even though it depends on the *conjunction* rather
+than each bug independently. Because such a test red-on-all-fixed is already filtered
+by the GREEN-on-all-fixed eligibility gate, the residual is narrow; it inflates
+absolute catch counts symmetrically across arms (so it does not bias the *delta*),
+but it can inflate the absolute rate feeding the WITHOUT *absolute* ceiling
+(`_WITHOUT_CEILING`). Rather than add per-test specificity gating this round, the
+scorer surfaces a per-arm `conjunction_inflation.tests_crediting_3plus_bugs`
+diagnostic in `last_run.json` so an operator can spot conjunction-driven inflation
+before trusting the ceiling. (Justification for stopping at doc+diagnostic: full
+gating would require an audited specificity rule per producer test, which the
+exemplar-only independence proof does not support; the diagnostic makes the residual
+observable, which the absolute-ceiling read needs, without a new unproven gate.)
+
+ERROR/collection-failure is NOT green
+and NOT red (rc table in `_fixtures.rc_to_verdict`). Every (test, variant) verdict is
+twice-run flake-guarded, including the all-fixed / base anchors. The oracle harvests
+ONLY the test files and runs them on pristine variants, so agent source edits /
+self-reported pass-fail are irrelevant.
+
+SCORING UNIT IS THE FILE (S1): each harvested test FILE is run as one pytest
+invocation and gated whole — it must be GREEN on all-fixed and RED on base to be
+eligible, and is discarded entirely if flaky on any minus-variant or if it ERRORs
+(see `errored_discards`). A file bundling several test functions shares that fate:
+one over-strict / flaky / import-erroring function sinks the file's other catches.
+Producers are therefore told (budget section, every arm uniformly) to write
+one self-contained test per file, so this file-as-unit penalty is symmetric across
+arms; `flaky_discards` + `errored_discards` (all-fixed anchor) +
+`errored_minus_discards` (a stable ERROR on a minus-Bᵢ variant) make every discard
+channel observable (the base-anchor ERROR is the one documented exception — see
+`caught_bugs`).
 
 A registered `interacting_set` (the rare audited escape for a genuinely co-violable
 pair) is credited once via the set's combined `minus`-variant; its members are
@@ -38,12 +72,38 @@ def _stable(variant_dir, test_file, manifest):
 
 
 def caught_bugs(test_files, repo_dir, *, interacting_sets=()):
-    """Return {"caught": set, "broad_test_catches": dict, "flaky_discards": int}.
+    """Return {"caught": set, "broad_test_catches": dict, "flaky_discards": int,
+    "errored_discards": int, "errored_minus_discards": int}.
 
     `caught` holds the bug_ids the tests caught (plus one "+"-joined id per
     registered interacting set credited). `broad_test_catches` maps each crediting
     test path -> how many bugs it isolated (reported, NOT gating). `flaky_discards`
     counts tests discarded for an unstable (test, variant) verdict.
+
+    `errored_discards` (S2) counts tests that ERROR'd (collection/import failure —
+    e.g. a harvested test importing a producer-authored helper that wasn't
+    harvested) on the ALL-FIXED anchor and so were ruled ineligible. ERROR is not
+    GREEN, so such a test can never be credited; surfacing the count makes a catch
+    that leaked into ERROR observable in last_run.json rather than silently lost.
+    Scope note (second-pass #1): this counter covers ERROR on the all-fixed anchor
+    ONLY. A test that is GREEN on all-fixed but ERRORs on the *base* anchor (the
+    `vb != RED` branch below) is dropped as "catches no real bug" without a counter
+    — an unusual shape (a catch that imports/collects under all-fixed but not under
+    the buggy base) and symmetric across arms, so it is left uncounted by design;
+    the observability claim is therefore scoped to the all-fixed anchor.
+
+    `errored_minus_discards` (S-1) closes the THIRD ERROR channel: an eligible test
+    (GREEN on all-fixed, RED on base) that returns a stable ERROR on a specific
+    `minus-Bᵢ` variant. There `matrix[k][t] == ERROR` is neither flaky (`is None`)
+    nor a credit (`== RED`), so the bug Bᵢ is silently uncredited for that test.
+    The exemplars are proven ERROR-free on every variant by the independence checker,
+    but an ARBITRARY producer test can take an import/collection-time path under the
+    one buggy minus-variant that it does not take under all-fixed/base — losing a
+    real catch with no trace. This counter increments once per (test, minus-variant)
+    ERROR cell so that loss is observable in last_run.json. Credit semantics are
+    unchanged (an ERROR cell is still not a credit); only the discard is now counted.
+    With this counter every discard channel — flaky, all-fixed ERROR, minus-variant
+    ERROR — is observable; the base-anchor ERROR remains uncounted by design (above).
     """
     repo_dir = Path(repo_dir)
     manifest = _fixtures.load_manifest(repo_dir)
@@ -56,6 +116,8 @@ def caught_bugs(test_files, repo_dir, *, interacting_sets=()):
     caught = set()
     broad = {}
     flaky = 0
+    errored = 0
+    errored_minus = 0
 
     # --- eligibility: GREEN on all-fixed AND RED on base (anchors twice-run) ---
     eligible = []
@@ -65,6 +127,11 @@ def caught_bugs(test_files, repo_dir, *, interacting_sets=()):
             va = _stable(af, t, manifest)
             if va is None:
                 flaky += 1
+                continue
+            if va == ERROR:
+                # collection/import failure on fully-corrected code: ineligible,
+                # but surface it (S2) — a real catch may be hiding in here.
+                errored += 1
                 continue
             if va != GREEN:
                 continue  # fails even fully-corrected -> pinned to no seeded bug
@@ -77,7 +144,9 @@ def caught_bugs(test_files, repo_dir, *, interacting_sets=()):
             eligible.append(t)
 
     if not eligible:
-        return {"caught": caught, "broad_test_catches": broad, "flaky_discards": flaky}
+        return {"caught": caught, "broad_test_catches": broad,
+                "flaky_discards": flaky, "errored_discards": errored,
+                "errored_minus_discards": errored_minus}
 
     # --- minus-variant matrix (cost opt: only eligible tests reach the minuses) ---
     matrix = {}  # key -> {test_path: verdict-or-None};  key = bug_id | ("set", tuple)
@@ -93,6 +162,10 @@ def caught_bugs(test_files, repo_dir, *, interacting_sets=()):
         if any(matrix[k][t] is None for k in matrix):
             flaky += 1
             continue
+        # S-1: a stable ERROR on a minus-variant is neither flaky nor a credit; the
+        # bug behind that cell is silently uncredited for this test. Count each such
+        # cell so the lost catch is observable (credit semantics unchanged).
+        errored_minus += sum(1 for k in matrix if matrix[k][t] == ERROR)
         isolated = 0
         for b in non_set:
             if matrix[b][t] == RED:
@@ -105,4 +178,6 @@ def caught_bugs(test_files, repo_dir, *, interacting_sets=()):
         if isolated:
             broad[str(t)] = isolated
 
-    return {"caught": caught, "broad_test_catches": broad, "flaky_discards": flaky}
+    return {"caught": caught, "broad_test_catches": broad,
+            "flaky_discards": flaky, "errored_discards": errored,
+            "errored_minus_discards": errored_minus}

--- a/skills/inquisitor/evals/fixtures/README.md
+++ b/skills/inquisitor/evals/fixtures/README.md
@@ -1,0 +1,100 @@
+# Phase-1b seeded repos (fixtures)
+
+Hermetic, runnable synthetic Python packages with deliberately-seeded
+**cross-component seam bugs** — the substrate the Phase-1b execution eval scores
+arms against. See `docs/plans/2026-06-15-inquisitor-phase1b-execution-eval-design.md`
+§3 (fixtures) and §4 (the differential oracle) for the full construct.
+
+## Per-repo layout (`fixtures/<repo-id>/`)
+
+```
+src/<pkg>/...               # all-buggy source tree (committed = base state)
+tests/                      # empty dir + conftest.py; arms/oracle write test files here
+fixes/<bug_id>.patch        # one independently-revertible patch per seeded bug
+exemplars/<bug_id>.py       # fixture-build BEHAVIORAL exemplar test for each bug
+ground-truth-bugs.json      # blind-authored bug list (schema below), off_axis tagged post-blind
+ground-truth-bugs.provenance.md   # blind boundary + post-blind off_axis pass record
+manifest.json               # repo id, pkg, test dir, runner cmd, bug ids, n
+```
+
+## Variants (materialized, never committed)
+
+The oracle and the fixture-build invariant checker materialize three variant
+classes from the committed base + the per-bug patches (see `_fixtures.py`):
+
+- **`base`** — the source tree as committed (every seeded bug live).
+- **`all-fixed`** — base + every `fixes/<bug_id>.patch` applied.
+- **`all-fixed-minus-Bᵢ`** — base + every patch **except** Bᵢ's (one per bug).
+
+All patches are authored **against the committed base** and touch **disjoint
+files or disjoint base-line ranges**, so they compose order-independently and
+zero-fuzz: `all-fixed` and every `all-fixed-minus-Bᵢ` apply cleanly.
+
+## `manifest.json` schema
+
+```json
+{
+  "repo_id": "notify",
+  "pkg": "notify",
+  "test_dir": "tests",
+  "runner_cmd": ["python3", "-m", "pytest", "-q"],
+  "bug_ids": ["nt-b1", "nt-b2", "..."],
+  "n": 8
+}
+```
+
+`len(bug_ids) == n` is an invariant (`load_manifest` asserts it).
+
+## `ground-truth-bugs.json` schema
+
+```json
+{
+  "_provenance": "see ground-truth-bugs.provenance.md",
+  "bugs": [
+    {
+      "bug_id": "nt-b1",
+      "desc": "epoch-int written into a field the consumer reads as an ISO timestamp",
+      "off_axis": false,
+      "fix_patch": "fixes/nt-b1.patch"
+    }
+  ],
+  "interacting_sets": []
+}
+```
+
+- **`bug_id`** — stable id; matches `fixes/<bug_id>.patch` and `exemplars/<bug_id>.py`.
+- **`desc`** — behavioral description of the observably-wrong output (authored blind).
+- **`off_axis`** — `true` for defects outside the 5 dimension lenses (Wiring /
+  Integration / Edge Cases / State & Lifecycle / Regression), so the bare arms
+  (WITHOUT/POOL) get fair credit.
+- **`fix_patch`** — repo-relative path to the patch that fixes ONLY this bug.
+- **`interacting_sets`** — list of `bug_id` lists; the audited escape for a
+  genuinely co-violable pair that fixture construction could not avoid (§3, §4).
+  Empty is the norm — independence is the rule.
+
+## Blind ground-truth discipline
+
+GT is authored from the source tree + factual context only, **blind to the
+dimension taxonomy** (the 5 lens titles and the four arm names WITH/POOL/MID/
+WITHOUT are the leak set). The exact blind input is recorded in
+`ground-truth-bugs.provenance.md`; `scripts/check_fixture_gt_provenance.py`
+asserts no leak.
+
+**`off_axis` is tagged in a separate post-blind pass** (§3): after blind GT
+authoring is sealed, a role that authors no arm's tests and is not the GT author
+applies the `off_axis` tag. The provenance file records this as a distinct,
+post-blind step.
+
+## Behavioral-independence (the fixture-construction invariant)
+
+The seeded bugs in each repo MUST be pairwise **behaviorally independent**: no
+two bugs may be co-violable by a single behavioral assertion. Concretely, each
+bug Bᵢ's exemplar test is:
+
+- **GREEN on `all-fixed`** (passes when nothing is broken),
+- **RED on the full-buggy base** (it actually catches a real bug),
+- **RED on its own `all-fixed-minus-Bᵢ`** (removing only Bᵢ's fix re-breaks it),
+- **GREEN on every *other* `all-fixed-minus-Bⱼ` (j≠i)** (no co-violable pairs).
+
+This is what makes §4's leave-one-out attribution clean and arm-neutral without
+a specificity gate. `scripts/check_fixture_independence.py` verifies it.

--- a/skills/inquisitor/evals/fixtures/README.md
+++ b/skills/inquisitor/evals/fixtures/README.md
@@ -17,6 +17,25 @@ ground-truth-bugs.provenance.md   # blind boundary + post-blind off_axis pass re
 manifest.json               # repo id, pkg, test dir, runner cmd, bug ids, n
 ```
 
+### Committed substrate is annotated; the producer copy is NOT
+
+The committed `src/` annotates each seeded bug with its id + a plain-language
+description (`# BUG nt-b8: …`, `(nt-b1)`) — build scaffolding for the maintainer
+and the oracle, NOT a producer-visible artifact. The **producer never sees the
+committed tree**: `stage_exec`'s `copy_for` builds the agent sandbox with
+`_fixtures.copy_repo_for_producer`, which (F2) copies ONLY `src/` + `tests/` —
+never `exemplars/`, `fixes/`, `ground-truth-bugs*`, or `manifest.json` — and (F1)
+**strips all comments and docstrings from every producer-visible `*.py` (both the
+copied `src/` AND `tests/` subtrees)**, so no leak token or bug-describing prose
+survives (token-aware, code byte-identical). `scripts/check_fixture_producer_blind.py`
++ `_fixtures._assert_no_leak` + `_fixtures.assert_no_description_leak` (stage-time
+assertions) enforce, **across every producer-visible subtree (`src/` and `tests/`,
+not `src/` alone)**, that no producer copy carries a bug-id token, GT-description
+prose, or an answer-key path; `_assert_no_leak` additionally machine-checks the
+`tests/`-is-empty-except-`conftest.py` invariant. The oracle scores from this
+committed tree (`_FIXTURES_DIR`), not from the producer copy, so the annotations
+never reach the measured arm yet remain available to scoring.
+
 ## Variants (materialized, never committed)
 
 The oracle and the fixture-build invariant checker materialize three variant

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b1.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b1.py
@@ -1,0 +1,13 @@
+from notify.db import Store, reset
+from notify.scheduler import Scheduler
+
+
+def test_scheduled_at_is_iso_string():
+    reset()
+    store = Store()
+    sched = Scheduler(store, lambda: 1_700_000_000)
+    rec = sched.schedule("j1", 60)
+    sa = rec["scheduled_at"]
+    # The notifier consumes scheduled_at as an ISO-8601 timestamp string.
+    assert isinstance(sa, str)
+    assert sa[:10] == "2023-11-14"

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b2.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b2.py
@@ -1,0 +1,12 @@
+from notify.db import Store, reset
+
+
+def test_job_survives_restart():
+    reset()
+    # Schedule a job through one store handle...
+    s1 = Store()
+    s1.save_job("j-keep", {"job_id": "j-keep", "delay": 30})
+    # ...then simulate a process restart: a brand-new Store handle must still
+    # see the previously-scheduled job (it is durable, not in-process-only).
+    s2 = Store()
+    assert s2.get_job("j-keep") == {"job_id": "j-keep", "delay": 30}

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b3.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b3.py
@@ -1,0 +1,12 @@
+from notify.db import Store, reset
+from notify.scheduler import Scheduler
+
+
+def test_negative_delay_is_clamped():
+    reset()
+    store = Store()
+    sched = Scheduler(store, lambda: 1_700_000_000)
+    # A caller-supplied negative delay would make the job fire in the past; the
+    # stored, validated delay must never be negative.
+    rec = sched.schedule("j-neg", -500)
+    assert rec["delay"] == 0

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b4.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b4.py
@@ -1,0 +1,14 @@
+from notify.db import Store, reset
+from notify.notifier import Notifier
+
+
+def test_alert_handler_builds_label():
+    reset()
+    store = Store()
+    store.save_job("j-alert", {"job_id": "j-alert"})
+    notifier = Notifier(store)
+    # Invoking the alert handler must produce a severity-prefixed label, not
+    # raise at runtime.
+    out = notifier.handle_alert("j-alert", "warn")
+    assert out["label"] == "WARN:j-alert"
+    assert out["severity"] == "warn"

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b5.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b5.py
@@ -1,0 +1,19 @@
+from notify import routes
+
+
+def test_disallowed_webhook_url_is_refused():
+    calls = []
+
+    def transport(url, payload):
+        calls.append((url, payload))
+        return 200
+
+    # A disallowed (non-allowlisted) URL must be refused before the transport
+    # is ever dialed.
+    refused = False
+    try:
+        routes.dispatch("file:///etc/passwd", {"x": 1}, transport)
+    except ValueError:
+        refused = True
+    assert refused is True
+    assert calls == []

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b6.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b6.py
@@ -1,0 +1,13 @@
+from notify.db import Store, reset
+
+
+def test_failed_delivery_not_recorded_as_sent():
+    reset()
+    store = Store()
+    # A non-2xx transport status means the delivery failed; it must NOT be
+    # recorded as sent.
+    store.record_delivery("j-fail", 500)
+    rows = store.deliveries()
+    assert len(rows) == 1
+    assert rows[0]["job_id"] == "j-fail"
+    assert rows[0]["sent"] is False

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b7.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b7.py
@@ -1,0 +1,15 @@
+from notify.db import Store, reset
+from notify.scheduler import Scheduler
+
+
+def test_cancel_reaches_job_from_other_instance():
+    reset()
+    store = Store()
+    # Two schedulers wired to the SAME store.
+    sched_a = Scheduler(store, lambda: 1_700_000_000)
+    sched_b = Scheduler(store, lambda: 1_700_000_000)
+    sched_a.schedule_tracked("j-x", 10)
+    # A cancel issued on the other instance must reach the job.
+    ok = sched_b.cancel("j-x")
+    assert ok is True
+    assert store.get_job("j-x") is None

--- a/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b8.py
+++ b/skills/inquisitor/evals/fixtures/notify/exemplars/nt-b8.py
@@ -1,0 +1,11 @@
+from notify.db import Store, reset
+from notify.notifier import Notifier
+
+
+def test_default_channel_is_email():
+    reset()
+    store = Store()
+    notifier = Notifier(store)
+    # A job that names no channel falls back to the historical default.
+    rec = {"job_id": "j-d"}
+    assert notifier.choose_channel(rec) == "email"

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b1.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b1.patch
@@ -1,0 +1,11 @@
+--- a/src/notify/scheduler.py
++++ b/src/notify/scheduler.py
+@@ -35,7 +35,7 @@
+         # BUG nt-b1: scheduled_at is written as a raw epoch int, but the
+         # notifier reads scheduled_at as an ISO-8601 timestamp string. The fix
+         # stores the ISO rendering instead of the bare int.
+-        scheduled_at = fire_at_epoch
++        scheduled_at = _iso_from_epoch(fire_at_epoch)
+         record = {
+             "job_id": job_id,
+             "delay": delay,

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b2.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b2.patch
@@ -1,0 +1,11 @@
+--- a/src/notify/db.py
++++ b/src/notify/db.py
+@@ -24,7 +24,7 @@
+         # BUG nt-b2: jobs are kept in a per-instance dict, so a new Store()
+         # (a process "restart") starts empty and loses everything previously
+         # scheduled. The fix points this at the module-level _PERSISTENT_JOBS.
+-        self._jobs = {}
++        self._jobs = _PERSISTENT_JOBS
+ 
+     def save_job(self, job_id, record):
+         self._jobs[job_id] = record

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b3.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b3.patch
@@ -1,0 +1,11 @@
+--- a/src/notify/scheduler.py
++++ b/src/notify/scheduler.py
+@@ -50,6 +50,8 @@
+         # BUG nt-b3: a None or negative delay is passed straight through, so a
+         # job's effective delay can be negative (it would fire in the past).
+         # The fix coerces None to 0 and clamps negatives up to 0.
++        if delay is None or delay < 0:
++            return 0
+         return delay
+ 
+     # -- seam nt-b7: cancellation across wired instances --------------------

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b4.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b4.patch
@@ -1,0 +1,9 @@
+--- a/src/notify/notifier.py
++++ b/src/notify/notifier.py
+@@ -51,5 +51,6 @@
+         # BUG nt-b4: `prefix` is never defined, so invoking this handler raises
+         # NameError at runtime (the module still imports fine). The fix derives
+         # prefix from the severity.
++        prefix = severity.upper()
+         label = prefix + ":" + str(job_id)
+         return {"label": label, "severity": severity}

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b5.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b5.patch
@@ -1,0 +1,11 @@
+--- a/src/notify/routes.py
++++ b/src/notify/routes.py
+@@ -28,6 +28,8 @@
+     # BUG nt-b5: the URL is dialed without any scheme/host validation, so a
+     # disallowed (e.g. file:// or attacker-controlled host) URL is sent to.
+     # The fix refuses anything not on the allowlist before calling transport.
++    if not is_allowed(url):
++        raise ValueError(f"refused webhook URL: {url}")
+     return transport(url, payload)
+ 
+ 

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b6.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b6.patch
@@ -1,0 +1,11 @@
+--- a/src/notify/db.py
++++ b/src/notify/db.py
+@@ -48,7 +48,7 @@
+         # BUG nt-b6: the status_code is ignored and every delivery is recorded
+         # as sent, so a failed (non-2xx) delivery is indistinguishable from a
+         # successful one. The fix records sent only on a 2xx status.
+-        delivered = True
++        delivered = 200 <= status_code < 300
+         _DELIVERIES.append({"job_id": job_id, "sent": delivered})
+         return delivered
+ 

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b7.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b7.patch
@@ -1,0 +1,11 @@
+--- a/src/notify/scheduler.py
++++ b/src/notify/scheduler.py
+@@ -63,7 +63,7 @@
+         # BUG nt-b7: cancel consults a per-instance set of job_ids this exact
+         # instance scheduled, so a cancel cannot reach a job another instance
+         # scheduled into the shared store. The fix cancels through the store.
+-        if job_id in self._locally_scheduled():
++        if self._store.get_job(job_id) is not None:
+             self._store.delete_job(job_id)
+             return True
+         return False

--- a/skills/inquisitor/evals/fixtures/notify/fixes/nt-b8.patch
+++ b/skills/inquisitor/evals/fixtures/notify/fixes/nt-b8.patch
@@ -1,0 +1,11 @@
+--- a/src/notify/notifier.py
++++ b/src/notify/notifier.py
+@@ -11,7 +11,7 @@
+ 
+ # The historically-correct default channel. Existing call sites that omit a
+ # channel rely on "email" being chosen.
+-DEFAULT_CHANNEL = "sms"  # BUG nt-b8: regressed from "email"; the fix restores it.
++DEFAULT_CHANNEL = "email"  # restored historical default.
+ 
+ 
+ class Notifier:

--- a/skills/inquisitor/evals/fixtures/notify/ground-truth-bugs.json
+++ b/skills/inquisitor/evals/fixtures/notify/ground-truth-bugs.json
@@ -1,0 +1,54 @@
+{
+  "_provenance": "see ground-truth-bugs.provenance.md",
+  "bugs": [
+    {
+      "bug_id": "nt-b1",
+      "desc": "A scheduled job's scheduled_at is returned as a raw epoch integer instead of an ISO-8601 timestamp string, so a reader that formats it as a date string breaks",
+      "off_axis": false,
+      "fix_patch": "fixes/nt-b1.patch"
+    },
+    {
+      "bug_id": "nt-b2",
+      "desc": "A job saved through one store handle is gone after a process restart: a freshly constructed store handle sees none of the previously saved jobs",
+      "off_axis": false,
+      "fix_patch": "fixes/nt-b2.patch"
+    },
+    {
+      "bug_id": "nt-b3",
+      "desc": "A job scheduled with a negative delay keeps that negative delay (fire time in the past) instead of being clamped to zero",
+      "off_axis": false,
+      "fix_patch": "fixes/nt-b3.patch"
+    },
+    {
+      "bug_id": "nt-b4",
+      "desc": "Invoking the alert handler crashes at call time instead of returning a severity-prefixed label",
+      "off_axis": false,
+      "fix_patch": "fixes/nt-b4.patch"
+    },
+    {
+      "bug_id": "nt-b5",
+      "desc": "A webhook to a disallowed URL is dialed through the transport instead of being refused before any send",
+      "off_axis": true,
+      "fix_patch": "fixes/nt-b5.patch"
+    },
+    {
+      "bug_id": "nt-b6",
+      "desc": "A delivery the transport reports as failed is still recorded as sent instead of not-sent",
+      "off_axis": true,
+      "fix_patch": "fixes/nt-b6.patch"
+    },
+    {
+      "bug_id": "nt-b7",
+      "desc": "A cancel issued through one scheduler instance cannot remove a job scheduled by a different scheduler instance sharing the same store",
+      "off_axis": false,
+      "fix_patch": "fixes/nt-b7.patch"
+    },
+    {
+      "bug_id": "nt-b8",
+      "desc": "A job that names no channel falls back to 'sms' instead of the historical default 'email'",
+      "off_axis": false,
+      "fix_patch": "fixes/nt-b8.patch"
+    }
+  ],
+  "interacting_sets": []
+}

--- a/skills/inquisitor/evals/fixtures/notify/ground-truth-bugs.provenance.md
+++ b/skills/inquisitor/evals/fixtures/notify/ground-truth-bugs.provenance.md
@@ -1,0 +1,22 @@
+# Ground-truth provenance — notify
+
+## Blind GT authoring
+The bug list (bug_id, desc, fix_patch) for this seeded repo was authored from the
+committed source tree plus the per-bug fix patches and the behavioral exemplar
+tests only — i.e. from the observable wrong-vs-correct behavior of each seam. The
+author was blind to the eval's lensed dimension taxonomy and to the arm/treatment
+names; no taxonomy or treatment string was consulted while writing the
+descriptions.
+
+Blind input: skills/inquisitor/evals/fixtures/notify/{src,fixes,exemplars}.
+
+## Off-axis tagging (post-blind, disjoint role)
+The off_axis flags were applied in a separate pass that ran AFTER the blind GT
+authoring above was sealed, by a role disjoint from the GT author and from every
+arm/exemplar test-authoring role. off_axis:true marks a defect that lies outside
+the lensed dimension taxonomy (so the bare, un-lensed arms are credited fairly for
+catching it); off_axis:false marks an on-taxonomy seam defect.
+
+## Independence
+All seeded bugs in this repo are pairwise behaviorally independent (verified by
+scripts/check_fixture_independence.py); no interacting_sets are registered.

--- a/skills/inquisitor/evals/fixtures/notify/manifest.json
+++ b/skills/inquisitor/evals/fixtures/notify/manifest.json
@@ -1,0 +1,1 @@
+{"repo_id":"notify","pkg":"notify","test_dir":"tests","runner_cmd":["python3","-m","pytest","-q"],"bug_ids":["nt-b1","nt-b2","nt-b3","nt-b4","nt-b5","nt-b6","nt-b7","nt-b8"],"n":8}

--- a/skills/inquisitor/evals/fixtures/notify/src/notify/app.py
+++ b/skills/inquisitor/evals/fixtures/notify/src/notify/app.py
@@ -1,0 +1,53 @@
+"""Application wiring: assembles Store + Scheduler + Notifier + routing.
+
+This is the composition root the exemplars drive end-to-end. It owns the
+hermetic defaults: a fake clock and an in-memory webhook transport.
+"""
+from notify.db import Store
+from notify.scheduler import Scheduler
+from notify.notifier import Notifier
+from notify import routes
+
+
+def fixed_clock(epoch=1_700_000_000):
+    """A deterministic clock factory (no real wall-clock)."""
+    return lambda: epoch
+
+
+class FakeTransport:
+    """In-memory webhook transport. Records calls; returns a canned status."""
+
+    def __init__(self, status=200):
+        self.status = status
+        self.calls = []
+
+    def __call__(self, url, payload):
+        self.calls.append((url, payload))
+        return self.status
+
+
+class App:
+    """Composition root wiring the notification subsystem together."""
+
+    def __init__(self, store=None, clock=None, transport=None):
+        self.store = store if store is not None else Store()
+        self.clock = clock if clock is not None else fixed_clock()
+        self.transport = transport if transport is not None else FakeTransport()
+        self.scheduler = Scheduler(self.store, self.clock)
+        self.notifier = Notifier(self.store)
+
+    def schedule(self, job_id, delay, channel=None):
+        rec = self.scheduler.schedule_tracked(job_id, delay)
+        if channel is not None:
+            rec["channel"] = channel
+            self.store.save_job(job_id, rec)
+        return rec
+
+    def cancel(self, job_id):
+        return self.scheduler.cancel(job_id)
+
+    def deliver(self, job_id, url):
+        """Send a job's webhook through routing, recording the outcome."""
+        payload = self.notifier.render(job_id)
+        status = routes.dispatch(url, payload, self.transport)
+        return self.store.record_delivery(job_id, status)

--- a/skills/inquisitor/evals/fixtures/notify/src/notify/db.py
+++ b/skills/inquisitor/evals/fixtures/notify/src/notify/db.py
@@ -1,0 +1,62 @@
+"""In-memory persistence layer for the notification scheduler.
+
+The store is a tiny stand-in for a real database. Jobs and delivery records
+live here. Two seams are exercised through this module:
+
+  * job persistence across a process "restart" (nt-b2)
+  * whether a delivery is recorded as "sent" only when it actually succeeded
+    (nt-b6)
+
+Everything is hermetic: no real DB, no I/O.
+"""
+
+
+# A module-level dict acts as the durable backing store. A fresh Store() wired
+# over the same namespace must see jobs scheduled before a "restart".
+_PERSISTENT_JOBS = {}
+_DELIVERIES = []
+
+
+class Store:
+    """Handle onto the notification persistence layer."""
+
+    def __init__(self):
+        # BUG nt-b2: jobs are kept in a per-instance dict, so a new Store()
+        # (a process "restart") starts empty and loses everything previously
+        # scheduled. The fix points this at the module-level _PERSISTENT_JOBS.
+        self._jobs = {}
+
+    def save_job(self, job_id, record):
+        self._jobs[job_id] = record
+
+    def get_job(self, job_id):
+        return self._jobs.get(job_id)
+
+    def all_jobs(self):
+        return dict(self._jobs)
+
+    def delete_job(self, job_id):
+        self._jobs.pop(job_id, None)
+
+    # -- delivery records ---------------------------------------------------
+
+    def record_delivery(self, job_id, status_code):
+        """Record the outcome of a webhook delivery.
+
+        A delivery counts as "sent" only when the transport reports success.
+        """
+        # BUG nt-b6: the status_code is ignored and every delivery is recorded
+        # as sent, so a failed (non-2xx) delivery is indistinguishable from a
+        # successful one. The fix records sent only on a 2xx status.
+        delivered = True
+        _DELIVERIES.append({"job_id": job_id, "sent": delivered})
+        return delivered
+
+    def deliveries(self):
+        return list(_DELIVERIES)
+
+
+def reset():
+    """Test helper: clear the durable backing store."""
+    _PERSISTENT_JOBS.clear()
+    _DELIVERIES.clear()

--- a/skills/inquisitor/evals/fixtures/notify/src/notify/notifier.py
+++ b/skills/inquisitor/evals/fixtures/notify/src/notify/notifier.py
@@ -1,0 +1,55 @@
+"""Notifier: consumes stored job records and produces an outbound message.
+
+Seams exercised here:
+
+  * the handler that renders a job into a deliverable message (nt-b4)
+  * the default channel applied when a job names none (nt-b8)
+
+The notifier reads `scheduled_at` as an ISO-8601 timestamp string (it is the
+consumer half of the scheduler->notifier seam, nt-b1).
+"""
+
+# The historically-correct default channel. Existing call sites that omit a
+# channel rely on "email" being chosen.
+DEFAULT_CHANNEL = "sms"  # BUG nt-b8: regressed from "email"; the fix restores it.
+
+
+class Notifier:
+    """Renders job records into outbound messages."""
+
+    def __init__(self, store):
+        self._store = store
+
+    def render(self, job_id):
+        """Render the stored job into a deliverable message dict.
+
+        Reads scheduled_at as an ISO-8601 string (consumer side of nt-b1).
+        """
+        record = self._store.get_job(job_id)
+        scheduled_at = record["scheduled_at"]
+        # The consumer expects an ISO string and slices off the date portion;
+        # if the producer wrote an epoch int this raises at runtime (nt-b1).
+        date_part = scheduled_at[:10]
+        return {
+            "job_id": job_id,
+            "fires_on": date_part,
+            "channel": self.choose_channel(record),
+        }
+
+    def choose_channel(self, record):
+        """Pick the delivery channel for a job, defaulting when none is set."""
+        return record.get("channel") or DEFAULT_CHANNEL
+
+    # -- seam nt-b4: the alert handler (kept well below render's lines) ------
+
+    def handle_alert(self, job_id, severity):
+        """Build an alert payload for a job (invoked by the alert wiring).
+
+        Imports cleanly; the undefined reference only fires when called.
+        """
+        record = self._store.get_job(job_id)
+        # BUG nt-b4: `prefix` is never defined, so invoking this handler raises
+        # NameError at runtime (the module still imports fine). The fix derives
+        # prefix from the severity.
+        label = prefix + ":" + str(job_id)
+        return {"label": label, "severity": severity}

--- a/skills/inquisitor/evals/fixtures/notify/src/notify/routes.py
+++ b/skills/inquisitor/evals/fixtures/notify/src/notify/routes.py
@@ -1,0 +1,37 @@
+"""Outbound webhook routing.
+
+Seam exercised here: validation of a caller-supplied webhook URL before the
+notifier dials it (nt-b5). The transport is a pluggable callable so the module
+stays hermetic — it never makes a real HTTP call.
+"""
+
+# Only these schemes/hosts are permitted webhook targets.
+_ALLOWED_SCHEMES = ("https",)
+_ALLOWED_HOSTS = ("hooks.internal", "hooks.example.com")
+
+
+def _parse(url):
+    """Crude scheme/host split (stdlib urllib would do, kept inline + hermetic)."""
+    scheme = url.split("://", 1)[0] if "://" in url else ""
+    rest = url.split("://", 1)[1] if "://" in url else url
+    host = rest.split("/", 1)[0]
+    return scheme, host
+
+
+def dispatch(url, payload, transport):
+    """Send `payload` to `url` via `transport`, returning the transport result.
+
+    `transport` is a callable (url, payload) -> status_code; the default in
+    app.py is an in-memory fake. A caller-supplied URL MUST be validated against
+    the allowlist before it is dialed.
+    """
+    # BUG nt-b5: the URL is dialed without any scheme/host validation, so a
+    # disallowed (e.g. file:// or attacker-controlled host) URL is sent to.
+    # The fix refuses anything not on the allowlist before calling transport.
+    return transport(url, payload)
+
+
+def is_allowed(url):
+    """Return True iff `url` is a permitted webhook target."""
+    scheme, host = _parse(url)
+    return scheme in _ALLOWED_SCHEMES and host in _ALLOWED_HOSTS

--- a/skills/inquisitor/evals/fixtures/notify/src/notify/scheduler.py
+++ b/skills/inquisitor/evals/fixtures/notify/src/notify/scheduler.py
@@ -1,0 +1,79 @@
+"""Job scheduler: turns a (job_id, delay) request into a stored job record.
+
+Seams exercised here:
+
+  * the timestamp it writes for the consumer (notifier) to read (nt-b1)
+  * validation of the caller-supplied delay (nt-b3)
+  * whether two wired schedulers share cancellation state (nt-b7)
+
+A clock is injected so the module is hermetic (no real wall-clock).
+"""
+import datetime
+
+
+def _iso_from_epoch(epoch_seconds):
+    """Render an epoch-second value as a UTC ISO-8601 string."""
+    return datetime.datetime.utcfromtimestamp(epoch_seconds).isoformat()
+
+
+class Scheduler:
+    """Schedules jobs into a shared Store, computing each job's fire time.
+
+    `clock` is a zero-arg callable returning the current epoch seconds (int).
+    """
+
+    def __init__(self, store, clock):
+        self._store = store
+        self._clock = clock
+
+    # -- seam nt-b1: the scheduled_at the notifier consumes -----------------
+
+    def schedule(self, job_id, delay):
+        now = self._clock()
+        delay = self._validate_delay(delay)
+        fire_at_epoch = now + delay
+        # BUG nt-b1: scheduled_at is written as a raw epoch int, but the
+        # notifier reads scheduled_at as an ISO-8601 timestamp string. The fix
+        # stores the ISO rendering instead of the bare int.
+        scheduled_at = fire_at_epoch
+        record = {
+            "job_id": job_id,
+            "delay": delay,
+            "scheduled_at": scheduled_at,
+        }
+        self._store.save_job(job_id, record)
+        return record
+
+    # -- seam nt-b3: delay validation (kept well below schedule's lines) ----
+
+    def _validate_delay(self, delay):
+        # BUG nt-b3: a None or negative delay is passed straight through, so a
+        # job's effective delay can be negative (it would fire in the past).
+        # The fix coerces None to 0 and clamps negatives up to 0.
+        return delay
+
+    # -- seam nt-b7: cancellation across wired instances --------------------
+
+    def cancel(self, job_id):
+        """Cancel a previously-scheduled job.
+
+        A cancel issued on any scheduler wired to the same store must reach a
+        job scheduled by any other such scheduler.
+        """
+        # BUG nt-b7: cancel consults a per-instance set of job_ids this exact
+        # instance scheduled, so a cancel cannot reach a job another instance
+        # scheduled into the shared store. The fix cancels through the store.
+        if job_id in self._locally_scheduled():
+            self._store.delete_job(job_id)
+            return True
+        return False
+
+    def _locally_scheduled(self):
+        if not hasattr(self, "_seen"):
+            self._seen = set()
+        return self._seen
+
+    def schedule_tracked(self, job_id, delay):
+        rec = self.schedule(job_id, delay)
+        self._locally_scheduled().add(job_id)
+        return rec

--- a/skills/inquisitor/evals/fixtures/notify/tests/conftest.py
+++ b/skills/inquisitor/evals/fixtures/notify/tests/conftest.py
@@ -1,0 +1,2 @@
+import pathlib, sys
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b1.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b1.py
@@ -1,0 +1,22 @@
+"""pg-b1: a cursor decoded to the wrong type breaks page chaining.
+
+Drive the cursor seam end to end through the paginator: take page 1, then follow
+its next_cursor to page 2 and assert page 2 begins at exactly one past the id the
+cursor encodes. The boundary is read from the cursor (not the emitted slice), so
+this isolates the encode/decode <-> store id-comparison seam from any unrelated
+slice off-by-one. With a string-typed decode the boundary comparison breaks and
+page 2 does not continue from the cursor.
+"""
+from paginate.store import Store
+from paginate.paginator import Paginator
+from paginate.cursor import decode_cursor
+
+
+def test_following_cursor_continues_from_the_encoded_boundary():
+    pg = Paginator(Store())
+    page1 = pg.page(limit=3)
+    assert page1["items"][0]["id"] == 1
+    boundary = decode_cursor(page1["next_cursor"])
+    page2 = pg.page(token=page1["next_cursor"], limit=3)
+    # page 2 must begin at the record immediately after the encoded boundary
+    assert page2["items"][0]["id"] == boundary + 1

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b2.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b2.py
@@ -1,0 +1,17 @@
+"""pg-b2: the response envelope shape regressed, breaking downstream consumers.
+
+A downstream consumer reads the documented envelope: resp["data"] for the
+records and resp["paging"]["next_cursor"] for the continuation token. Assert the
+handler emits exactly that documented shape (not the flat legacy shape). Checks
+shape only, so an unrelated off-by-one in the page contents cannot mask it.
+"""
+from paginate.store import Store
+from paginate.routes import list_records
+
+
+def test_response_uses_the_documented_envelope_shape():
+    resp = list_records(Store(), token=None, limit=3)
+    assert set(resp.keys()) == {"data", "paging"}
+    assert isinstance(resp["data"], list)
+    assert "next_cursor" in resp["paging"]
+    assert all("id" in r for r in resp["data"])

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b3.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b3.py
@@ -1,0 +1,20 @@
+"""pg-b3: a non-positive limit is passed through instead of being floored.
+
+Through the route handler, a limit of 0 must yield a sane non-empty page (the
+default), never an empty or reversed-slice page. Reads the page shape-agnostically
+so an unrelated envelope-shape change does not mask this defect.
+"""
+from paginate.store import Store
+from paginate.routes import list_records
+
+
+def _items(resp):
+    return resp["data"] if "data" in resp else resp["items"]
+
+
+def test_zero_limit_is_floored_to_a_sane_page_not_empty():
+    resp = list_records(Store(), token=None, limit=0)
+    items = _items(resp)
+    # floored to a sane page: non-empty and starting at the first record
+    assert len(items) >= 1
+    assert items[0]["id"] == 1

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b4.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b4.py
@@ -1,0 +1,22 @@
+"""pg-b4: paging on a positional offset (not the stable id) skips a record when
+the dataset shrinks between page requests.
+
+Use the cursor-free store<->paginator seam (page_from_boundary with an explicit
+id boundary) so this depends only on the store's paging key, not on the cursor
+codec. Take page 1, delete an earlier record, then fetch the next page by the
+last-seen id: the next page must *start* with the very next id, no skip.
+"""
+from paginate.store import Store
+from paginate.paginator import Paginator
+
+
+def test_no_record_skipped_when_earlier_record_deleted_between_pages():
+    store = Store()
+    pg = Paginator(store)
+    page1 = pg.page_from_boundary(0, 3)
+    assert [r["id"] for r in page1["items"]][:1] == [1]
+    last_id = page1["items"][-1]["id"]  # 3
+    store.delete(1)  # an earlier record disappears between requests
+    page2 = pg.page_from_boundary(last_id, 3)
+    # must continue from id 3 with no skip: next page starts at 4 (not 5)
+    assert page2["items"][0]["id"] == last_id + 1

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b5.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b5.py
@@ -1,0 +1,15 @@
+"""pg-b5: an off-by-one at the page boundary drops the trailing record.
+
+Cursor-free store<->paginator seam: a single page request for N records must
+emit exactly those N records, including the boundary record (none dropped).
+"""
+from paginate.store import Store
+from paginate.paginator import Paginator
+
+
+def test_page_emits_every_requested_record_including_the_boundary():
+    pg = Paginator(Store())
+    page = pg.page_from_boundary(0, 4)
+    ids = [r["id"] for r in page["items"]]
+    # all four requested records present; the 4th (boundary) is not dropped
+    assert ids == [1, 2, 3, 4]

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b6.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b6.py
@@ -1,0 +1,24 @@
+"""pg-b6: the default page size regressed from the documented value.
+
+When the caller relies on the default (limit omitted), the boundary advanced by
+the page must be the documented DEFAULT_PAGE_SIZE-th record. Read next_cursor's
+encoded id via the same codec the producer used (cursor-stable), and compare to
+the documented default size. Independent of the off-by-one emit bug because
+next_cursor keys on the last fetched id, not the emitted slice.
+"""
+import base64
+
+from paginate.store import Store
+from paginate.paginator import Paginator, DEFAULT_PAGE_SIZE
+
+
+def _decode_id(token):
+    return int(base64.urlsafe_b64decode(token.encode("ascii")).decode("ascii"))
+
+
+def test_default_page_advances_by_the_documented_default_size():
+    pg = Paginator(Store())
+    page = pg.page()  # no limit -> documented default
+    assert DEFAULT_PAGE_SIZE == 5
+    # the cursor must point at the 5th record (id 5), not the 10th
+    assert _decode_id(page["next_cursor"]) == 5

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b7.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b7.py
@@ -1,0 +1,22 @@
+"""pg-b7: no upper bound on limit lets a caller request an unbounded page.
+
+Through the route handler, an absurdly large limit must be capped at the server
+maximum. Reads the page shape-agnostically and asserts the returned count never
+exceeds the cap (independent of any off-by-one in the emitted slice).
+"""
+from paginate.store import Store
+from paginate.routes import list_records
+from paginate.paginator import MAX_PAGE_SIZE
+
+
+def _items(resp):
+    return resp["data"] if "data" in resp else resp["items"]
+
+
+def test_oversized_limit_is_capped_at_the_server_maximum():
+    # dataset deliberately larger than the cap so an uncapped limit would
+    # return far more than MAX_PAGE_SIZE records.
+    big = [{"id": i, "name": "r{}".format(i)} for i in range(1, 121)]
+    resp = list_records(Store(big), token=None, limit=10_000)
+    items = _items(resp)
+    assert len(items) <= MAX_PAGE_SIZE  # capped at 50, never 120 / 10000

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b8.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b8.py
@@ -1,0 +1,16 @@
+"""pg-b8: a malformed cursor is swallowed and silently restarts at page 1.
+
+The app entry point must surface a malformed cursor as a clean InvalidCursor
+rejection, never silently return the first page (which a caller cannot
+distinguish from a legitimate first page).
+"""
+import pytest
+
+from paginate.app import App
+from paginate.cursor import InvalidCursor
+
+
+def test_malformed_cursor_is_rejected_not_silently_reset():
+    app = App()
+    with pytest.raises(InvalidCursor):
+        app.list(token="%%%not-a-valid-cursor%%%")

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b1.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b1.patch
@@ -1,0 +1,8 @@
+--- a/src/paginate/cursor.py
++++ b/src/paginate/cursor.py
+@@ -37,4 +37,4 @@
+     # the raw decoded STRING instead of int(text). The store then compares
+     # integer record ids against a string boundary, so the comparison never
+     # advances correctly and the next page does not continue where this ended.
+-    return text
++    return int(text)

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b2.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b2.patch
@@ -1,0 +1,8 @@
+--- a/src/paginate/routes.py
++++ b/src/paginate/routes.py
+@@ -30,4 +30,4 @@
+     # ({"items", "next_cursor"}) instead of the documented envelope
+     # ({"data", "paging": {"next_cursor"}}), breaking downstream consumers
+     # that read resp["data"] / resp["paging"]["next_cursor"].
+-    return {"items": items, "next_cursor": next_cursor}
++    return {"data": items, "paging": {"next_cursor": next_cursor}}

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b3.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b3.patch
@@ -1,0 +1,9 @@
+--- a/src/paginate/validate.py
++++ b/src/paginate/validate.py
+@@ -20,5 +20,5 @@
+     # instead of being floored to the default page size, producing an empty
+     # page or a reversed-slice page downstream.
+     if limit < 1:
+-        return limit
++        return DEFAULT_PAGE_SIZE
+     return limit

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b4.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b4.patch
@@ -1,0 +1,10 @@
+--- a/src/paginate/store.py
++++ b/src/paginate/store.py
+@@ -47,5 +47,5 @@
+         # an earlier record is deleted between page requests, every later
+         # record shifts down one position, so this offset overshoots and the
+         # first record of the next page is skipped.
+-        offset = boundary_id  # treat the boundary value itself as the offset
+-        return [dict(r) for r in self._records[offset:offset + limit]]
++        out = [r for r in self._records if r["id"] > boundary_id]
++        return [dict(r) for r in out[:limit]]

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b5.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b5.patch
@@ -1,0 +1,11 @@
+--- a/src/paginate/paginator.py
++++ b/src/paginate/paginator.py
+@@ -36,7 +36,7 @@
+         # BUG pg-b5: off-by-one at the page boundary — the trailing record is
+         # dropped from the emitted page (rows[:-1]) even though next_cursor
+         # still advances past it, so that record is lost between pages.
+-        emitted = rows[:-1] if len(rows) > 1 else rows
++        emitted = rows
+         last = rows[-1]
+         next_cursor = cursor_mod.encode_cursor(last["id"])
+         return {"items": emitted, "next_cursor": next_cursor}

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b6.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b6.patch
@@ -1,0 +1,11 @@
+--- a/src/paginate/paginator.py
++++ b/src/paginate/paginator.py
+@@ -24,7 +24,7 @@
+             # BUG pg-b6: the documented default page size is DEFAULT_PAGE_SIZE
+             # (5); this hardcodes 10, so a caller relying on the default walks
+             # the collection in the wrong-sized pages.
+-            limit = 10
++            limit = DEFAULT_PAGE_SIZE
+         boundary_id = cursor_mod.decode_cursor(token)
+         return self.page_from_boundary(boundary_id, limit)
+ 

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b7.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b7.patch
@@ -1,0 +1,11 @@
+--- a/src/paginate/routes.py
++++ b/src/paginate/routes.py
+@@ -16,7 +16,7 @@
+     """Cap an already-normalized limit to the server maximum page size."""
+     # BUG pg-b7: no upper bound is enforced — a caller can request an unbounded
+     # page (resource exhaustion). The limit must be capped at MAX_PAGE_SIZE.
+-    return limit
++    return min(limit, MAX_PAGE_SIZE)
+ 
+ 
+ def list_records(store, token=None, limit=None):

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b8.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b8.patch
@@ -1,0 +1,8 @@
+--- a/src/paginate/app.py
++++ b/src/paginate/app.py
+@@ -18,4 +18,4 @@
+             # BUG pg-b8: a malformed cursor is swallowed and the handler
+             # silently restarts at page 1 instead of surfacing the rejection.
+             # The caller can never tell a bad cursor from a real first page.
+-            return list_records(self.store, token=None, limit=limit)
++            raise

--- a/skills/inquisitor/evals/fixtures/paginate/ground-truth-bugs.json
+++ b/skills/inquisitor/evals/fixtures/paginate/ground-truth-bugs.json
@@ -1,0 +1,54 @@
+{
+  "_provenance": "see ground-truth-bugs.provenance.md",
+  "bugs": [
+    {
+      "bug_id": "pg-b1",
+      "desc": "Following a page's continuation token returns records that do not continue from where the previous page ended",
+      "off_axis": false,
+      "fix_patch": "fixes/pg-b1.patch"
+    },
+    {
+      "bug_id": "pg-b2",
+      "desc": "The list response is returned in a flat layout instead of the documented nested envelope, so a consumer reading the documented keys cannot find the records or the continuation token",
+      "off_axis": false,
+      "fix_patch": "fixes/pg-b2.patch"
+    },
+    {
+      "bug_id": "pg-b3",
+      "desc": "Requesting a page with a zero or non-positive size returns an empty page instead of a sane non-empty page",
+      "off_axis": false,
+      "fix_patch": "fixes/pg-b3.patch"
+    },
+    {
+      "bug_id": "pg-b4",
+      "desc": "When an earlier record is removed between two page requests, the next page skips a record instead of continuing contiguously",
+      "off_axis": false,
+      "fix_patch": "fixes/pg-b4.patch"
+    },
+    {
+      "bug_id": "pg-b5",
+      "desc": "The last record of every page is dropped, so it never appears on any page",
+      "off_axis": false,
+      "fix_patch": "fixes/pg-b5.patch"
+    },
+    {
+      "bug_id": "pg-b6",
+      "desc": "Omitting the page size returns a differently sized page than the documented default",
+      "off_axis": false,
+      "fix_patch": "fixes/pg-b6.patch"
+    },
+    {
+      "bug_id": "pg-b7",
+      "desc": "Requesting an enormous page size returns an unbounded number of records instead of a capped page",
+      "off_axis": true,
+      "fix_patch": "fixes/pg-b7.patch"
+    },
+    {
+      "bug_id": "pg-b8",
+      "desc": "Supplying a garbage continuation token silently returns the first page instead of reporting the token as invalid",
+      "off_axis": true,
+      "fix_patch": "fixes/pg-b8.patch"
+    }
+  ],
+  "interacting_sets": []
+}

--- a/skills/inquisitor/evals/fixtures/paginate/ground-truth-bugs.provenance.md
+++ b/skills/inquisitor/evals/fixtures/paginate/ground-truth-bugs.provenance.md
@@ -1,0 +1,22 @@
+# Ground-truth provenance — paginate
+
+## Blind GT authoring
+The bug list (bug_id, desc, fix_patch) for this seeded repo was authored from the
+committed source tree plus the per-bug fix patches and the behavioral exemplar
+tests only — i.e. from the observable wrong-vs-correct behavior of each seam. The
+author was blind to the eval's lensed dimension taxonomy and to the arm/treatment
+names; no taxonomy or treatment string was consulted while writing the
+descriptions.
+
+Blind input: skills/inquisitor/evals/fixtures/paginate/{src,fixes,exemplars}.
+
+## Off-axis tagging (post-blind, disjoint role)
+The off_axis flags were applied in a separate pass that ran AFTER the blind GT
+authoring above was sealed, by a role disjoint from the GT author and from every
+arm/exemplar test-authoring role. off_axis:true marks a defect that lies outside
+the lensed dimension taxonomy (so the bare, un-lensed arms are credited fairly for
+catching it); off_axis:false marks an on-taxonomy seam defect.
+
+## Independence
+All seeded bugs in this repo are pairwise behaviorally independent (verified by
+scripts/check_fixture_independence.py); no interacting_sets are registered.

--- a/skills/inquisitor/evals/fixtures/paginate/manifest.json
+++ b/skills/inquisitor/evals/fixtures/paginate/manifest.json
@@ -1,0 +1,1 @@
+{"repo_id":"paginate","pkg":"paginate","test_dir":"tests","runner_cmd":["python3","-m","pytest","-q"],"bug_ids":["pg-b1","pg-b2","pg-b3","pg-b4","pg-b5","pg-b6","pg-b7","pg-b8"],"n":8}

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/__init__.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/__init__.py
@@ -1,0 +1,1 @@
+"""paginate — cursor-based pagination over an in-memory record store."""

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/app.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/app.py
@@ -1,0 +1,21 @@
+"""Application wiring: build a store with the canonical dataset and expose a
+single `list` entry point bound to it. The entry point is also where a
+malformed cursor surfaces to the caller as a clean rejection.
+"""
+from .store import Store
+from .routes import list_records
+from .cursor import InvalidCursor
+
+
+class App:
+    def __init__(self, store=None):
+        self.store = store if store is not None else Store()
+
+    def list(self, token=None, limit=None):
+        try:
+            return list_records(self.store, token=token, limit=limit)
+        except InvalidCursor:
+            # BUG pg-b8: a malformed cursor is swallowed and the handler
+            # silently restarts at page 1 instead of surfacing the rejection.
+            # The caller can never tell a bad cursor from a real first page.
+            return list_records(self.store, token=None, limit=limit)

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/cursor.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/cursor.py
@@ -1,0 +1,40 @@
+"""Opaque cursor encode/decode.
+
+A cursor carries the id of the last record returned on the previous page. The
+store advances a page by returning records whose id is strictly greater than
+the decoded cursor value, comparing integer ids. The producer encodes an
+integer id, so the consumer MUST hand back an integer — not a string — or the
+store's id comparison breaks.
+"""
+import base64
+import binascii
+
+
+class InvalidCursor(ValueError):
+    """Raised when a caller-supplied cursor token is malformed."""
+
+
+def encode_cursor(last_id):
+    """Encode the last-seen record id into an opaque cursor token."""
+    raw = str(int(last_id)).encode("ascii")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def decode_cursor(token):
+    """Decode an opaque cursor token back into an integer record id boundary.
+
+    A malformed token is rejected with `InvalidCursor`.
+    """
+    if token is None:
+        return None
+    try:
+        text = base64.urlsafe_b64decode(token.encode("ascii")).decode("ascii")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        raise InvalidCursor("cursor is not valid base64")
+    if not text.lstrip("-").isdigit():
+        raise InvalidCursor("cursor payload is not an integer")
+    # BUG pg-b1: the producer encodes an integer id, but the consumer returns
+    # the raw decoded STRING instead of int(text). The store then compares
+    # integer record ids against a string boundary, so the comparison never
+    # advances correctly and the next page does not continue where this ended.
+    return text

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/paginator.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/paginator.py
@@ -1,0 +1,42 @@
+"""Page assembly: glue between the cursor codec and the record store.
+
+`Paginator.page` decodes the incoming cursor to a stable id boundary, asks the
+store for the next slice, and assembles the response: the items plus a
+`next_cursor` token that encodes the LAST returned record's id so the following
+page continues from exactly where this one ended.
+"""
+from . import cursor as cursor_mod
+
+DEFAULT_PAGE_SIZE = 5
+MAX_PAGE_SIZE = 50
+
+
+class Paginator:
+    def __init__(self, store):
+        self._store = store
+
+    def page(self, token=None, limit=None):
+        """Assemble one page from an opaque cursor token.
+
+        Returns {"items": [...], "next_cursor": <token-or-None>}.
+        """
+        if limit is None:
+            # BUG pg-b6: the documented default page size is DEFAULT_PAGE_SIZE
+            # (5); this hardcodes 10, so a caller relying on the default walks
+            # the collection in the wrong-sized pages.
+            limit = 10
+        boundary_id = cursor_mod.decode_cursor(token)
+        return self.page_from_boundary(boundary_id, limit)
+
+    def page_from_boundary(self, boundary_id, limit):
+        """Assemble a page given an already-decoded id boundary (cursor-free)."""
+        rows = self._store.records_after(boundary_id, limit)
+        if not rows:
+            return {"items": [], "next_cursor": None}
+        # BUG pg-b5: off-by-one at the page boundary — the trailing record is
+        # dropped from the emitted page (rows[:-1]) even though next_cursor
+        # still advances past it, so that record is lost between pages.
+        emitted = rows[:-1] if len(rows) > 1 else rows
+        last = rows[-1]
+        next_cursor = cursor_mod.encode_cursor(last["id"])
+        return {"items": emitted, "next_cursor": next_cursor}

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/routes.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/routes.py
@@ -1,0 +1,33 @@
+"""The list endpoint — the HTTP-ish boundary in front of the paginator.
+
+`list_records` is the request handler. It normalizes the caller-supplied
+`limit`, caps it to a server maximum, drives the paginator, and returns the
+documented response envelope:
+
+    {"data": [...records...], "paging": {"next_cursor": <token-or-None>}}
+
+Downstream consumers read `resp["data"]` and `resp["paging"]["next_cursor"]`.
+"""
+from .paginator import Paginator, MAX_PAGE_SIZE
+from .validate import normalize_limit
+
+
+def _cap_limit(limit):
+    """Cap an already-normalized limit to the server maximum page size."""
+    # BUG pg-b7: no upper bound is enforced — a caller can request an unbounded
+    # page (resource exhaustion). The limit must be capped at MAX_PAGE_SIZE.
+    return limit
+
+
+def list_records(store, token=None, limit=None):
+    """Handle a list request and return the documented response envelope."""
+    eff_limit = _cap_limit(normalize_limit(limit))
+    paginator = Paginator(store)
+    page = paginator.page(token=token, limit=eff_limit)
+    items = page["items"]
+    next_cursor = page["next_cursor"]
+    # BUG pg-b2: the response is emitted in a flat legacy shape
+    # ({"items", "next_cursor"}) instead of the documented envelope
+    # ({"data", "paging": {"next_cursor"}}), breaking downstream consumers
+    # that read resp["data"] / resp["paging"]["next_cursor"].
+    return {"items": items, "next_cursor": next_cursor}

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/store.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/store.py
@@ -1,0 +1,51 @@
+"""In-memory record store with a deterministic, fixed dataset.
+
+Records are dicts {"id": int, "name": str} kept sorted by id. The id is the
+*stable key* a cursor pages on: `records_after(boundary_id, limit)` returns the
+next `limit` records whose id is strictly greater than `boundary_id`. Paging on
+the stable id (not a positional offset) is what keeps pages stable when records
+are inserted or removed between requests.
+"""
+
+
+def seed_records():
+    """Return the canonical fixed dataset: ids 1..20, deterministic."""
+    return [{"id": i, "name": "rec-{:02d}".format(i)} for i in range(1, 21)]
+
+
+class Store:
+    def __init__(self, records=None):
+        # sorted by id; the stable paging key
+        self._records = sorted(
+            (dict(r) for r in (records if records is not None else seed_records())),
+            key=lambda r: r["id"],
+        )
+
+    def __len__(self):
+        return len(self._records)
+
+    def delete(self, rec_id):
+        """Remove a record by id (mutates the store between page requests)."""
+        self._records = [r for r in self._records if r["id"] != rec_id]
+
+    def insert(self, rec_id, name):
+        """Insert a record, keeping the list sorted by id."""
+        self._records.append({"id": rec_id, "name": name})
+        self._records.sort(key=lambda r: r["id"])
+
+    def records_after(self, boundary_id, limit):
+        """Return up to `limit` records with id strictly greater than boundary.
+
+        Paging on the stable id keeps already-returned records from reappearing
+        and not-yet-returned records from being skipped when the dataset
+        mutates between page requests.
+        """
+        if boundary_id is None:
+            boundary_id = 0
+        # BUG pg-b4: pages by POSITION instead of by the stable id. It treats
+        # the boundary value as a slice offset into the (contiguous) list. When
+        # an earlier record is deleted between page requests, every later
+        # record shifts down one position, so this offset overshoots and the
+        # first record of the next page is skipped.
+        offset = boundary_id  # treat the boundary value itself as the offset
+        return [dict(r) for r in self._records[offset:offset + limit]]

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/validate.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/validate.py
@@ -1,0 +1,24 @@
+"""Request-parameter validation, sitting between the route handler and the
+paginator. Keeps the limit within sane bounds before it reaches page assembly.
+"""
+from .paginator import DEFAULT_PAGE_SIZE
+
+
+def normalize_limit(limit):
+    """Return a sane positive limit, rejecting non-positive requests.
+
+    A 0 or negative limit is meaningless for a page; it must be rejected (or
+    floored to the default), never passed through to the slice as-is.
+    """
+    if limit is None:
+        return DEFAULT_PAGE_SIZE
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be an integer")
+    # BUG pg-b3: a non-positive limit (0 or negative) is returned unchanged
+    # instead of being floored to the default page size, producing an empty
+    # page or a reversed-slice page downstream.
+    if limit < 1:
+        return limit
+    return limit

--- a/skills/inquisitor/evals/fixtures/paginate/tests/conftest.py
+++ b/skills/inquisitor/evals/fixtures/paginate/tests/conftest.py
@@ -1,0 +1,2 @@
+import pathlib, sys
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b1.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b1.py
@@ -1,0 +1,12 @@
+"""rb-b1: a newly-created role must start with NO permissions (default-deny).
+
+A fresh role with no explicit permissions granted must NOT grant a protected
+action. Buggy base seeds new roles with a wildcard -> wrongful allow.
+"""
+from rbac.roles import Role
+
+
+def test_new_role_denies_protected_action():
+    fresh = Role("fresh")  # created with no explicit permissions
+    assert fresh.has_permission("delete") is False
+    assert fresh.has_permission("read") is False

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b2.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b2.py
@@ -1,0 +1,15 @@
+"""rb-b2: an assigned role must resolve so a permitted user is ALLOWED.
+
+A user assigned the "editor" role (which grants "write") must be authorized to
+write. Buggy base looks role ids up by the wrong type -> the role never resolves
+-> the legitimately-permitted user is wrongly denied.
+"""
+from rbac.store import Store
+from rbac.middleware import Middleware
+
+
+def test_assigned_role_allows_permitted_user():
+    store = Store()
+    store.add_user("alice", role_names=["editor"])
+    mw = Middleware(store)
+    assert mw.authorize({"user_id": "alice"}, "write") is True

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b3.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b3.py
@@ -1,0 +1,16 @@
+"""rb-b3 (off-axis security): a protected handler must reject an
+unauthenticated request.
+
+delete_document requires "delete"; an unauthenticated request (no principal)
+must get a 403. Buggy base omits the authz check on this handler entirely, so
+the unauthenticated request performs the delete.
+"""
+from rbac.store import Store
+from rbac.middleware import Middleware
+from rbac.routes import delete_document
+
+
+def test_unauthenticated_delete_is_rejected():
+    mw = Middleware(Store())
+    resp = delete_document(mw, {"user_id": None})  # no principal
+    assert resp["status"] == 403

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b4.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b4.py
@@ -1,0 +1,29 @@
+"""rb-b4: a revoked permission must take effect after cache invalidation.
+
+The middleware has a warm cache entry for a principal; the underlying grant is
+then revoked and the cache is invalidated. The next check must re-read the store
+and DENY. Buggy base's invalidate() is a no-op, so the stale cached permission
+still allows the revoked action.
+
+The cache is primed directly (not via a store-backed authorize) so this exemplar
+isolates the invalidation seam and does not depend on role-resolution behavior.
+"""
+from rbac.store import Store
+from rbac.middleware import Middleware
+
+
+def test_revoked_access_denied_after_invalidate():
+    store = Store()
+    store.add_user("carol", role_names=["editor"])
+    mw = Middleware(store)
+
+    # Warm the cache directly to isolate the invalidation seam.
+    mw._perm_cache["carol"] = {"read", "write"}
+    assert mw.authorize({"user_id": "carol"}, "write") is True   # served from cache
+
+    editor = store._roles[store.role_id_for("editor")]
+    editor.revoke("write")
+    mw.invalidate("carol")
+
+    # After invalidation the next check must re-resolve and deny.
+    assert mw.authorize({"user_id": "carol"}, "write") is False

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b5.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b5.py
@@ -1,0 +1,15 @@
+"""rb-b5: a denied dispatch must NOT execute the handler.
+
+The admin_panel route requires "manage_users" and delegates its gating to the
+app-level dispatch guard. A viewer (who lacks "manage_users") dispatching it must
+get a 403. Buggy base computes the verdict but invokes the handler regardless, so
+the denied principal still reaches the protected body.
+"""
+from rbac.app import App
+
+
+def test_denied_dispatch_does_not_execute_handler():
+    app = App()
+    app.store.add_user("dave", role_names=["viewer"])  # no manage_users
+    resp = app.dispatch("admin_panel", {"user_id": "dave"})
+    assert resp["status"] == 403

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b6.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b6.py
@@ -1,0 +1,14 @@
+"""rb-b6: the canonical "auditor" role must still grant "read".
+
+A working path (the reports view) depends on the auditor role granting "read".
+The regression changed that default mapping, dropping the read grant. This
+exercises the defaults -> roles producer seam directly (independent of store
+role-id resolution) so it isolates the regressed mapping.
+"""
+from rbac.defaults import default_permissions_for
+from rbac.roles import Role
+
+
+def test_auditor_default_grants_read():
+    role = Role("auditor", default_permissions_for("auditor"))
+    assert role.has_permission("read") is True

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b7.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b7.py
@@ -1,0 +1,17 @@
+"""rb-b7 (off-axis security): a client-supplied scope must not self-elevate.
+
+A viewer (granted only "read") sends a request requesting the "delete" scope.
+The effective permission set must never exceed what the principal was granted, so
+the delete must be DENIED. Buggy base unions the requested scopes onto the
+granted set, letting the caller self-elevate.
+"""
+from rbac.store import Store
+from rbac.middleware import Middleware
+
+
+def test_client_cannot_self_elevate_via_requested_scope():
+    store = Store()
+    store.add_user("erin", role_names=["viewer"])  # granted only "read"
+    mw = Middleware(store)
+    request = {"user_id": "erin", "requested_scopes": ["delete"]}
+    assert mw.authorize(request, "delete") is False

--- a/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b8.py
+++ b/skills/inquisitor/evals/fixtures/rbac/exemplars/rb-b8.py
@@ -1,0 +1,13 @@
+"""rb-b8 (off-axis error-handling): a missing user must be safely DENIED.
+
+A request whose principal the store has never registered must resolve to no
+permissions and be denied every protected action. Buggy base's missing-user path
+returns a wildcard set, so an unknown principal passes every check.
+"""
+from rbac.store import Store
+from rbac.middleware import Middleware
+
+
+def test_missing_user_is_denied():
+    mw = Middleware(Store())  # empty store; "ghost" was never added
+    assert mw.authorize({"user_id": "ghost"}, "read") is False

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b1.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b1.patch
@@ -1,0 +1,11 @@
+--- a/src/rbac/roles.py
++++ b/src/rbac/roles.py
+@@ -15,7 +15,7 @@
+         # actions until someone narrows them. Manifests only when a Role is
+         # built with permissions=None and then checked at runtime.
+         if permissions is None:
+-            self.permissions = {"*"}
++            self.permissions = set()
+         else:
+             self.permissions = set(permissions)
+ 

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b2.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b2.patch
@@ -1,0 +1,11 @@
+--- a/src/rbac/store.py
++++ b/src/rbac/store.py
+@@ -50,7 +50,7 @@
+             # str() form of the id, which never matches the int keys in
+             # self._roles -> the assigned role resolves to nothing and a
+             # legitimately-permitted user is denied.
+-            role = self._roles.get(str(rid))
++            role = self._roles.get(rid)
+             if role is not None:
+                 resolved.append(role)
+         return resolved

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b3.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b3.patch
@@ -1,0 +1,13 @@
+--- a/src/rbac/routes.py
++++ b/src/rbac/routes.py
+@@ -31,8 +31,6 @@
+ 
+ 
+ def delete_document(mw, request):
+-    # rb-b3 (wiring gap / missing authz check -> unauthenticated reaches the
+-    # handler): every other handler gates on mw.authorize(...) before acting.
+-    # This one was wired up without its check, so any request — including one
+-    # with no principal — performs the delete.
++    if not mw.authorize(request, "delete"):
++        return DENIED
+     return _ok("deleted")

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b4.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b4.patch
@@ -1,0 +1,14 @@
+--- a/src/rbac/middleware.py
++++ b/src/rbac/middleware.py
+@@ -27,10 +27,7 @@
+ 
+         Must be called whenever a user's roles/permissions change.
+         """
+-        # rb-b4 (stale cached role after update -> revoked access still works):
+-        # invalidation should evict the user's cache entry so a revocation takes
+-        # effect on the next check. Instead this is a no-op, so a principal whose
+-        # permission was revoked keeps passing checks from the stale cache.
++        self._perm_cache.pop(user_id, None)
+         return None
+ 
+     def authorize(self, request, required_permission):

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b5.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b5.patch
@@ -1,0 +1,16 @@
+--- a/src/rbac/app.py
++++ b/src/rbac/app.py
+@@ -44,11 +44,7 @@
+         handler, required = entry
+         if required is not None:
+             allowed = self.mw.authorize(request, required)
+-            # rb-b5 (middleware result ignored -> denials don't take effect):
+-            # the decision is computed but the guard never returns DENIED on a
+-            # negative verdict, so the handler runs regardless of the verdict and
+-            # a denied principal still reaches the protected body.
+-            if allowed:
+-                return handler(self.mw, request)
++            if not allowed:
++                return DENIED
+             return handler(self.mw, request)
+         return handler(self.mw, request)

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b6.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b6.patch
@@ -1,0 +1,15 @@
+--- a/src/rbac/defaults.py
++++ b/src/rbac/defaults.py
+@@ -10,11 +10,7 @@
+     "admin": {"read", "write", "delete", "manage_users"},
+     "editor": {"read", "write"},
+     "viewer": {"read"},
+-    # rb-b6 (regression): a previously-correct grant was changed. The "auditor"
+-    # role historically granted "read" (the reports route depends on it); this
+-    # mapping was altered to grant "write" instead, dropping the read grant a
+-    # working path relied on.
+-    "auditor": {"write"},
++    "auditor": {"read"},
+ }
+ 
+ 

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b7.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b7.patch
@@ -1,0 +1,13 @@
+--- a/src/rbac/scopes.py
++++ b/src/rbac/scopes.py
+@@ -18,9 +18,4 @@
+         return set(granted)
+     if "*" in granted:
+         return set(requested)
+-    # rb-b7 (trusting client-supplied scope -> privilege escalation): the
+-    # effective set should be granted ∩ requested (a request can only narrow).
+-    # Instead it UNIONs the client-supplied scopes onto the granted set, so a
+-    # caller can self-elevate by simply asking for a permission it was never
+-    # granted.
+-    return set(granted) | set(requested)
++    return set(granted) & set(requested)

--- a/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b8.patch
+++ b/skills/inquisitor/evals/fixtures/rbac/fixes/rb-b8.patch
@@ -1,0 +1,15 @@
+--- a/src/rbac/lookup.py
++++ b/src/rbac/lookup.py
+@@ -15,11 +15,7 @@
+     """
+     user = store.get_user(user_id)
+     if user is None:
+-        # rb-b8 (missing-user error path mis-handled -> wrongful ALLOW): an
+-        # unknown user should resolve to an empty permission set. Instead the
+-        # missing case returns a wildcard set treated as "all permissions", so a
+-        # principal the store never registered passes every check.
+-        return {"*"}
++        return set()
+     perms = set()
+     for role in store.roles_for_user(user_id):
+         if "*" in role.permissions:

--- a/skills/inquisitor/evals/fixtures/rbac/ground-truth-bugs.json
+++ b/skills/inquisitor/evals/fixtures/rbac/ground-truth-bugs.json
@@ -1,0 +1,54 @@
+{
+  "_provenance": "see ground-truth-bugs.provenance.md",
+  "bugs": [
+    {
+      "bug_id": "rb-b1",
+      "desc": "A role created with no explicit permissions grants every action instead of starting with none",
+      "off_axis": false,
+      "fix_patch": "fixes/rb-b1.patch"
+    },
+    {
+      "bug_id": "rb-b2",
+      "desc": "A user's assigned role fails to resolve, so a user who holds a permission is refused the action",
+      "off_axis": false,
+      "fix_patch": "fixes/rb-b2.patch"
+    },
+    {
+      "bug_id": "rb-b3",
+      "desc": "The delete handler performs the delete for a request that has no authenticated principal",
+      "off_axis": false,
+      "fix_patch": "fixes/rb-b3.patch"
+    },
+    {
+      "bug_id": "rb-b4",
+      "desc": "After a grant is revoked and the cache is invalidated, the revoked action still succeeds",
+      "off_axis": false,
+      "fix_patch": "fixes/rb-b4.patch"
+    },
+    {
+      "bug_id": "rb-b5",
+      "desc": "A dispatch the guard rules disallowed still runs the protected handler body",
+      "off_axis": false,
+      "fix_patch": "fixes/rb-b5.patch"
+    },
+    {
+      "bug_id": "rb-b6",
+      "desc": "The auditor role no longer grants read, breaking the reports path that relied on it",
+      "off_axis": false,
+      "fix_patch": "fixes/rb-b6.patch"
+    },
+    {
+      "bug_id": "rb-b7",
+      "desc": "A caller obtains a permission it was never granted by listing it as a requested scope",
+      "off_axis": true,
+      "fix_patch": "fixes/rb-b7.patch"
+    },
+    {
+      "bug_id": "rb-b8",
+      "desc": "A request for a user the store never registered is granted protected actions",
+      "off_axis": true,
+      "fix_patch": "fixes/rb-b8.patch"
+    }
+  ],
+  "interacting_sets": []
+}

--- a/skills/inquisitor/evals/fixtures/rbac/ground-truth-bugs.provenance.md
+++ b/skills/inquisitor/evals/fixtures/rbac/ground-truth-bugs.provenance.md
@@ -1,0 +1,22 @@
+# Ground-truth provenance — rbac
+
+## Blind GT authoring
+The bug list (bug_id, desc, fix_patch) for this seeded repo was authored from the
+committed source tree plus the per-bug fix patches and the behavioral exemplar
+tests only — i.e. from the observable wrong-vs-correct behavior of each seam. The
+author was blind to the eval's lensed dimension taxonomy and to the arm/treatment
+names; no taxonomy or treatment string was consulted while writing the
+descriptions.
+
+Blind input: skills/inquisitor/evals/fixtures/rbac/{src,fixes,exemplars}.
+
+## Off-axis tagging (post-blind, disjoint role)
+The off_axis flags were applied in a separate pass that ran AFTER the blind GT
+authoring above was sealed, by a role disjoint from the GT author and from every
+arm/exemplar test-authoring role. off_axis:true marks a defect that lies outside
+the lensed dimension taxonomy (so the bare, un-lensed arms are credited fairly for
+catching it); off_axis:false marks an on-taxonomy seam defect.
+
+## Independence
+All seeded bugs in this repo are pairwise behaviorally independent (verified by
+scripts/check_fixture_independence.py); no interacting_sets are registered.

--- a/skills/inquisitor/evals/fixtures/rbac/manifest.json
+++ b/skills/inquisitor/evals/fixtures/rbac/manifest.json
@@ -1,0 +1,1 @@
+{"repo_id":"rbac","pkg":"rbac","test_dir":"tests","runner_cmd":["python3","-m","pytest","-q"],"bug_ids":["rb-b1","rb-b2","rb-b3","rb-b4","rb-b5","rb-b6","rb-b7","rb-b8"],"n":8}

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/__init__.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/__init__.py
@@ -1,0 +1,5 @@
+"""rbac — a tiny role-based access-control / authorization middleware fixture.
+
+Hermetic, in-memory. All identity / time is injected by callers; nothing here
+touches the network, clock, randomness, or the filesystem.
+"""

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/app.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/app.py
@@ -1,0 +1,54 @@
+"""Application wiring.
+
+Builds the store + middleware and exposes `dispatch(route, request)`. The app
+maintains a route table mapping a route name to (handler, required_permission)
+and enforces the required permission at the dispatch boundary *before* invoking
+the handler — the app-level guard is the chokepoint for routes that delegate
+their gating to it.
+"""
+
+from rbac.store import Store
+from rbac.middleware import Middleware
+from rbac import routes
+
+
+DENIED = {"status": 403, "body": "forbidden"}
+
+
+def admin_panel(mw, request):
+    # Intentionally relies on the app-level dispatch guard for its
+    # authorization (it requires "manage_users" via the route table); it does
+    # no self-check.
+    return {"status": 200, "body": "admin-panel"}
+
+
+# route name -> (handler, required_permission_or_None)
+ROUTE_TABLE = {
+    "read_document": (routes.read_document, None),
+    "write_document": (routes.write_document, None),
+    "view_reports": (routes.view_reports, None),
+    "delete_document": (routes.delete_document, None),
+    "admin_panel": (admin_panel, "manage_users"),
+}
+
+
+class App:
+    def __init__(self, store=None):
+        self.store = store or Store()
+        self.mw = Middleware(self.store)
+
+    def dispatch(self, route, request):
+        entry = ROUTE_TABLE.get(route)
+        if entry is None:
+            return {"status": 404, "body": "not found"}
+        handler, required = entry
+        if required is not None:
+            allowed = self.mw.authorize(request, required)
+            # rb-b5 (middleware result ignored -> denials don't take effect):
+            # the decision is computed but the guard never returns DENIED on a
+            # negative verdict, so the handler runs regardless of the verdict and
+            # a denied principal still reaches the protected body.
+            if allowed:
+                return handler(self.mw, request)
+            return handler(self.mw, request)
+        return handler(self.mw, request)

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/defaults.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/defaults.py
@@ -1,0 +1,23 @@
+"""Canonical default role -> permission mappings.
+
+The seed catalogue every store starts from. `routes`/`middleware` depend on these
+exact grants; changing one silently re-defines who may do what (a regression
+surface).
+"""
+
+# Each role maps to the set of permission strings it grants.
+DEFAULT_ROLE_PERMISSIONS = {
+    "admin": {"read", "write", "delete", "manage_users"},
+    "editor": {"read", "write"},
+    "viewer": {"read"},
+    # rb-b6 (regression): a previously-correct grant was changed. The "auditor"
+    # role historically granted "read" (the reports route depends on it); this
+    # mapping was altered to grant "write" instead, dropping the read grant a
+    # working path relied on.
+    "auditor": {"write"},
+}
+
+
+def default_permissions_for(role_name):
+    """Return a *copy* of the canonical permission set for a role name."""
+    return set(DEFAULT_ROLE_PERMISSIONS.get(role_name, set()))

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/lookup.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/lookup.py
@@ -1,0 +1,33 @@
+"""Principal resolution.
+
+Turns a request's user id into a resolved principal (its set of permissions),
+consulting the store. This is the layer that decides what an *unknown* user
+gets.
+"""
+
+
+def resolve_permissions(store, user_id):
+    """Return the union of all permissions granted to user_id.
+
+    A user the store has never seen is unknown and must resolve to NO
+    permissions (default-deny) — the caller will then deny every protected
+    action.
+    """
+    user = store.get_user(user_id)
+    if user is None:
+        # rb-b8 (missing-user error path mis-handled -> wrongful ALLOW): an
+        # unknown user should resolve to an empty permission set. Instead the
+        # missing case returns a wildcard set treated as "all permissions", so a
+        # principal the store never registered passes every check.
+        return {"*"}
+    perms = set()
+    for role in store.roles_for_user(user_id):
+        if "*" in role.permissions:
+            return {"*"}
+        perms |= role.permissions
+    return perms
+
+
+def principal_allows(perms, permission):
+    """True if a resolved permission set grants `permission`."""
+    return "*" in perms or permission in perms

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/middleware.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/middleware.py
@@ -1,0 +1,43 @@
+"""Request authorization middleware.
+
+`authorize(...)` is the single chokepoint: given the store, a request, and the
+permission a route requires, it resolves the principal (honoring any requested
+scope) and returns an allow/deny decision. It memoizes resolved permission sets
+per user to avoid re-walking the store on every call.
+"""
+
+from rbac.lookup import resolve_permissions, principal_allows
+from rbac.scopes import effective_permissions
+
+
+class Middleware:
+    def __init__(self, store):
+        self.store = store
+        self._perm_cache = {}   # user_id -> resolved permission set
+
+    def _resolve(self, user_id):
+        if user_id in self._perm_cache:
+            return self._perm_cache[user_id]
+        perms = resolve_permissions(self.store, user_id)
+        self._perm_cache[user_id] = perms
+        return perms
+
+    def invalidate(self, user_id):
+        """Drop a cached principal so the next check re-reads the store.
+
+        Must be called whenever a user's roles/permissions change.
+        """
+        # rb-b4 (stale cached role after update -> revoked access still works):
+        # invalidation should evict the user's cache entry so a revocation takes
+        # effect on the next check. Instead this is a no-op, so a principal whose
+        # permission was revoked keeps passing checks from the stale cache.
+        return None
+
+    def authorize(self, request, required_permission):
+        """Return True iff the request's principal may perform the action."""
+        user_id = request.get("user_id")
+        if user_id is None:
+            return False
+        granted = self._resolve(user_id)
+        effective = effective_permissions(granted, request.get("requested_scopes"))
+        return principal_allows(effective, required_permission)

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/roles.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/roles.py
@@ -1,0 +1,35 @@
+"""Role / permission model.
+
+A Role is a named bag of permission strings. New roles are created empty and
+permissions are granted explicitly (default-deny).
+"""
+
+
+class Role:
+    def __init__(self, name, permissions=None):
+        self.name = name
+        # rb-b1 (default lockout inverted): a freshly-created role with no
+        # explicit permission set should start EMPTY (default-deny). Instead it
+        # is seeded with a wildcard "*" that `has_permission` treats as
+        # "grants everything", so brand-new roles wrongly allow protected
+        # actions until someone narrows them. Manifests only when a Role is
+        # built with permissions=None and then checked at runtime.
+        if permissions is None:
+            self.permissions = {"*"}
+        else:
+            self.permissions = set(permissions)
+
+    def grant(self, permission):
+        self.permissions.discard("*")
+        self.permissions.add(permission)
+
+    def revoke(self, permission):
+        self.permissions.discard(permission)
+
+    def has_permission(self, permission):
+        if "*" in self.permissions:
+            return True
+        return permission in self.permissions
+
+    def __repr__(self):
+        return f"Role({self.name!r}, {sorted(self.permissions)!r})"

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/routes.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/routes.py
@@ -1,0 +1,38 @@
+"""Protected request handlers.
+
+Each handler is `handler(mw, request) -> dict`. Every handler must consult the
+middleware for the permission it requires before doing any work, and return a
+403 envelope when denied.
+"""
+
+DENIED = {"status": 403, "body": "forbidden"}
+
+
+def _ok(body):
+    return {"status": 200, "body": body}
+
+
+def read_document(mw, request):
+    if not mw.authorize(request, "read"):
+        return DENIED
+    return _ok("document-contents")
+
+
+def write_document(mw, request):
+    if not mw.authorize(request, "write"):
+        return DENIED
+    return _ok("written")
+
+
+def view_reports(mw, request):
+    if not mw.authorize(request, "read"):
+        return DENIED
+    return _ok("reports")
+
+
+def delete_document(mw, request):
+    # rb-b3 (wiring gap / missing authz check -> unauthenticated reaches the
+    # handler): every other handler gates on mw.authorize(...) before acting.
+    # This one was wired up without its check, so any request — including one
+    # with no principal — performs the delete.
+    return _ok("deleted")

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/scopes.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/scopes.py
@@ -1,0 +1,26 @@
+"""Effective-scope computation.
+
+A request may *ask* for an elevated scope (e.g. an admin tool requesting the
+"manage_users" scope). The effective permission set the middleware enforces must
+be the INTERSECTION of what the principal actually has and what it requested —
+a request can only ever narrow, never widen, the principal's granted set.
+"""
+
+
+def effective_permissions(granted, requested=None):
+    """Compute the permissions a request actually operates under.
+
+    `granted` is the principal's real permission set (from the store).
+    `requested` is the optional client-supplied scope list. The result must
+    never exceed `granted`.
+    """
+    if requested is None:
+        return set(granted)
+    if "*" in granted:
+        return set(requested)
+    # rb-b7 (trusting client-supplied scope -> privilege escalation): the
+    # effective set should be granted ∩ requested (a request can only narrow).
+    # Instead it UNIONs the client-supplied scopes onto the granted set, so a
+    # caller can self-elevate by simply asking for a permission it was never
+    # granted.
+    return set(granted) | set(requested)

--- a/skills/inquisitor/evals/fixtures/rbac/src/rbac/store.py
+++ b/skills/inquisitor/evals/fixtures/rbac/src/rbac/store.py
@@ -1,0 +1,56 @@
+"""In-memory user + role store.
+
+Holds Role objects keyed by name, and users keyed by user id. Each user has a
+list of assigned role *ids* (the integer the store handed out at registration).
+"""
+
+from rbac.roles import Role
+from rbac.defaults import DEFAULT_ROLE_PERMISSIONS
+
+
+class Store:
+    def __init__(self):
+        self._roles = {}            # role_id (int) -> Role
+        self._role_ids = {}         # role_name (str) -> role_id (int)
+        self._users = {}            # user_id (str) -> {"roles": [role_id, ...]}
+        self._next_role_id = 1
+        for name, perms in DEFAULT_ROLE_PERMISSIONS.items():
+            self.define_role(name, perms)
+
+    def define_role(self, name, permissions=None):
+        rid = self._next_role_id
+        self._next_role_id += 1
+        self._roles[rid] = Role(name, permissions)
+        self._role_ids[name] = rid
+        return rid
+
+    def add_user(self, user_id, role_names=()):
+        rids = []
+        for name in role_names:
+            rid = self._role_ids.get(name)
+            if rid is not None:
+                rids.append(rid)
+        self._users[user_id] = {"roles": rids}
+
+    def role_id_for(self, name):
+        return self._role_ids.get(name)
+
+    def get_user(self, user_id):
+        return self._users.get(user_id)
+
+    def roles_for_user(self, user_id):
+        """Resolve a user's assigned role ids to Role objects."""
+        user = self._users.get(user_id)
+        if user is None:
+            return []
+        resolved = []
+        for rid in user["roles"]:
+            # rb-b2 (type-mismatch lookup -> wrongful DENY): assigned ids are
+            # ints (handed out by define_role), but here we look them up by the
+            # str() form of the id, which never matches the int keys in
+            # self._roles -> the assigned role resolves to nothing and a
+            # legitimately-permitted user is denied.
+            role = self._roles.get(str(rid))
+            if role is not None:
+                resolved.append(role)
+        return resolved

--- a/skills/inquisitor/evals/fixtures/rbac/tests/conftest.py
+++ b/skills/inquisitor/evals/fixtures/rbac/tests/conftest.py
@@ -1,0 +1,2 @@
+import pathlib, sys
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))

--- a/skills/inquisitor/evals/neutral-proxy-prompt-eval.md
+++ b/skills/inquisitor/evals/neutral-proxy-prompt-eval.md
@@ -9,7 +9,11 @@ from its `src/` directory and run under `python3 -m pytest`.
 ## Budget
 
 Write at most **5 tests**. Every test must actually execute and either pass or
-fail — do **not** describe tests you do not run.
+fail — do **not** describe tests you do not run. Put each test in its **own**
+`test_*.py` file and keep it self-contained (import only from `src/`, not a
+helper module you wrote): the scorer runs each file in isolation on a pristine
+repo, so a file that over-asserts or imports an unharvested helper is discarded
+whole.
 
 ## What to do
 

--- a/skills/inquisitor/evals/neutral-proxy-prompt-eval.md
+++ b/skills/inquisitor/evals/neutral-proxy-prompt-eval.md
@@ -1,0 +1,21 @@
+# Bug-hunting task
+
+You are given a Python repository. Write **and run** pytest tests that expose
+**bugs** in the code.
+
+The repository is at the path provided to you. Your tests must import the package
+from its `src/` directory and run under `python3 -m pytest`.
+
+## Budget
+
+Write at most **5 tests**. Every test must actually execute and either pass or
+fail — do **not** describe tests you do not run.
+
+## What to do
+
+1. Read the repository source.
+2. Write up to 5 pytest tests that FAIL when a bug is present and PASS when the
+   code is correct.
+3. Run them with `python3 -m pytest` and iterate until they execute cleanly
+   (no collection/import errors).
+4. Leave your test file(s) in the repository's test directory.

--- a/skills/inquisitor/evals/pool-prompt-eval.md
+++ b/skills/inquisitor/evals/pool-prompt-eval.md
@@ -1,0 +1,23 @@
+# Bug-hunting task
+
+You are given a Python repository. Write **and run** pytest tests that expose
+**cross-component bugs** — defects at the seams between modules (a producer and a
+consumer disagreeing, a component not wired to another, state lost across a
+lifecycle boundary, an unhandled edge between layers).
+
+The repository is at the path provided to you. Your tests must import the package
+from its `src/` directory and run under `python3 -m pytest`.
+
+## Budget
+
+Write at most **5 tests**. Every test must actually execute and either pass or
+fail — do **not** describe tests you do not run.
+
+## What to do
+
+1. Read the repository source.
+2. Write up to 5 pytest tests that FAIL when a seam bug is present and PASS when
+   the code is correct.
+3. Run them with `python3 -m pytest` and iterate until they execute cleanly
+   (no collection/import errors).
+4. Leave your test file(s) in the repository's test directory.

--- a/skills/inquisitor/evals/pool-prompt-eval.md
+++ b/skills/inquisitor/evals/pool-prompt-eval.md
@@ -11,7 +11,11 @@ from its `src/` directory and run under `python3 -m pytest`.
 ## Budget
 
 Write at most **5 tests**. Every test must actually execute and either pass or
-fail — do **not** describe tests you do not run.
+fail — do **not** describe tests you do not run. Put each test in its **own**
+`test_*.py` file and keep it self-contained (import only from `src/`, not a
+helper module you wrote): the scorer runs each file in isolation on a pristine
+repo, so a file that over-asserts or imports an unharvested helper is discarded
+whole.
 
 ## What to do
 

--- a/skills/inquisitor/evals/run_evals.py
+++ b/skills/inquisitor/evals/run_evals.py
@@ -22,6 +22,7 @@ Phase 1 only: identification breadth, execution stubbed. See the gated design
 from __future__ import annotations
 import argparse
 import datetime as _dt
+import hashlib
 import json
 import math
 import re
@@ -32,6 +33,7 @@ from pathlib import Path
 
 from ._dispatch_paths import fixture_sha, resolve_dispatch_dir, template_sha
 from ._runid import validate_run_id
+from . import _oracle
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _EVALS_DIR = Path(__file__).resolve().parent
@@ -53,6 +55,61 @@ DIMENSION_TITLES = ["Wiring", "Integration", "Edge Cases",
                     "State & Lifecycle", "Regression"]
 
 _DEFAULT_TRIALS = 5  # decision-run default (design "Cost envelope")
+
+# --- Phase 1b: seeded-repo EXECUTION mode (4 arms + oracle) ----------------
+# Forked entirely behind `mode` so the Phase-1 stage()/score() bodies (and their
+# 30+ guard tests) are byte-untouched. Phase-1 manifests carry no `mode` →
+# score() falls through to the 3-arm judge path; Phase-1b manifests carry
+# mode:"phase1b-exec" or mode:"pilot" → the oracle path below.
+_FIXTURES_DIR = _EVALS_DIR / "fixtures"
+_WITHOUT_EXEC = _EVALS_DIR / "without-prompt-eval.md"   # the SINGLE SOURCE (§2/C0)
+_POOL_EXEC = _EVALS_DIR / "pool-prompt-eval.md"         # byte-identical to WITHOUT
+_NEUTRAL_PROXY = _EVALS_DIR / "neutral-proxy-prompt-eval.md"  # WITHOUT minus framing
+_EXEC_REPOS = ("notify", "rbac", "paginate")
+_EXEC_ARMS = ("with", "pool", "mid", "without")
+_PILOT_ARMS = ("neutral-proxy",)
+_PILOT_MIN_TRIALS = 3                 # §5/M6 floor for the calibration pilot
+_PILOT_BAND = (0.40, 0.70)            # §5 keep zone (percentage governs — M1)
+_WITHOUT_CEILING = 0.70               # §7 F2: WITHOUT ceiling-broken threshold
+_PER_AGENT_TEST_BUDGET = 5            # §6/S3 uniform per-agent budget (no per-arm 25)
+# Present in WITHOUT/POOL, REMOVED in the neutral proxy (S4 framing check).
+_FRAMING_MARKER = "cross-component"
+
+# The shared WITH/MID procedural EXECUTION scaffold (§9 S1 scaffold parity): WITH's
+# 5 dimension agents and the single MID agent embed this VERBATIM, so their scaffold
+# hashes are equal by construction; they differ only in the lens section (one lens
+# vs all five). The lens text itself is single-sourced from the Dimension Reference
+# in `inquisitor-dimension-prompt-eval.md` (parse_dimension_blocks) — never copied.
+_EXEC_SCAFFOLD = """\
+# Inquisitor execution agent
+
+You are a relentless hunter for cross-component seam bugs. You are given a Python
+repository (its path is provided at dispatch). Your job is to write AND run pytest
+tests that expose seam bugs, then leave the test files in the repository.
+
+## Your Job
+1. Read the repository source under `src/`.
+2. Through the dimension lens(es) below, identify the most likely cross-component
+   seam defects (a producer/consumer mismatch, an unwired component, state lost
+   across a lifecycle, an unhandled edge between layers, a regression).
+3. Write pytest tests that FAIL when such a defect is present and PASS on correct
+   code. Import the package from `src/`; run under `python3 -m pytest`.
+4. RUN them with `python3 -m pytest` and iterate until they execute cleanly (no
+   collection/import errors) — a test you do not run does not count.
+5. Leave your final test file(s) in the repository's test directory.
+
+## Budget
+At most **5 tests** (this per-agent budget is uniform across every arm).
+
+## What You Must NOT Do
+- Do NOT edit the repository source — write tests only.
+- Do NOT describe tests you do not actually run.
+"""
+
+
+def _sha_text(text: str) -> str:
+    """sha256 of a string (for hashing the in-module exec scaffold)."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 # S-2 guard: a rendered WITH dispatch must carry NO residual [DIMENSION_*] slot.
 # Scoped to the [DIMENSION_*] slot class ONLY (NOT arbitrary [...] tokens): the
@@ -356,9 +413,16 @@ def _load_fixtures() -> list:
 
 
 def stage(run_id: str, *, trials: int = _DEFAULT_TRIALS,
-          fixture: int | str | None = None, force: bool = False) -> Path:
+          fixture: int | str | None = None, force: bool = False,
+          repo: str | None = None, exec_mode: bool = False,
+          pilot: bool = False) -> Path:
     """Render the three-arm dispatch files + the two shared prompt files; write
-    stage-manifest.json. Returns the dispatch directory path."""
+    stage-manifest.json. Returns the dispatch directory path.
+
+    Phase 1b: when exec_mode / repo / pilot is set, fork to stage_exec() (the
+    seeded-repo 4-arm execution path) — the Phase-1 body below is left untouched."""
+    if exec_mode or repo is not None or pilot:
+        return stage_exec(run_id, trials=trials, repo=repo, pilot=pilot, force=force)
     validate_run_id(run_id)
     if trials < 1:
         raise ValueError(f"--trials must be >= 1 (got {trials})")
@@ -591,6 +655,12 @@ def score(run_id: str, *, allow_incomplete: bool = False) -> int:
         print(f"[fatal] no stage-manifest.json at {manifest_path}", file=sys.stderr)
         return 1
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    # Phase 1b fork: an exec/pilot manifest routes to the oracle-driven scorer; a
+    # Phase-1 manifest (no `mode`) falls through to the 3-arm judge path below (S1).
+    if manifest.get("mode") in ("phase1b-exec", "pilot"):
+        return score_exec(run_id, manifest, dispatch_dir,
+                          allow_incomplete=allow_incomplete)
 
     # .collect-status gating (test 5): refuse without it unless --allow-incomplete.
     status_file = dispatch_dir / ".collect-status"
@@ -939,6 +1009,305 @@ def _secondary_graded_label(lr: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Phase 1b: EXECUTION-mode stage_exec() + score_exec() (4 arms + the oracle)
+# ---------------------------------------------------------------------------
+
+
+def _exec_with_dimension(title: str, block: str) -> str:
+    """A WITH dimension exec prompt: shared scaffold + this single lens block."""
+    return (_EXEC_SCAFFOLD + "\n## Your dimension\n\n### " + block.rstrip() + "\n")
+
+
+def _exec_mid(blocks: list) -> str:
+    """The MID exec prompt: the SAME shared scaffold + all five lens blocks."""
+    body = _EXEC_SCAFFOLD + "\n## All five dimensions\n\nApply every one of these "
+    body += "five dimension lenses:\n\n"
+    body += "\n".join("### " + b.rstrip() + "\n" for _t, b in blocks)
+    return body
+
+
+def _select_exec_repos(repo) -> list:
+    if repo is None:
+        repos = list(_EXEC_REPOS)
+    else:
+        if repo not in _EXEC_REPOS:
+            raise ValueError(f"--repo {repo!r} not in {_EXEC_REPOS}")
+        repos = [repo]
+    for r in repos:
+        if not (_FIXTURES_DIR / r / "manifest.json").exists():
+            raise ValueError(f"seeded repo {r!r} missing manifest.json under "
+                             f"{_FIXTURES_DIR}")
+    return repos
+
+
+def stage_exec(run_id: str, *, trials: int, repo: str | None = None,
+               pilot: bool = False, force: bool = False) -> Path:
+    """Render the 4-arm (or pilot neutral-proxy) execution cells over the seeded
+    repos, materialize one repo copy per producer, write a mode-stamped manifest."""
+    validate_run_id(run_id)
+    if trials < 1:
+        raise ValueError(f"--trials must be >= 1 (got {trials})")
+    if pilot and trials < _PILOT_MIN_TRIALS:
+        raise ValueError(
+            f"--pilot enforces a floor of {_PILOT_MIN_TRIALS} trials (got {trials})")
+    repos = _select_exec_repos(repo)
+    blocks = parse_dimension_blocks(_DIM_TEMPLATE.read_text(encoding="utf-8"))
+
+    dispatch_dir = resolve_dispatch_dir(run_id)
+    if dispatch_dir.exists():
+        if not force:
+            raise FileExistsError(f"dispatch dir {dispatch_dir} exists; pass force=True")
+        shutil.rmtree(dispatch_dir)
+    dispatch_dir.mkdir(parents=True)
+    copies_root = dispatch_dir / "copies"
+    copies_root.mkdir()
+
+    # Stage the three bare prompt artifacts verbatim (hashed in the manifest).
+    for src in (_WITHOUT_EXEC, _POOL_EXEC, _NEUTRAL_PROXY):
+        (dispatch_dir / src.name).write_text(src.read_text(encoding="utf-8"),
+                                             encoding="utf-8")
+    # Render the WITH dim + MID exec prompts (shared scaffold + single-source lenses).
+    with_dim_files = {}
+    for n, (title, block) in enumerate(blocks, 1):
+        fn = f"with-dim{n}-{_slug(title)}.md"
+        (dispatch_dir / fn).write_text(_exec_with_dimension(title, block), encoding="utf-8")
+        with_dim_files[title] = fn
+    (dispatch_dir / "mid.md").write_text(_exec_mid(blocks), encoding="utf-8")
+
+    def copy_for(cell_key: str, idx: int, repo_id: str) -> str:
+        dst = copies_root / f"{cell_key}-p{idx}"
+        shutil.copytree(_FIXTURES_DIR / repo_id, dst)
+        return str(dst.relative_to(dispatch_dir))
+
+    arms = _PILOT_ARMS if pilot else _EXEC_ARMS
+    cells: list = []
+    for repo_id in repos:
+        for trial in range(1, trials + 1):
+            if pilot:
+                key = f"{repo_id}-t{trial}-neutral-proxy"
+                cells.append({
+                    "repo_id": repo_id, "trial": trial, "arm": "neutral-proxy",
+                    "producers": [{"agent": 1,
+                                   "dispatch_file": _NEUTRAL_PROXY.name,
+                                   "repo_copy": copy_for(key, 1, repo_id)}],
+                    "result_file": f"{key}-tests.json"})
+                continue
+            specs = [
+                ("with", [(i, with_dim_files[t]) for i, (t, _b) in enumerate(blocks, 1)]),
+                ("pool", [(i, _POOL_EXEC.name) for i in range(1, 6)]),
+                ("mid", [(1, "mid.md")]),
+                ("without", [(1, _WITHOUT_EXEC.name)]),
+            ]
+            for arm, prods in specs:
+                key = f"{repo_id}-t{trial}-{arm}"
+                producers = [{"agent": i, "dispatch_file": df,
+                              "repo_copy": copy_for(key, i, repo_id)}
+                             for (i, df) in prods]
+                cells.append({"repo_id": repo_id, "trial": trial, "arm": arm,
+                              "producers": producers,
+                              "result_file": f"{key}-tests.json"})
+
+    scaffold_sha = _sha_text(_EXEC_SCAFFOLD)
+    manifest = {
+        "run_id": run_id,
+        "stage_timestamp": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "mode": "pilot" if pilot else "phase1b-exec",
+        "arms": list(arms),
+        "trials": trials,
+        "repos": repos,
+        "per_agent_test_budget": _PER_AGENT_TEST_BUDGET,
+        "prompt_shas": {
+            "with_scaffold": scaffold_sha,
+            "mid_scaffold": scaffold_sha,                 # == with_scaffold (S1)
+            "without": template_sha(_WITHOUT_EXEC),
+            "pool": template_sha(_POOL_EXEC),             # == without (POOL parity)
+            "neutral_proxy": template_sha(_NEUTRAL_PROXY),
+        },
+        "cells": cells,
+    }
+    (dispatch_dir / "stage-manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8")
+    return dispatch_dir
+
+
+def _pilot_band(mean_rate: float) -> dict:
+    """§5: the neutral-proxy mean vs the 40-70% keep band (percentage governs)."""
+    lo, hi = _PILOT_BAND
+    verdict = "harden" if mean_rate > hi else "soften" if mean_rate < lo else "in-band"
+    return {"mean_rate": mean_rate, "band": [lo, hi], "verdict": verdict}
+
+
+def _exec_cell_caught(cell, dispatch_dir, repo_meta, complete):
+    """Run the oracle over one cell's harvested test files. Returns (caught_set,
+    res_or_None, fatal_msg_or_None)."""
+    rf = dispatch_dir / cell["result_file"]
+    if not rf.exists():
+        return set(), None, (f"missing result_file {cell['result_file']}" if complete else None)
+    data = json.loads(rf.read_text(encoding="utf-8"))
+    if data.get("dispatch_status") != "OK":
+        return set(), None, (f"cell {cell['result_file']} dispatch_status != OK"
+                             if complete else None)
+    test_files = [Path(p) for p in data.get("test_files", [])]
+    res = _oracle.caught_bugs(test_files, _FIXTURES_DIR / cell["repo_id"],
+                              interacting_sets=repo_meta[cell["repo_id"]]["isets"])
+    return res["caught"], res, None
+
+
+def _two_of_three(count: int, total: int) -> int:
+    """The ≥2/3 threshold count for `total` repos (3 repos → 2; 1 → 1)."""
+    return math.ceil(2 * total / 3)
+
+
+def score_exec(run_id: str, manifest: dict, dispatch_dir: Path, *,
+               allow_incomplete: bool) -> int:
+    """Oracle-driven scoring for a Phase-1b exec/pilot run. Mode-forked from
+    score() so the Phase-1 judge path is untouched (S1)."""
+    mode = manifest["mode"]
+    arms = tuple(manifest["arms"])
+    repos = list(manifest["repos"])
+    trials = manifest["trials"]
+
+    status_file = dispatch_dir / ".collect-status"
+    if not status_file.exists() and not allow_incomplete:
+        print(f"[fatal] no .collect-status in {dispatch_dir}; collect is incomplete "
+              f"(pass --allow-incomplete for a smoke/debug score)", file=sys.stderr)
+        return 1
+    complete = not allow_incomplete
+
+    repo_meta: dict = {}
+    for r in repos:
+        gt = json.loads((_FIXTURES_DIR / r / "ground-truth-bugs.json").read_text(
+            encoding="utf-8"))
+        bug_ids = [b["bug_id"] for b in gt["bugs"]]
+        repo_meta[r] = {
+            "bug_ids": bug_ids,
+            "off": {b["bug_id"]: bool(b["off_axis"]) for b in gt["bugs"]},
+            "isets": gt.get("interacting_sets", []),
+            "n": len(bug_ids),
+        }
+
+    cells_by = {(c["arm"], c["repo_id"], c["trial"]): c for c in manifest["cells"]}
+    if complete:
+        expected = {(a, r, t) for a in arms for r in repos
+                    for t in range(1, trials + 1)}
+        missing = sorted(expected - set(cells_by))
+        dups = [k for k in cells_by] if len(cells_by) != len(manifest["cells"]) else []
+        if missing or dups:
+            print(f"[fatal] exec cell-grid incomplete for {dispatch_dir}: "
+                  f"missing={missing} (arms {list(arms)} × repos {repos} × "
+                  f"trials 1..{trials}); refusing to score", file=sys.stderr)
+            return 1
+
+    # caught[arm][repo][trial] -> set of caught ids
+    caught: dict = {a: {r: {} for r in repos} for a in arms}
+    broad_per_arm: dict = {a: [] for a in arms}
+    flaky_per_arm: dict = {a: 0 for a in arms}
+    for (arm, r, t), cell in cells_by.items():
+        cset, res, fatal = _exec_cell_caught(cell, dispatch_dir, repo_meta, complete)
+        if fatal:
+            print(f"[fatal] {fatal}", file=sys.stderr)
+            return 1
+        caught[arm][r][t] = cset
+        if res is not None:
+            broad_per_arm[arm].extend(res["broad_test_catches"].values())
+            flaky_per_arm[arm] += res["flaky_discards"]
+
+    total_bugs = sum(repo_meta[r]["n"] for r in repos)
+
+    def repo_trial_rate(a, r, t):
+        return len(caught[a][r].get(t, set())) / repo_meta[r]["n"] if repo_meta[r]["n"] else 0.0
+
+    def repo_mean_rate(a, r):
+        return statistics.mean([repo_trial_rate(a, r, t)
+                                for t in range(1, trials + 1)])
+
+    # --- pilot path: neutral-proxy band per repo, no 4-arm grid ---
+    if mode == "pilot":
+        per_repo = {r: _pilot_band(repo_mean_rate("neutral-proxy", r)) for r in repos}
+        last_run = {
+            "run_id": run_id, "mode": mode, "complete": complete, "trials": trials,
+            "repos": repos, "arms": list(arms),
+            "pilot_band": {"band": list(_PILOT_BAND), "per_repo": per_repo},
+            "flaky_discards": flaky_per_arm,
+        }
+        (_EVALS_DIR / "last_run.json").write_text(json.dumps(last_run, indent=2),
+                                                  encoding="utf-8")
+        return 0
+
+    # --- decision path: 4-arm deltas + WITHOUT ceiling + KEEP statistic ---
+    per_trial_rate = {a: [sum(len(caught[a][r].get(t, set())) for r in repos)
+                          / total_bugs for t in range(1, trials + 1)]
+                      for a in arms}
+
+    def majority_caught(a, r, b):
+        hits = sum(1 for t in range(1, trials + 1) if b in caught[a][r].get(t, set()))
+        return hits * 2 > trials
+
+    arm_repo_caught = {a: {r: sum(1 for b in repo_meta[r]["bug_ids"]
+                                  if majority_caught(a, r, b)) for r in repos}
+                       for a in arms}
+    arm_rate = {a: sum(arm_repo_caught[a][r] for r in repos) / total_bugs
+                for a in arms}
+
+    without_means = {r: repo_mean_rate("without", r) for r in repos}
+    with_means = {r: repo_mean_rate("with", r) for r in repos}
+    below = sum(1 for r in repos if without_means[r] <= _WITHOUT_CEILING)
+    without_ceiling_broken = below >= _two_of_three(below, len(repos))
+    per_repo_sign = {r: with_means[r] - without_means[r] for r in repos}
+    positive = sum(1 for r in repos if per_repo_sign[r] > 0)
+    sign_holds = positive >= _two_of_three(positive, len(repos))
+
+    deltas = {
+        "_note": ("paired = mean of per-trial deltas; the KEEP gate reads "
+                  "beyond_spread on with_without (NOT trial_spread — S-B)"),
+        "with_without": _delta_block(per_trial_rate["with"],
+                                     per_trial_rate["without"], with_beyond=True),
+        "with_pool": _delta_block(per_trial_rate["with"],
+                                  per_trial_rate["pool"], with_beyond=True),
+        "pool_without": _delta_block(per_trial_rate["pool"],
+                                     per_trial_rate["without"], with_beyond=False),
+        "with_mid": _delta_block(per_trial_rate["with"],
+                                 per_trial_rate["mid"], with_beyond=False),
+    }
+
+    off_bugs = [(r, b) for r in repos for b in repo_meta[r]["bug_ids"]
+                if repo_meta[r]["off"][b]]
+    off_total = len(off_bugs)
+    off_pass = {a: sum(1 for (r, b) in off_bugs if majority_caught(a, r, b))
+                for a in arms}
+
+    last_run = {
+        "run_id": run_id, "mode": mode, "complete": complete, "trials": trials,
+        "repos": repos, "arms": list(arms), "graded_bugs": total_bugs,
+        "arm_rates": {a: {"rate": arm_rate[a], "per_repo": arm_repo_caught[a]}
+                      for a in arms},
+        "deltas": deltas,
+        "without_ceiling_broken": without_ceiling_broken,
+        "without_repo_means": without_means,
+        "keep_statistic": {
+            "_note": ("KEEP = beyond_spread on with_without AND positive sign on "
+                      ">=2/3 repos; trial_spread is explicitly REJECTED as the gate "
+                      "(S-B). score surfaces the inputs; the human reads the §7 "
+                      "branches — it emits no keep/condemn verdict."),
+            "statistic": "beyond_spread",
+            "beyond_spread": deltas["with_without"]["beyond_spread"],
+            "per_repo_sign": per_repo_sign,
+            "sign_holds_2of3": sign_holds,
+            "without_ceiling_broken": without_ceiling_broken,
+        },
+        "off_axis_diagnostic": {a: {"pass": off_pass[a], "total": off_total,
+                                    "rate": _rate(off_pass[a], off_total)}
+                                for a in arms},
+        "broad_test_catches": {a: (statistics.mean(broad_per_arm[a])
+                                   if broad_per_arm[a] else 0.0) for a in arms},
+        "flaky_discards": flaky_per_arm,
+    }
+    (_EVALS_DIR / "last_run.json").write_text(json.dumps(last_run, indent=2),
+                                              encoding="utf-8")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -947,10 +1316,17 @@ def _parse_args(argv: list) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Inquisitor fan-out eval harness.")
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    sp_stage = sub.add_parser("stage", help="Render three-arm dispatch files")
+    sp_stage = sub.add_parser("stage", help="Render dispatch files (3-arm judge "
+                              "or, with --exec/--repo/--pilot, 4-arm execution)")
     sp_stage.add_argument("run_id")
-    sp_stage.add_argument("--trials", type=int, default=_DEFAULT_TRIALS)
-    sp_stage.add_argument("--fixture", default=None)
+    # default None so --pilot can floor to 3 while bare stage defaults to 5.
+    sp_stage.add_argument("--trials", type=int, default=None)
+    sp_stage.add_argument("--fixture", default=None)          # Phase-1 selector
+    sp_stage.add_argument("--repo", default=None)             # Phase-1b seeded repo
+    sp_stage.add_argument("--exec", dest="exec_mode", action="store_true",
+                          help="Phase-1b execution mode over all seeded repos")
+    sp_stage.add_argument("--pilot", action="store_true",
+                          help="Phase-1b calibration pilot (neutral-proxy only)")
     sp_stage.add_argument("--force", action="store_true")
 
     sp_score = sub.add_parser("score", help="Aggregate verdicts + write last_run.json")
@@ -963,8 +1339,12 @@ def _parse_args(argv: list) -> argparse.Namespace:
 def main(argv: list | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
     if args.cmd == "stage":
-        dispatch_dir = stage(args.run_id, trials=args.trials,
-                             fixture=args.fixture, force=args.force)
+        trials = args.trials
+        if trials is None:                # --pilot floors to 3; bare stage → 5
+            trials = _PILOT_MIN_TRIALS if args.pilot else _DEFAULT_TRIALS
+        dispatch_dir = stage(args.run_id, trials=trials, fixture=args.fixture,
+                             force=args.force, repo=args.repo,
+                             exec_mode=args.exec_mode, pilot=args.pilot)
         print(dispatch_dir)
         return 0
     if args.cmd == "score":

--- a/skills/inquisitor/evals/run_evals.py
+++ b/skills/inquisitor/evals/run_evals.py
@@ -16,8 +16,13 @@ There is no `collect` subcommand — collect is the live orchestrator procedure
 documented in README.md. `score` reads the judge verdict files and computes the
 three paired deltas (see the `score` section, added in build-order step 5).
 
-Phase 1 only: identification breadth, execution stubbed. See the gated design
-`docs/plans/2026-06-13-inquisitor-fanout-eval-harness-design.md`.
+Two phases live behind the manifest `mode` field (the Phase-1 path is byte-
+untouched): a manifest with NO `mode` runs the Phase-1 3-arm identification-breadth
+judge `score` (execution stubbed); a `mode:"phase1b-exec"` / `mode:"pilot"` manifest
+runs the Phase-1b 4-arm write-AND-run `score_exec` scored by the deterministic
+leave-one-out oracle (`_oracle.py`, no LLM). See the gated designs
+`docs/plans/2026-06-13-inquisitor-fanout-eval-harness-design.md` (Phase 1) and
+`docs/plans/2026-06-15-inquisitor-phase1b-execution-eval-design.md` (Phase 1b).
 """
 from __future__ import annotations
 import argparse
@@ -33,7 +38,7 @@ from pathlib import Path
 
 from ._dispatch_paths import fixture_sha, resolve_dispatch_dir, template_sha
 from ._runid import validate_run_id
-from . import _oracle
+from . import _fixtures, _oracle
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _EVALS_DIR = Path(__file__).resolve().parent
@@ -99,7 +104,12 @@ tests that expose seam bugs, then leave the test files in the repository.
 5. Leave your final test file(s) in the repository's test directory.
 
 ## Budget
-At most **5 tests** (this per-agent budget is uniform across every arm).
+At most **5 tests** (this per-agent budget is uniform across every arm). Put
+each test in its **own** `test_*.py` file and make it self-contained — import
+only from `src/`, do not import a helper module you wrote. The scorer runs each
+test file in isolation on a pristine repo, so a file that over-asserts or imports
+an unharvested helper is discarded as a whole; one-test-per-file keeps that
+penalty uniform.
 
 ## What You Must NOT Do
 - Do NOT edit the repository source — write tests only.
@@ -1075,8 +1085,12 @@ def stage_exec(run_id: str, *, trials: int, repo: str | None = None,
     (dispatch_dir / "mid.md").write_text(_exec_mid(blocks), encoding="utf-8")
 
     def copy_for(cell_key: str, idx: int, repo_id: str) -> str:
+        # F1/F2: the producer copy is the BLIND substrate — only src/ + tests/,
+        # leak annotations stripped, no exemplars/fixes/GT/manifest. The oracle
+        # scores from _FIXTURES_DIR (not this copy), so narrowing loses nothing.
         dst = copies_root / f"{cell_key}-p{idx}"
-        shutil.copytree(_FIXTURES_DIR / repo_id, dst)
+        _fixtures.copy_repo_for_producer(_FIXTURES_DIR / repo_id, dst)
+        _fixtures._assert_no_leak(dst)
         return str(dst.relative_to(dispatch_dir))
 
     arms = _PILOT_ARMS if pilot else _EXEC_ARMS
@@ -1143,17 +1157,40 @@ def _exec_cell_caught(cell, dispatch_dir, repo_meta, complete):
     rf = dispatch_dir / cell["result_file"]
     if not rf.exists():
         return set(), None, (f"missing result_file {cell['result_file']}" if complete else None)
-    data = json.loads(rf.read_text(encoding="utf-8"))
+    # S-1: an EXISTING but empty/truncated/non-JSON result_file (collect interrupted
+    # mid-write, partial flush, OOM-killed harvester — a normal outcome across a
+    # multi-cell live run) is a broken-collector ingest failure, not a scorer bug.
+    # Handle it as a clean per-cell [fatal] like every sibling guard, never a raw
+    # JSONDecodeError traceback off the load-bearing exec-scoring path.
+    try:
+        data = json.loads(rf.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, ValueError) as e:
+        return set(), None, (f"cell {cell['result_file']} is not valid JSON: {e}"
+                             if complete else None)
     if data.get("dispatch_status") != "OK":
         return set(), None, (f"cell {cell['result_file']} dispatch_status != OK"
                              if complete else None)
     test_files = [Path(p) for p in data.get("test_files", [])]
+    # M-1: the oracle `shutil.copyfile`s each test_file into a variant from score's
+    # cwd, so a relative path would resolve against an unspecified directory. The
+    # collect contract (C4) writes absolute paths; fail loud if one isn't, rather
+    # than silently copying the wrong file (or nothing).
+    for p in test_files:
+        if not p.is_absolute():
+            return set(), None, (f"cell {cell['result_file']} test_file {str(p)!r} "
+                                 f"is not absolute (collect must write absolute paths)")
+        # S-1: a stale/deleted absolute test_file would reach the oracle's
+        # `shutil.copyfile` and crash with an uncaught FileNotFoundError. Guard
+        # existence here so it fails loud with per-cell attribution instead.
+        if not p.exists():
+            return set(), None, (f"cell {cell['result_file']} test_file {str(p)!r} "
+                                 f"does not exist (stale/deleted collect path)")
     res = _oracle.caught_bugs(test_files, _FIXTURES_DIR / cell["repo_id"],
                               interacting_sets=repo_meta[cell["repo_id"]]["isets"])
     return res["caught"], res, None
 
 
-def _two_of_three(count: int, total: int) -> int:
+def _two_of_three(total: int) -> int:
     """The ≥2/3 threshold count for `total` repos (3 repos → 2; 1 → 1)."""
     return math.ceil(2 * total / 3)
 
@@ -1186,22 +1223,48 @@ def score_exec(run_id: str, manifest: dict, dispatch_dir: Path, *,
             "n": len(bug_ids),
         }
 
+    # S-2: interacting_set scoring is NOT unified across the two views score_exec
+    # takes of `caught`. The oracle credits a registered set once via a single
+    # "+"-joined id (e.g. "nt-b3+nt-b7"); the per-trial rate divides raw len(caught)
+    # — which counts that joined id — by n=len(bug_ids), while majority_caught /
+    # arm_repo_caught / off_pass iterate the INDIVIDUAL bug_ids (which never appear
+    # in `caught`). So a real set-catch is under-counted in the tally yet counted in
+    # the rate, silently desyncing the two arm-rate views and the absolute rate that
+    # feeds the WITHOUT ceiling. The feature is dead for the current decision run
+    # (all repos register empty sets), so rather than ship a half-wired scorer that
+    # mis-reports on first real use, refuse loudly until the rate plumbing is unified.
+    set_repos = sorted(r for r in repos if repo_meta[r]["isets"])
+    if set_repos:
+        print(f"[fatal] interacting_set scoring not yet unified — refusing to score: "
+              f"repos with non-empty interacting_sets={set_repos}. The credit unit "
+              f"(joined '+'-id) and the per-repo tally unit (individual bug_ids) are "
+              f"mismatched in score_exec; unify them before scoring a run that uses "
+              f"interacting_sets.", file=sys.stderr)
+        return 1
+
     cells_by = {(c["arm"], c["repo_id"], c["trial"]): c for c in manifest["cells"]}
     if complete:
         expected = {(a, r, t) for a in arms for r in repos
                     for t in range(1, trials + 1)}
         missing = sorted(expected - set(cells_by))
-        dups = [k for k in cells_by] if len(cells_by) != len(manifest["cells"]) else []
+        seen: dict = {}
+        for c in manifest["cells"]:
+            seen[(c["arm"], c["repo_id"], c["trial"])] = seen.get(
+                (c["arm"], c["repo_id"], c["trial"]), 0) + 1
+        dups = sorted(k for k, n in seen.items() if n > 1)
         if missing or dups:
             print(f"[fatal] exec cell-grid incomplete for {dispatch_dir}: "
-                  f"missing={missing} (arms {list(arms)} × repos {repos} × "
-                  f"trials 1..{trials}); refusing to score", file=sys.stderr)
+                  f"missing={missing} dups={dups} (arms {list(arms)} × repos "
+                  f"{repos} × trials 1..{trials}); refusing to score",
+                  file=sys.stderr)
             return 1
 
     # caught[arm][repo][trial] -> set of caught ids
     caught: dict = {a: {r: {} for r in repos} for a in arms}
     broad_per_arm: dict = {a: [] for a in arms}
     flaky_per_arm: dict = {a: 0 for a in arms}
+    errored_per_arm: dict = {a: 0 for a in arms}
+    errored_minus_per_arm: dict = {a: 0 for a in arms}
     for (arm, r, t), cell in cells_by.items():
         cset, res, fatal = _exec_cell_caught(cell, dispatch_dir, repo_meta, complete)
         if fatal:
@@ -1211,6 +1274,8 @@ def score_exec(run_id: str, manifest: dict, dispatch_dir: Path, *,
         if res is not None:
             broad_per_arm[arm].extend(res["broad_test_catches"].values())
             flaky_per_arm[arm] += res["flaky_discards"]
+            errored_per_arm[arm] += res.get("errored_discards", 0)
+            errored_minus_per_arm[arm] += res.get("errored_minus_discards", 0)
 
     total_bugs = sum(repo_meta[r]["n"] for r in repos)
 
@@ -1229,14 +1294,17 @@ def score_exec(run_id: str, manifest: dict, dispatch_dir: Path, *,
             "repos": repos, "arms": list(arms),
             "pilot_band": {"band": list(_PILOT_BAND), "per_repo": per_repo},
             "flaky_discards": flaky_per_arm,
+            "errored_discards": errored_per_arm,
+            "errored_minus_discards": errored_minus_per_arm,
         }
         (_EVALS_DIR / "last_run.json").write_text(json.dumps(last_run, indent=2),
                                                   encoding="utf-8")
         return 0
 
     # --- decision path: 4-arm deltas + WITHOUT ceiling + KEEP statistic ---
-    per_trial_rate = {a: [sum(len(caught[a][r].get(t, set())) for r in repos)
-                          / total_bugs for t in range(1, trials + 1)]
+    per_trial_rate = {a: [(sum(len(caught[a][r].get(t, set())) for r in repos)
+                           / total_bugs if total_bugs else 0.0)
+                          for t in range(1, trials + 1)]
                       for a in arms}
 
     def majority_caught(a, r, b):
@@ -1246,16 +1314,30 @@ def score_exec(run_id: str, manifest: dict, dispatch_dir: Path, *,
     arm_repo_caught = {a: {r: sum(1 for b in repo_meta[r]["bug_ids"]
                                   if majority_caught(a, r, b)) for r in repos}
                        for a in arms}
-    arm_rate = {a: sum(arm_repo_caught[a][r] for r in repos) / total_bugs
+    arm_rate = {a: (sum(arm_repo_caught[a][r] for r in repos) / total_bugs
+                    if total_bugs else 0.0)
                 for a in arms}
 
     without_means = {r: repo_mean_rate("without", r) for r in repos}
     with_means = {r: repo_mean_rate("with", r) for r in repos}
+    # S-2: the 2-of-3 robustness vote is only a robustness statistic with the full
+    # 3-repo grid. A `--repo X` (or any <3-repo) run collapses `_two_of_three` to a
+    # 1-of-1 (or 2-of-2) vote — NOT cross-repo-corroborated — so we MUST NOT present
+    # `without_ceiling_broken`/`sign_holds_2of3` as if 3-repo-backed. Mirrors the
+    # `trials < 3 -> beyond_spread forced False` degeneracy guard: when the vote is
+    # degenerate we stamp `degenerate_repo_count: true` and null the boolean
+    # verdicts, recording `repos_voting` (the actual repo count behind the vote).
+    repos_voting = len(repos)
+    degenerate_repo_count = repos_voting < 3
     below = sum(1 for r in repos if without_means[r] <= _WITHOUT_CEILING)
-    without_ceiling_broken = below >= _two_of_three(below, len(repos))
     per_repo_sign = {r: with_means[r] - without_means[r] for r in repos}
     positive = sum(1 for r in repos if per_repo_sign[r] > 0)
-    sign_holds = positive >= _two_of_three(positive, len(repos))
+    if degenerate_repo_count:
+        without_ceiling_broken = None
+        sign_holds = None
+    else:
+        without_ceiling_broken = below >= _two_of_three(repos_voting)
+        sign_holds = positive >= _two_of_three(repos_voting)
 
     deltas = {
         "_note": ("paired = mean of per-trial deltas; the KEEP gate reads "
@@ -1283,15 +1365,30 @@ def score_exec(run_id: str, manifest: dict, dispatch_dir: Path, *,
                       for a in arms},
         "deltas": deltas,
         "without_ceiling_broken": without_ceiling_broken,
+        "without_ceiling_broken_note": (
+            "term of art (design §7): 'broken' = WITHOUT is BELOW the "
+            f"{_WITHOUT_CEILING:.2f} ceiling on >=2/3 repos (headroom EXISTS, the "
+            "no-headroom ceiling problem is cleared), NOT that WITHOUT exceeded it. "
+            "True is the GOOD case for a trustworthy CONDEMN."),
         "without_repo_means": without_means,
+        "repos_voting": repos_voting,
+        "degenerate_repo_count": degenerate_repo_count,
         "keep_statistic": {
             "_note": ("KEEP = beyond_spread on with_without AND positive sign on "
                       ">=2/3 repos; trial_spread is explicitly REJECTED as the gate "
                       "(S-B). score surfaces the inputs; the human reads the §7 "
-                      "branches — it emits no keep/condemn verdict."),
+                      "branches — it emits no keep/condemn verdict. S-2: with "
+                      "<3 repos the 2-of-3 vote is degenerate (not cross-repo "
+                      "corroborated) — `sign_holds_2of3`/`without_ceiling_broken` "
+                      "are null and `degenerate_repo_count` is true; read the raw "
+                      "`repos_*_count` / `repos_voting` instead."),
             "statistic": "beyond_spread",
             "beyond_spread": deltas["with_without"]["beyond_spread"],
             "per_repo_sign": per_repo_sign,
+            "repos_voting": repos_voting,
+            "degenerate_repo_count": degenerate_repo_count,
+            "repos_positive_sign_count": positive,
+            "repos_below_ceiling_count": below,
             "sign_holds_2of3": sign_holds,
             "without_ceiling_broken": without_ceiling_broken,
         },
@@ -1300,7 +1397,25 @@ def score_exec(run_id: str, manifest: dict, dispatch_dir: Path, *,
                                 for a in arms},
         "broad_test_catches": {a: (statistics.mean(broad_per_arm[a])
                                    if broad_per_arm[a] else 0.0) for a in arms},
+        # S-3: a single test credited to >=3 bugs is the conjunction-inflation
+        # signal. The no-specificity-gate credit rule (caught(Bᵢ) ⟸ RED on
+        # minus-Bᵢ) is sound under §3 disjointness for the EXEMPLARS (proven by
+        # check_fixture_independence.py); for an ARBITRARY producer test the
+        # transfer is a variant-property argument, not a checked fact, so a broad
+        # test whose single assertion happens to depend on a conjunction would be
+        # credited to each bug — inflating absolute catch rates that feed the
+        # WITHOUT *absolute* ceiling. This per-arm count lets an operator spot that
+        # inflation before trusting the ceiling (see _oracle docstring).
+        "conjunction_inflation": {
+            "_note": ("per-arm count of tests crediting >=3 bugs (S-3 "
+                      "conjunction-inflation signal — inspect before trusting the "
+                      "absolute WITHOUT ceiling; not a gate)."),
+            "tests_crediting_3plus_bugs": {
+                a: sum(1 for n in broad_per_arm[a] if n >= 3) for a in arms},
+        },
         "flaky_discards": flaky_per_arm,
+        "errored_discards": errored_per_arm,
+        "errored_minus_discards": errored_minus_per_arm,
     }
     (_EVALS_DIR / "last_run.json").write_text(json.dumps(last_run, indent=2),
                                               encoding="utf-8")

--- a/skills/inquisitor/evals/test_build_collect_args.py
+++ b/skills/inquisitor/evals/test_build_collect_args.py
@@ -76,6 +76,14 @@ class BuildCollectArgsTest(unittest.TestCase):
         self.assertEqual(len(obj["units"]), 3)
         self.assertEqual({u["arm"] for u in obj["units"]}, {"neutral-proxy"})
 
+    def test_phase1_manifest_self_explaining_error(self):
+        # M-2: a Phase-1 (no-`mode`, dispatch_files-shaped) manifest must fail with a
+        # clear "exec/pilot-only" message, not a raw KeyError on cell["producers"].
+        d = self._write({"run_id": "x", "dispatch_files": ["a.md", "b.md"]})
+        with self.assertRaises(SystemExit) as cm:
+            _build_collect_args.build(d)
+        self.assertIn("exec/pilot-only", str(cm.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/inquisitor/evals/test_build_collect_args.py
+++ b/skills/inquisitor/evals/test_build_collect_args.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for _build_collect_args.build() — the Phase-1b no-judge dispatch args (#424).
+
+stdlib unittest. Synthesizes an exec/pilot stage-manifest and asserts the producer
+unit list is correct and judge-free.
+"""
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.inquisitor.evals import _build_collect_args  # noqa: E402
+
+_JUDGE_KEYS = {"dim_paths", "mid_path", "without_path", "items", "judge_prompt"}
+
+
+def _exec_manifest():
+    cells = []
+    specs = [("with", 5), ("pool", 5), ("mid", 1), ("without", 1)]
+    for arm, k in specs:
+        cells.append({
+            "repo_id": "notify", "trial": 1, "arm": arm,
+            "producers": [{"agent": i, "dispatch_file": f"{arm}-{i}.md",
+                           "repo_copy": f"copies/notify-t1-{arm}-p{i}"}
+                          for i in range(1, k + 1)],
+            "result_file": f"notify-t1-{arm}-tests.json"})
+    return {"run_id": "x", "mode": "phase1b-exec",
+            "arms": ["with", "pool", "mid", "without"], "trials": 1,
+            "repos": ["notify"], "cells": cells}
+
+
+class BuildCollectArgsTest(unittest.TestCase):
+    def _write(self, manifest):
+        d = pathlib.Path(self._tmp.name)
+        (d / "stage-manifest.json").write_text(json.dumps(manifest))
+        return d
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_exec_producer_units(self):
+        d = self._write(_exec_manifest())
+        obj = _build_collect_args.build(d)
+        self.assertEqual(obj["mode"], "phase1b-exec")
+        self.assertEqual(len(obj["units"]), 12)            # 5+5+1+1
+        for u in obj["units"]:
+            self.assertTrue(pathlib.Path(u["dispatch_file"]).is_absolute())
+            self.assertTrue(pathlib.Path(u["repo_copy"]).is_absolute())
+            self.assertTrue(u["result_file"].endswith("-tests.json"))
+            self.assertIn(u["arm"], ("with", "pool", "mid", "without"))
+        # no Phase-1 judge inputs leaked into the args object or any unit
+        self.assertFalse(_JUDGE_KEYS & set(obj))
+        for u in obj["units"]:
+            self.assertFalse(_JUDGE_KEYS & set(u))
+        # WITH/POOL contribute 5 producers each, all pointing at the cell result_file
+        with_units = [u for u in obj["units"] if u["arm"] == "with"]
+        self.assertEqual(len(with_units), 5)
+        self.assertEqual(len({u["result_file"] for u in with_units}), 1)
+
+    def test_pilot_units(self):
+        m = {"run_id": "x", "mode": "pilot", "arms": ["neutral-proxy"], "trials": 3,
+             "repos": ["notify"],
+             "cells": [{"repo_id": "notify", "trial": t, "arm": "neutral-proxy",
+                        "producers": [{"agent": 1,
+                                       "dispatch_file": "neutral-proxy-prompt-eval.md",
+                                       "repo_copy": f"copies/notify-t{t}-np-p1"}],
+                        "result_file": f"notify-t{t}-neutral-proxy-tests.json"}
+                       for t in (1, 2, 3)]}
+        obj = _build_collect_args.build(self._write(m))
+        self.assertEqual(obj["mode"], "pilot")
+        self.assertEqual(len(obj["units"]), 3)
+        self.assertEqual({u["arm"] for u in obj["units"]}, {"neutral-proxy"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/inquisitor/evals/test_fixtures.py
+++ b/skills/inquisitor/evals/test_fixtures.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Tests for _fixtures.py — variant materialization helper (#424 Phase 1b).
+
+stdlib unittest (harness convention; pytest is the fixture *runner*, not the
+unit-test gate). Invoked as a bare script by scripts/run_tests.sh, so bootstrap
+repo-root onto sys.path before importing the package.
+"""
+import json
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.inquisitor.evals import _fixtures  # noqa: E402
+
+# git-style unified diff fixing toy bug b1 (return "BUG" -> return "OK").
+# -p1 strips the a/ prefix when applied from the variant root.
+B1_PATCH = '''\
+--- a/src/toy/m.py
++++ b/src/toy/m.py
+@@ -1,2 +1,2 @@
+ def value():
+-    return "BUG"
++    return "OK"
+'''
+
+M_PY = 'def value():\n    return "BUG"\n'
+
+MANIFEST = {
+    "repo_id": "toy",
+    "pkg": "toy",
+    "test_dir": "tests",
+    "runner_cmd": ["python3", "-m", "pytest", "-q"],
+    "bug_ids": ["b1"],
+    "n": 1,
+}
+
+
+def _build_toy_repo(root: pathlib.Path):
+    (root / "src" / "toy").mkdir(parents=True)
+    (root / "src" / "toy" / "__init__.py").write_text("")
+    (root / "src" / "toy" / "m.py").write_text(M_PY)
+    (root / "fixes").mkdir()
+    (root / "fixes" / "b1.patch").write_text(B1_PATCH)
+    (root / "manifest.json").write_text(json.dumps(MANIFEST))
+
+
+class FixturesTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.toy = pathlib.Path(self._tmp.name) / "toy"
+        self.toy.mkdir()
+        _build_toy_repo(self.toy)
+        self._dirs = []
+
+    def tearDown(self):
+        for d in self._dirs:
+            shutil.rmtree(d, ignore_errors=True)
+        self._tmp.cleanup()
+
+    def _materialize(self, **kw):
+        d = _fixtures.materialize_variant(self.toy, **kw)
+        self._dirs.append(d)
+        return pathlib.Path(d)
+
+    def _m_py(self, d: pathlib.Path) -> str:
+        return (d / "src" / "toy" / "m.py").read_text()
+
+    def test_base_has_bug(self):
+        d = self._materialize(apply=[])
+        self.assertIn("BUG", self._m_py(d))
+
+    def test_all_fixed_applies_every_patch(self):
+        d = self._materialize(apply=["b1"])
+        self.assertNotIn("BUG", self._m_py(d))
+        self.assertIn("OK", self._m_py(d))
+
+    def test_exclude_cancels_apply(self):
+        # apply all known bug_ids except the excluded one -> == base here
+        d = self._materialize(apply=["b1"], exclude=["b1"])
+        self.assertIn("BUG", self._m_py(d))
+
+    def test_load_manifest(self):
+        m = _fixtures.load_manifest(self.toy)
+        self.assertEqual(m["repo_id"], "toy")
+        self.assertEqual(m["n"], 1)
+        self.assertEqual(m["bug_ids"], ["b1"])
+
+    def test_load_manifest_n_mismatch_raises(self):
+        bad = pathlib.Path(self._tmp.name) / "bad"
+        bad.mkdir()
+        _build_toy_repo(bad)
+        m = dict(MANIFEST, n=2)
+        (bad / "manifest.json").write_text(json.dumps(m))
+        with self.assertRaises(ValueError):
+            _fixtures.load_manifest(bad)
+
+    def test_unknown_bug_id_raises(self):
+        with self.assertRaises(ValueError):
+            self._materialize(apply=["bX"])
+
+    def test_convenience_wrappers(self):
+        b = pathlib.Path(_fixtures.base(self.toy)); self._dirs.append(b)
+        af = pathlib.Path(_fixtures.all_fixed(self.toy)); self._dirs.append(af)
+        afm = pathlib.Path(_fixtures.all_fixed_minus(self.toy, "b1")); self._dirs.append(afm)
+        self.assertIn("BUG", self._m_py(b))
+        self.assertNotIn("BUG", self._m_py(af))
+        self.assertIn("BUG", self._m_py(afm))  # only bug excluded -> base
+
+    def test_variant_context_manager_cleans_up(self):
+        with _fixtures.variant(self.toy, apply=["b1"]) as d:
+            dp = pathlib.Path(d)
+            self.assertNotIn("BUG", self._m_py(dp))
+        self.assertFalse(dp.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/inquisitor/evals/test_fixtures.py
+++ b/skills/inquisitor/evals/test_fixtures.py
@@ -116,5 +116,183 @@ class FixturesTest(unittest.TestCase):
         self.assertFalse(dp.exists())
 
 
+class ProducerCopyTest(unittest.TestCase):
+    """F1+F2+S3: blind producer copy (strip + subset) and subprocess timeout."""
+
+    # the bug-describing prose mirrors the real fixtures: id token + a
+    # plain-language defect description + a "The fix …" sentence, in a comment AND
+    # a docstring; the GT desc is a verbatim window of that prose.
+    DESC = "a None or negative delay is passed straight through to the job"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self._tmp.name) / "toy"
+        (self.repo / "src" / "toy").mkdir(parents=True)
+        (self.repo / "src" / "toy" / "__init__.py").write_text("")
+        (self.repo / "src" / "toy" / "m.py").write_text(
+            '"""seam exercised here (nt-b1). ' + self.DESC + '."""\n'
+            'DEFAULT = "sms"  # BUG nt-b8: ' + self.DESC + '. The fix clamps it.\n'
+            'CODE = "nt-keep"  # a runtime string (no leak token) stays intact\n'
+            'def value():\n    """' + self.DESC + '"""\n    return DEFAULT\n')
+        (self.repo / "tests").mkdir()
+        (self.repo / "tests" / "conftest.py").write_text("# conftest\n")
+        (self.repo / "exemplars").mkdir()
+        (self.repo / "exemplars" / "nt-b1.py").write_text("# answer\n")
+        (self.repo / "fixes").mkdir()
+        (self.repo / "fixes" / "nt-b1.patch").write_text("--- a\n+++ b\n")
+        (self.repo / "manifest.json").write_text(json.dumps(MANIFEST))
+        (self.repo / "ground-truth-bugs.json").write_text(json.dumps(
+            {"bugs": [{"bug_id": "nt-b8", "desc": self.DESC}]}))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_strip_removes_comments_and_docstrings_keeps_code(self):
+        src = ('"""module doc (pg-b2): ' + self.DESC + '"""\n'
+               'X = 1  # BUG nt-b3: bad\n'
+               'KEEP = "literal pg value"\n'
+               'def f():\n    """fn doc here."""\n    return X\n')
+        out = _fixtures._strip_comments_and_docstrings(src)
+        # all bug prose + tokens gone
+        self.assertNotIn("nt-b3", out)
+        self.assertNotIn("pg-b2", out)
+        self.assertNotIn("BUG", out)
+        self.assertNotIn(self.DESC, out)
+        # code preserved; result still compiles
+        self.assertIn("X = 1", out)
+        self.assertIn("return X", out)
+        compile(out, "stripped.py", "exec")
+        # M-3: a NON-docstring string literal is left intact (runtime data)
+        self.assertIn('KEEP = "literal pg value"', out)
+        # no-comment/no-docstring source is returned byte-identical
+        clean = "def g():\n    return 7\n"
+        self.assertEqual(_fixtures._strip_comments_and_docstrings(clean), clean)
+
+    def test_copy_excludes_answer_key_and_strips_prose(self):
+        copy = pathlib.Path(self._tmp.name) / "copy"
+        _fixtures.copy_repo_for_producer(self.repo, copy)
+        # F2: answer-key paths excluded
+        for forbidden in ("exemplars", "fixes", "manifest.json",
+                          "ground-truth-bugs.json"):
+            self.assertFalse((copy / forbidden).exists())
+        # producer-visible subset present
+        self.assertTrue((copy / "src" / "toy" / "m.py").exists())
+        self.assertTrue((copy / "tests" / "conftest.py").exists())
+        # F1: leak tokens AND bug-describing prose stripped, code preserved
+        m = (copy / "src" / "toy" / "m.py").read_text()
+        self.assertNotIn("nt-b", m)
+        self.assertNotIn("BUG", m)
+        self.assertNotIn(self.DESC, m)
+        self.assertNotIn("The fix", m)
+        self.assertIn('DEFAULT = "sms"', m)
+        # non-docstring runtime string survived
+        self.assertIn('CODE = "nt-keep"', m)
+
+    def test_producer_copy_has_no_gt_description_prose(self):
+        # The test whose ABSENCE let F-1 through: materialize a producer copy and
+        # assert NONE of the GT bug descriptions survive (adversarial guard, not
+        # re-using the strip's own regex).
+        copy = pathlib.Path(self._tmp.name) / "copy_desc"
+        _fixtures.copy_repo_for_producer(self.repo, copy)
+        descs = [self.DESC]
+        _fixtures.assert_no_description_leak(copy, descs)  # passes on stripped copy
+        # and the guard is ADVERSARIAL: a re-introduced desc window trips it
+        (copy / "src" / "toy" / "leak.py").write_text("# " + self.DESC + "\n")
+        with self.assertRaises(AssertionError):
+            _fixtures.assert_no_description_leak(copy, descs)
+
+    def test_assert_no_leak_raises_on_token_and_path(self):
+        copy = pathlib.Path(self._tmp.name) / "copy2"
+        _fixtures.copy_repo_for_producer(self.repo, copy)
+        _fixtures._assert_no_leak(copy)  # clean copy passes
+        # re-introduce a leak token
+        (copy / "src" / "toy" / "leak.py").write_text("# BUG nt-b9\n")
+        with self.assertRaises(AssertionError):
+            _fixtures._assert_no_leak(copy)
+        # forbidden path
+        copy3 = pathlib.Path(self._tmp.name) / "copy3"
+        _fixtures.copy_repo_for_producer(self.repo, copy3)
+        (copy3 / "fixes").mkdir()
+        with self.assertRaises(AssertionError):
+            _fixtures._assert_no_leak(copy3)
+
+    def test_tests_subtree_in_blindness_scope(self):
+        # S-1: tests/ is producer-visible (`_PRODUCER_VISIBLE`), so an annotated
+        # tests/ file must (a) be stripped by copy_repo_for_producer and (b) be in
+        # scope of BOTH leak guards. Drop a test file carrying a leak token + a
+        # GT-desc window + "The fix" into the SOURCE repo's tests/, then materialize.
+        (self.repo / "tests" / "test_seam.py").write_text(
+            '"""seam (nt-b8): ' + self.DESC + '. The fix clamps it."""\n'
+            'def test_seam():\n    assert True\n')
+        copy = pathlib.Path(self._tmp.name) / "copy_tests"
+        _fixtures.copy_repo_for_producer(self.repo, copy)
+        # (a) the strip ran over tests/ too: token + prose gone, code preserved
+        t = (copy / "tests" / "test_seam.py").read_text()
+        self.assertNotIn("nt-b", t)
+        self.assertNotIn(self.DESC, t)
+        self.assertNotIn("The fix", t)
+        self.assertIn("assert True", t)
+        # remove the stripped test file so the tests/-empty-except-conftest invariant
+        # below does not pre-empt the token/prose guards we exercise next
+        (copy / "tests" / "test_seam.py").unlink()
+        # (b) a leak token re-introduced into the COPY's tests/ trips _assert_no_leak
+        # via the token guard (proving the scope is tests/-inclusive, not src/-only)
+        (copy / "tests" / "test_leak.py").write_text("# BUG nt-b9: leak\n")
+        with self.assertRaises(AssertionError) as cm:
+            _fixtures._assert_no_leak(copy)
+        self.assertIn("leaks bug-identity token", str(cm.exception))
+        (copy / "tests" / "test_leak.py").unlink()
+        # ... and GT-desc prose in a tests/ file trips assert_no_description_leak
+        (copy / "tests" / "test_prose.py").write_text("# " + self.DESC + "\n")
+        with self.assertRaises(AssertionError):
+            _fixtures.assert_no_description_leak(copy, [self.DESC])
+        (copy / "tests" / "test_prose.py").unlink()
+        # belt-and-suspenders: a clean (no-leak) non-conftest tests/ file is flagged
+        # by the tests/-empty-except-conftest invariant
+        (copy / "tests" / "test_plain.py").write_text("def test_p():\n    assert 1\n")
+        with self.assertRaises(AssertionError) as cm2:
+            _fixtures._assert_no_leak(copy)
+        self.assertIn("non-conftest file", str(cm2.exception))
+        (copy / "tests" / "test_plain.py").unlink()
+        # tests/ = conftest.py only passes the guard
+        _fixtures._assert_no_leak(copy)
+
+    def test_missing_patch_cleans_up_tmp(self):
+        # M-1: the missing-patch error path rmtrees its temp dir before raising,
+        # matching its two sibling error paths (timeout, patch-reject). Manifest
+        # names a bug whose fixes/<id>.patch is absent.
+        repo = pathlib.Path(self._tmp.name) / "nopatch"
+        (repo / "src").mkdir(parents=True)
+        (repo / "fixes").mkdir()
+        (repo / "manifest.json").write_text(json.dumps(
+            {**MANIFEST, "bug_ids": ["nt-z1"], "n": 1}))
+        before = set(pathlib.Path(tempfile.gettempdir()).glob("variant-*"))
+        with self.assertRaises(FileNotFoundError):
+            _fixtures.materialize_variant(repo, apply=["nt-z1"])
+        after = set(pathlib.Path(tempfile.gettempdir()).glob("variant-*"))
+        self.assertEqual(after - before, set(),
+                         "missing-patch path leaked a /tmp/variant-* dir")
+
+    def test_run_test_in_dir_timeout_maps_to_error(self):
+        # A hung test maps to ERROR (non-eligible), not a hang. Use a tiny
+        # timeout via monkeypatch to keep the test fast.
+        variant = pathlib.Path(self._tmp.name) / "variant"
+        (variant / "src" / "toy").mkdir(parents=True)
+        (variant / "src" / "toy" / "__init__.py").write_text("")
+        (variant / "tests").mkdir()
+        (variant / "tests" / "conftest.py").write_text(
+            "import pathlib, sys\n"
+            "sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / 'src'))\n")
+        hung = pathlib.Path(self._tmp.name) / "test_hung.py"
+        hung.write_text("import time\ndef test_h():\n    time.sleep(30)\n")
+        orig = _fixtures._SUBPROCESS_TIMEOUT_S
+        _fixtures._SUBPROCESS_TIMEOUT_S = 1
+        try:
+            verdict = _fixtures.run_test_in_dir(variant, str(hung), MANIFEST)
+        finally:
+            _fixtures._SUBPROCESS_TIMEOUT_S = orig
+        self.assertEqual(verdict, "ERROR")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/inquisitor/evals/test_oracle.py
+++ b/skills/inquisitor/evals/test_oracle.py
@@ -116,6 +116,39 @@ class ErrorTruthTable(OracleTestBase):
         r = self.caught("x = 1\n")
         self.assertEqual(r["caught"], set())
 
+    def test_errored_discard_is_surfaced(self):
+        # S2: a test ERRORing on all-fixed (e.g. importing an unharvested helper)
+        # is ineligible AND counted in errored_discards (not silently lost).
+        r = self.caught("import does_not_exist_xyz\ndef test():\n    assert True\n")
+        self.assertEqual(r["caught"], set())
+        self.assertEqual(r["errored_discards"], 1)
+        self.assertEqual(r["flaky_discards"], 0)
+
+    def test_clean_run_reports_zero_errored_discards(self):
+        r = self.caught("from toy.calc import a\ndef test():\n    assert a() == 10\n")
+        self.assertEqual(r["caught"], {"b1"})
+        self.assertEqual(r["errored_discards"], 0)
+        self.assertEqual(r.get("errored_minus_discards", 0), 0)
+
+    def test_minus_variant_error_is_surfaced(self):
+        # S-1: an eligible test (GREEN on all-fixed, RED on base via `assert a()==10`)
+        # that takes a COLLECTION-time import error on exactly the minus-b3 variant.
+        # The module-level trap fires only when a/b are fixed but c is NOT — i.e.
+        # all-fixed-minus-b3 (a=10,b=20,c=3). On all-fixed (c=30) and on base (a=1)
+        # the condition is False, so collection succeeds there. The b3 cell is a
+        # stable ERROR: neither flaky nor a credit — it MUST bump errored_minus_discards
+        # so the lost b3 catch is observable, not silently dropped.
+        body = ("from toy.calc import a, b, c\n"
+                "if a() == 10 and b() == 20 and c() == 3:\n"
+                "    import does_not_exist_xyz  # collection-time ERROR on minus-b3 only\n"
+                "def test():\n    assert a() == 10\n")
+        r = self.caught(body)
+        self.assertEqual(r["caught"], {"b1"})       # b1 still credited (RED on minus-b1)
+        self.assertNotIn("b3", r["caught"])         # b3 lost to the ERROR cell
+        self.assertEqual(r["errored_minus_discards"], 1)
+        self.assertEqual(r["errored_discards"], 0)  # all-fixed anchor collected fine
+        self.assertEqual(r["flaky_discards"], 0)    # the ERROR is stable, not flaky
+
 
 class SourceEditsIgnored(OracleTestBase):
     def test_source_edits_ignored(self):

--- a/skills/inquisitor/evals/test_oracle.py
+++ b/skills/inquisitor/evals/test_oracle.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Tests for _oracle.py — the differential leave-one-out scorer (#424 Phase 1b §4).
+
+stdlib unittest. Built against canned test files + a toy 3-bug repo (b1/b2/b3) —
+no live agents, no real fixtures. Covers the §9 testable invariants: leave-one-out
+necessity + mandatory red-on-base, no specificity gate (coarse test credited to
+EACH independent bug), ERROR != green, source-edits-ignored, incidental silencing,
+interacting-bug attribution, registered interacting_set, and the twice-run flake
+guard (incl. anchors).
+"""
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.inquisitor.evals import _oracle  # noqa: E402
+
+# Toy calc.py: a()/b()/c() well-SEPARATED so per-bug diff -u hunks are
+# context-disjoint and compose order-independently at zero fuzz.
+PAD = "\n_p1 = 0\n_p2 = 0\n_p3 = 0\n_p4 = 0\n_p5 = 0\n"
+CALC = ("def a():\n    return 1\n" + PAD +
+        "\ndef b():\n    return 2\n" + PAD +
+        "\ndef c():\n    return 3\n")
+CALC_A = CALC.replace("    return 1\n", "    return 10\n", 1)
+CALC_B = CALC.replace("    return 2\n", "    return 20\n", 1)
+CALC_C = CALC.replace("    return 3\n", "    return 30\n", 1)
+
+CONFTEST = ("import pathlib, sys\n"
+            "sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / 'src'))\n")
+
+
+def _diff(path, before, after):
+    with tempfile.TemporaryDirectory() as d:
+        a = pathlib.Path(d) / "a"
+        b = pathlib.Path(d) / "b"
+        a.write_text(before)
+        b.write_text(after)
+        out = subprocess.run(["diff", "-u", str(a), str(b)],
+                             capture_output=True, text=True).stdout
+    return "\n".join([f"--- a/{path}", f"+++ b/{path}"] + out.splitlines()[2:]) + "\n"
+
+
+def _build_toy(root: pathlib.Path):
+    (root / "src" / "toy").mkdir(parents=True)
+    (root / "src" / "toy" / "__init__.py").write_text("")
+    (root / "src" / "toy" / "calc.py").write_text(CALC)
+    (root / "tests").mkdir()
+    (root / "tests" / "conftest.py").write_text(CONFTEST)
+    (root / "fixes").mkdir()
+    (root / "fixes" / "b1.patch").write_text(_diff("src/toy/calc.py", CALC, CALC_A))
+    (root / "fixes" / "b2.patch").write_text(_diff("src/toy/calc.py", CALC, CALC_B))
+    (root / "fixes" / "b3.patch").write_text(_diff("src/toy/calc.py", CALC, CALC_C))
+    (root / "manifest.json").write_text(json.dumps(
+        {"repo_id": "toy", "pkg": "toy", "test_dir": "tests",
+         "runner_cmd": ["python3", "-m", "pytest", "-q"],
+         "bug_ids": ["b1", "b2", "b3"], "n": 3}))
+
+
+class OracleTestBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self._tmp.name) / "toy"
+        self.repo.mkdir()
+        _build_toy(self.repo)
+        self._wsi = 0
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def write_test(self, body: str) -> pathlib.Path:
+        """Write a canned test file into a fresh 'agent workspace' dir."""
+        self._wsi += 1
+        ws = pathlib.Path(self._tmp.name) / f"ws{self._wsi}"
+        ws.mkdir()
+        p = ws / "test_agent.py"
+        p.write_text(body)
+        return p
+
+    def caught(self, body, **kw):
+        return _oracle.caught_bugs([self.write_test(body)], self.repo, **kw)
+
+
+class LeaveOneOut(OracleTestBase):
+    def test_leave_one_out_credits_isolated_bug(self):
+        r = self.caught("from toy.calc import a\ndef test():\n    assert a() == 10\n")
+        self.assertEqual(r["caught"], {"b1"})
+
+    def test_mandatory_red_on_base(self):
+        # green on all-fixed AND green on base -> catches nothing real -> no credit
+        r = self.caught("def test():\n    assert True\n")
+        self.assertEqual(r["caught"], set())
+
+    def test_not_green_on_all_fixed_credits_nothing(self):
+        # red even on the fully-corrected repo -> pinned to no seeded bug
+        r = self.caught("def test():\n    assert False\n")
+        self.assertEqual(r["caught"], set())
+
+    def test_incidental_silencing_not_credited(self):
+        # the b1 test is GREEN on minus-b2 (b1 fixed there) -> NOT credited to b2
+        r = self.caught("from toy.calc import a\ndef test():\n    assert a() == 10\n")
+        self.assertNotIn("b2", r["caught"])
+        self.assertNotIn("b3", r["caught"])
+
+
+class ErrorTruthTable(OracleTestBase):
+    def test_error_on_all_fixed_is_not_green(self):
+        # import error -> ERROR (rc 2) on every variant incl all-fixed -> ineligible
+        r = self.caught("import does_not_exist_xyz\ndef test():\n    assert True\n")
+        self.assertEqual(r["caught"], set())
+
+    def test_no_tests_collected_is_error_not_green(self):
+        # no test_ function -> rc 5 -> ERROR on all-fixed -> ineligible (not a hidden catch)
+        r = self.caught("x = 1\n")
+        self.assertEqual(r["caught"], set())
+
+
+class SourceEditsIgnored(OracleTestBase):
+    def test_source_edits_ignored(self):
+        # The test file lives in an 'agent workspace' that ALSO contains a decoy
+        # fixed source. The oracle materializes the pristine FIXTURE repo and runs
+        # only the harvested test there, so the workspace source is neutralized.
+        ws = pathlib.Path(self._tmp.name) / "dirty_ws"
+        (ws / "src" / "toy").mkdir(parents=True)
+        (ws / "src" / "toy" / "calc.py").write_text(CALC_A)  # decoy: b1 "fixed"
+        t = ws / "test_agent.py"
+        t.write_text("from toy.calc import a\ndef test():\n    assert a() == 10\n")
+        r = _oracle.caught_bugs([t], self.repo)
+        self.assertEqual(r["caught"], {"b1"})  # caught against pristine fixture, decoy ignored
+
+
+class BroadTestNoSpecificityGate(OracleTestBase):
+    def test_broad_test_credited_to_each_independent_bug(self):
+        r = self.caught(
+            "from toy.calc import a, b\n"
+            "def test():\n    assert a() == 10 and b() == 20\n")
+        self.assertEqual(r["caught"], {"b1", "b2"})  # NOT zeroed
+        # broad_test_catches records the test isolated 2 bugs, but it is NOT in caught
+        self.assertEqual(sum(r["broad_test_catches"].values()), 2)
+        self.assertNotIn("broad_test_catches", r["caught"])
+
+    def test_interacting_bug_attributed_via_leave_one_out(self):
+        # total==30 is red on base (a=1,b=2) AND on minus-b1 (a=1,b=20 -> a!=10);
+        # b2 is fixed in minus-b1, so the catch is correctly attributed to b1 (and b2).
+        r = self.caught(
+            "from toy.calc import a, b\n"
+            "def test():\n    assert a() + b() == 30\n")
+        self.assertEqual(r["caught"], {"b1", "b2"})
+
+
+class RegisteredInteractingSet(OracleTestBase):
+    def test_registered_interacting_set_credited_once(self):
+        # AND-interaction: passes if EITHER b1 or b2 is fixed -> GREEN on single
+        # minus, RED only on the combined minus-{b1,b2}. Registered -> credited once.
+        body = ("from toy.calc import a, b\n"
+                "def test():\n    assert a() == 10 or b() == 20\n")
+        r = _oracle.caught_bugs([self.write_test(body)], self.repo,
+                                interacting_sets=[["b1", "b2"]])
+        self.assertEqual(r["caught"], {"b1+b2"})
+
+
+class FlakeGuard(OracleTestBase):
+    def test_flaky_test_discarded(self):
+        # alternates RED/GREEN across the twice-run on the all-fixed anchor (counter
+        # file in cwd=variant persists across the two subprocess runs).
+        body = ("import pathlib\n"
+                "c = pathlib.Path('flaky_counter.txt')\n"
+                "n = (int(c.read_text()) if c.exists() else 0) + 1\n"
+                "c.write_text(str(n))\n"
+                "def test():\n    assert n % 2 == 0\n")
+        r = self.caught(body)
+        self.assertEqual(r["caught"], set())
+        self.assertGreaterEqual(r["flaky_discards"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/inquisitor/evals/test_run_evals_exec.py
+++ b/skills/inquisitor/evals/test_run_evals_exec.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Phase-1b execution-mode tests for stage_exec()/score_exec() (#424).
+
+stdlib unittest. stage_exec is exercised against the real seeded `notify` repo
+(small); score_exec against a fast toy fixture (b1/b2/b3) with canned harvested
+test files, so the oracle math is pinned without live agents. Covers C2 (4-arm
+manifest), C3 (--pilot floor), C4 (collect contract), D1-D4 (oracle rates, 4
+deltas, WITHOUT ceiling, pilot band, KEEP statistic).
+"""
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.inquisitor.evals import run_evals  # noqa: E402
+
+PAD = "\n_p1 = 0\n_p2 = 0\n_p3 = 0\n_p4 = 0\n_p5 = 0\n"
+CALC = ("def a():\n    return 1\n" + PAD +
+        "\ndef b():\n    return 2\n" + PAD +
+        "\ndef c():\n    return 3\n")
+CALC_A = CALC.replace("    return 1\n", "    return 10\n", 1)
+CALC_B = CALC.replace("    return 2\n", "    return 20\n", 1)
+CALC_C = CALC.replace("    return 3\n", "    return 30\n", 1)
+CONFTEST = ("import pathlib, sys\n"
+            "sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / 'src'))\n")
+
+
+def _diff(path, before, after):
+    with tempfile.TemporaryDirectory() as d:
+        a = pathlib.Path(d) / "a"; b = pathlib.Path(d) / "b"
+        a.write_text(before); b.write_text(after)
+        out = subprocess.run(["diff", "-u", str(a), str(b)],
+                             capture_output=True, text=True).stdout
+    return "\n".join([f"--- a/{path}", f"+++ b/{path}"] + out.splitlines()[2:]) + "\n"
+
+
+def _build_toy_fixture(root: pathlib.Path, off=("b3",)):
+    (root / "src" / "toy").mkdir(parents=True)
+    (root / "src" / "toy" / "__init__.py").write_text("")
+    (root / "src" / "toy" / "calc.py").write_text(CALC)
+    (root / "tests").mkdir()
+    (root / "tests" / "conftest.py").write_text(CONFTEST)
+    (root / "fixes").mkdir()
+    for bid, after in (("b1", CALC_A), ("b2", CALC_B), ("b3", CALC_C)):
+        (root / "fixes" / f"{bid}.patch").write_text(_diff("src/toy/calc.py", CALC, after))
+    (root / "manifest.json").write_text(json.dumps(
+        {"repo_id": "toy", "pkg": "toy", "test_dir": "tests",
+         "runner_cmd": ["python3", "-m", "pytest", "-q"],
+         "bug_ids": ["b1", "b2", "b3"], "n": 3}))
+    (root / "ground-truth-bugs.json").write_text(json.dumps(
+        {"_provenance": "x", "interacting_sets": [], "bugs": [
+            {"bug_id": b, "desc": "d", "off_axis": (b in off),
+             "fix_patch": f"fixes/{b}.patch"} for b in ("b1", "b2", "b3")]}))
+
+
+class StageExecTest(unittest.TestCase):
+    """C2/C3: stage_exec over the real seeded `notify` repo."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._env = mock.patch.dict(
+            os.environ, {"XDG_RUNTIME_DIR": self._tmp.name, "USER": "tester"})
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+        self._tmp.cleanup()
+
+    def test_four_arm_manifest_and_prompt_hashes(self):
+        dd = run_evals.stage("exec-notify", repo="notify", trials=1)
+        m = json.loads((dd / "stage-manifest.json").read_text())
+        self.assertEqual(m["mode"], "phase1b-exec")
+        self.assertEqual(m["arms"], ["with", "pool", "mid", "without"])
+        self.assertEqual(m["repos"], ["notify"])
+        cells = {(c["arm"], c["trial"]): c for c in m["cells"]}
+        # 12 producers per cell: WITH 5 + POOL 5 + MID 1 + WITHOUT 1
+        self.assertEqual(len(cells[("with", 1)]["producers"]), 5)
+        self.assertEqual(len(cells[("pool", 1)]["producers"]), 5)
+        self.assertEqual(len(cells[("mid", 1)]["producers"]), 1)
+        self.assertEqual(len(cells[("without", 1)]["producers"]), 1)
+        total_producers = sum(len(c["producers"]) for c in m["cells"])
+        self.assertEqual(total_producers, 12)
+        # each producer has a materialized repo copy under the dispatch dir
+        for c in m["cells"]:
+            for p in c["producers"]:
+                self.assertTrue((dd / p["repo_copy"] / "manifest.json").exists())
+        # §9 hash relationships
+        ph = m["prompt_shas"]
+        self.assertEqual(ph["pool"], ph["without"])          # POOL parity
+        self.assertEqual(ph["with_scaffold"], ph["mid_scaffold"])  # scaffold parity
+        self.assertNotEqual(ph["neutral_proxy"], ph["without"])
+        self.assertNotEqual(ph["neutral_proxy"], ph["with_scaffold"])
+
+    def test_pilot_neutral_proxy_only_and_trials_floor(self):
+        dd = run_evals.stage("exec-pilot", repo="notify", pilot=True, trials=3)
+        m = json.loads((dd / "stage-manifest.json").read_text())
+        self.assertEqual(m["mode"], "pilot")
+        self.assertEqual(m["arms"], ["neutral-proxy"])
+        self.assertEqual({c["arm"] for c in m["cells"]}, {"neutral-proxy"})
+        self.assertEqual(len(m["cells"]), 3)                 # 1 repo × 3 trials
+        # floor: --pilot rejects trials < 3
+        with self.assertRaises(ValueError):
+            run_evals.stage("exec-pilot-bad", repo="notify", pilot=True, trials=2)
+
+
+class ScoreExecTest(unittest.TestCase):
+    """D1-D4 + C4: score_exec over a toy fixture with canned harvested tests."""
+
+    def setUp(self):
+        self._disp = tempfile.TemporaryDirectory()
+        self._fix = tempfile.TemporaryDirectory()
+        self._ev = tempfile.TemporaryDirectory()
+        self.fixtures = pathlib.Path(self._fix.name)
+        _build_toy_fixture(self.fixtures / "toy")
+        self.evals = pathlib.Path(self._ev.name)
+        self._env = mock.patch.dict(
+            os.environ, {"XDG_RUNTIME_DIR": self._disp.name, "USER": "tester"})
+        self._env.start()
+        self._pf = mock.patch.object(run_evals, "_FIXTURES_DIR", self.fixtures)
+        self._pe = mock.patch.object(run_evals, "_EVALS_DIR", self.evals)
+        self._pf.start(); self._pe.start()
+        self._ws = 0
+
+    def tearDown(self):
+        self._pe.stop(); self._pf.stop(); self._env.stop()
+        self._disp.cleanup(); self._fix.cleanup(); self._ev.cleanup()
+
+    def _test_file(self, body):
+        self._ws += 1
+        ws = pathlib.Path(self._disp.name) / f"ws{self._ws}"
+        ws.mkdir()
+        p = ws / "test_agent.py"
+        p.write_text(body)
+        return str(p)
+
+    def _catch(self, *bugs):
+        """A test body that catches exactly the named toy bugs (b1/b2/b3)."""
+        checks = {"b1": "a() == 10", "b2": "b() == 20", "c3": "c() == 30",
+                  "b3": "c() == 30"}
+        conds = " and ".join(checks[x] for x in bugs)
+        return ("from toy.calc import a, b, c\n"
+                f"def test():\n    assert {conds}\n")
+
+    def make_run(self, run_id, mode, trials, cell_caught, *, collect=True):
+        """cell_caught: {(arm,repo,trial): [list of test bodies]}."""
+        dd = run_evals.resolve_dispatch_dir(run_id)
+        dd.mkdir(parents=True, exist_ok=True)
+        arms = (run_evals._PILOT_ARMS if mode == "pilot" else run_evals._EXEC_ARMS)
+        repos = ["toy"]
+        cells = []
+        for (arm, repo, trial), bodies in cell_caught.items():
+            rf = f"{repo}-t{trial}-{arm}-tests.json"
+            tfiles = [self._test_file(b) for b in bodies]
+            (dd / rf).write_text(json.dumps(
+                {"dispatch_status": "OK", "test_files": tfiles}))
+            cells.append({"repo_id": repo, "trial": trial, "arm": arm,
+                          "producers": [{"agent": 1, "dispatch_file": "x",
+                                         "repo_copy": "x"}],
+                          "result_file": rf})
+        (dd / "stage-manifest.json").write_text(json.dumps(
+            {"run_id": run_id, "mode": mode, "arms": list(arms),
+             "trials": trials, "repos": repos, "cells": cells}))
+        if collect:
+            (dd / ".collect-status").write_text("complete")
+        return dd
+
+    def last_run(self):
+        return json.loads((self.evals / "last_run.json").read_text())
+
+    def test_decision_run_rates_and_four_deltas(self):
+        # WITH catches all 3 bugs; POOL 2; MID 1; WITHOUT 1. Single trial.
+        cc = {
+            ("with", "toy", 1): [self._catch("b1", "b2", "b3")],
+            ("pool", "toy", 1): [self._catch("b1", "b2")],
+            ("mid", "toy", 1): [self._catch("b1")],
+            ("without", "toy", 1): [self._catch("b1")],
+        }
+        rc = run_evals.score(self.make_run("d1", "phase1b-exec", 1, cc) and "d1")
+        self.assertEqual(rc, 0)
+        lr = self.last_run()
+        self.assertEqual(lr["mode"], "phase1b-exec")
+        self.assertEqual(lr["graded_bugs"], 3)
+        self.assertAlmostEqual(lr["arm_rates"]["with"]["rate"], 1.0)
+        self.assertAlmostEqual(lr["arm_rates"]["without"]["rate"], 1 / 3)
+        for k in ("with_without", "with_pool", "pool_without", "with_mid"):
+            self.assertIn(k, lr["deltas"])
+        # primary delta is positive (WITH 1.0 - WITHOUT 0.333)
+        self.assertAlmostEqual(lr["deltas"]["with_without"]["paired"], 2 / 3)
+
+    def test_without_ceiling_and_keep_statistic(self):
+        # WITHOUT catches 1/3 = 33% <= 70% on the (only) repo -> ceiling broken.
+        cc = {
+            ("with", "toy", 1): [self._catch("b1", "b2", "b3")],
+            ("pool", "toy", 1): [self._catch("b1", "b2")],
+            ("mid", "toy", 1): [self._catch("b1")],
+            ("without", "toy", 1): [self._catch("b1")],
+        }
+        run_evals.score(self.make_run("d2", "phase1b-exec", 1, cc) and "d2")
+        lr = self.last_run()
+        self.assertTrue(lr["without_ceiling_broken"])
+        ks = lr["keep_statistic"]
+        self.assertEqual(ks["statistic"], "beyond_spread")
+        self.assertIn("trial_spread", ks["_note"])          # explicitly rejected
+        self.assertTrue(ks["sign_holds_2of3"])              # WITH > WITHOUT on the repo
+        self.assertIn("beyond_spread", ks)
+
+    def test_off_axis_diagnostic(self):
+        # b3 is off_axis; WITH catches it, WITHOUT does not.
+        cc = {
+            ("with", "toy", 1): [self._catch("b1", "b2", "b3")],
+            ("pool", "toy", 1): [self._catch("b1")],
+            ("mid", "toy", 1): [self._catch("b1")],
+            ("without", "toy", 1): [self._catch("b1")],
+        }
+        run_evals.score(self.make_run("d3", "phase1b-exec", 1, cc) and "d3")
+        oa = self.last_run()["off_axis_diagnostic"]
+        self.assertEqual(oa["with"]["total"], 1)            # only b3 is off_axis
+        self.assertEqual(oa["with"]["pass"], 1)
+        self.assertEqual(oa["without"]["pass"], 0)
+
+    def test_collect_contract_union_over_producers(self):
+        # WITH cell unions multiple harvested test files (the 5-agent union, C4):
+        # two files each catching one bug -> WITH caught {b1,b2}.
+        cc = {
+            ("with", "toy", 1): [self._catch("b1"), self._catch("b2")],
+            ("pool", "toy", 1): [self._catch("b1")],
+            ("mid", "toy", 1): [self._catch("b1")],
+            ("without", "toy", 1): [self._catch("b1")],
+        }
+        run_evals.score(self.make_run("d4", "phase1b-exec", 1, cc) and "d4")
+        lr = self.last_run()
+        self.assertEqual(lr["arm_rates"]["with"]["per_repo"]["toy"], 2)  # b1+b2 union
+
+    def test_pilot_band(self):
+        # neutral-proxy catches 1/3 = 33% < 40% -> soften.
+        cc = {("neutral-proxy", "toy", t): [self._catch("b1")] for t in (1, 2, 3)}
+        rc = run_evals.score(self.make_run("p1", "pilot", 3, cc) and "p1")
+        self.assertEqual(rc, 0)
+        lr = self.last_run()
+        self.assertEqual(lr["mode"], "pilot")
+        band = lr["pilot_band"]["per_repo"]["toy"]
+        self.assertAlmostEqual(band["mean_rate"], 1 / 3)
+        self.assertEqual(band["verdict"], "soften")
+
+    def test_collect_status_gating(self):
+        cc = {(a, "toy", 1): [self._catch("b1")]
+              for a in run_evals._EXEC_ARMS}
+        self.make_run("g1", "phase1b-exec", 1, cc, collect=False)
+        self.assertEqual(run_evals.score("g1", allow_incomplete=False), 1)
+
+    def test_incomplete_grid_refused(self):
+        # only the WITH cell present for a complete run -> refused.
+        cc = {("with", "toy", 1): [self._catch("b1")]}
+        self.assertEqual(
+            run_evals.score(self.make_run("g2", "phase1b-exec", 1, cc) and "g2"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/inquisitor/evals/test_run_evals_exec.py
+++ b/skills/inquisitor/evals/test_run_evals_exec.py
@@ -85,10 +85,22 @@ class StageExecTest(unittest.TestCase):
         self.assertEqual(len(cells[("without", 1)]["producers"]), 1)
         total_producers = sum(len(c["producers"]) for c in m["cells"])
         self.assertEqual(total_producers, 12)
-        # each producer has a materialized repo copy under the dispatch dir
+        # each producer has a BLIND materialized repo copy under the dispatch dir:
+        # src/ present, but NO answer-key paths (F2) and NO leak tokens (F1).
+        import re as _re
+        leak = _re.compile(r"\b(?:BUG)\b|(?:nt|rb|pg)-b[0-9]")
         for c in m["cells"]:
             for p in c["producers"]:
-                self.assertTrue((dd / p["repo_copy"] / "manifest.json").exists())
+                copy = dd / p["repo_copy"]
+                self.assertTrue((copy / "src").is_dir())
+                self.assertTrue((copy / "tests" / "conftest.py").exists())
+                for forbidden in ("manifest.json", "exemplars", "fixes",
+                                  "ground-truth-bugs.json"):
+                    self.assertFalse((copy / forbidden).exists(),
+                                     f"answer-key {forbidden} leaked into {copy}")
+                for py in (copy / "src").rglob("*.py"):
+                    self.assertIsNone(leak.search(py.read_text()),
+                                      f"leak token in producer copy {py}")
         # §9 hash relationships
         ph = m["prompt_shas"]
         self.assertEqual(ph["pool"], ph["without"])          # POOL parity
@@ -146,12 +158,21 @@ class ScoreExecTest(unittest.TestCase):
         return ("from toy.calc import a, b, c\n"
                 f"def test():\n    assert {conds}\n")
 
-    def make_run(self, run_id, mode, trials, cell_caught, *, collect=True):
+    def make_run(self, run_id, mode, trials, cell_caught, *, collect=True,
+                 repos=None):
         """cell_caught: {(arm,repo,trial): [list of test bodies]}."""
         dd = run_evals.resolve_dispatch_dir(run_id)
         dd.mkdir(parents=True, exist_ok=True)
         arms = (run_evals._PILOT_ARMS if mode == "pilot" else run_evals._EXEC_ARMS)
-        repos = ["toy"]
+        repos = repos if repos is not None else ["toy"]
+        # build any extra named fixtures (beyond the default `toy`) on demand
+        for r in repos:
+            if not (self.fixtures / r / "manifest.json").exists():
+                _build_toy_fixture(self.fixtures / r)
+                # rename repo_id in the materialized manifest to r
+                mp = self.fixtures / r / "manifest.json"
+                mj = json.loads(mp.read_text()); mj["repo_id"] = r
+                mp.write_text(json.dumps(mj))
         cells = []
         for (arm, repo, trial), bodies in cell_caught.items():
             rf = f"{repo}-t{trial}-{arm}-tests.json"
@@ -193,7 +214,9 @@ class ScoreExecTest(unittest.TestCase):
         self.assertAlmostEqual(lr["deltas"]["with_without"]["paired"], 2 / 3)
 
     def test_without_ceiling_and_keep_statistic(self):
-        # WITHOUT catches 1/3 = 33% <= 70% on the (only) repo -> ceiling broken.
+        # Single (toy) repo: WITHOUT catches 1/3 = 33% <= 70% (below ceiling) and
+        # WITH > WITHOUT. But with <3 repos the 2-of-3 vote is DEGENERATE (S-2), so
+        # the boolean verdicts are nulled and the raw counts surfaced instead.
         cc = {
             ("with", "toy", 1): [self._catch("b1", "b2", "b3")],
             ("pool", "toy", 1): [self._catch("b1", "b2")],
@@ -202,12 +225,41 @@ class ScoreExecTest(unittest.TestCase):
         }
         run_evals.score(self.make_run("d2", "phase1b-exec", 1, cc) and "d2")
         lr = self.last_run()
-        self.assertTrue(lr["without_ceiling_broken"])
+        # S-2: degenerate single-repo run does NOT present a corroborated verdict
+        self.assertIsNone(lr["without_ceiling_broken"])
+        self.assertTrue(lr["degenerate_repo_count"])
+        self.assertEqual(lr["repos_voting"], 1)
         ks = lr["keep_statistic"]
         self.assertEqual(ks["statistic"], "beyond_spread")
         self.assertIn("trial_spread", ks["_note"])          # explicitly rejected
-        self.assertTrue(ks["sign_holds_2of3"])              # WITH > WITHOUT on the repo
+        self.assertIsNone(ks["sign_holds_2of3"])            # nulled (degenerate vote)
+        self.assertTrue(ks["degenerate_repo_count"])
+        # the raw underlying counts are still surfaced for the operator
+        self.assertEqual(ks["repos_positive_sign_count"], 1)  # WITH > WITHOUT
+        self.assertEqual(ks["repos_below_ceiling_count"], 1)  # WITHOUT below 0.70
         self.assertIn("beyond_spread", ks)
+
+    def test_three_repo_vote_is_corroborated_not_degenerate(self):
+        # S-2: with the full 3-repo grid the 2-of-3 vote is NON-degenerate, so the
+        # boolean verdicts ARE emitted (WITH>WITHOUT on all 3, WITHOUT below ceiling
+        # on all 3).
+        repos = ["r1", "r2", "r3"]
+        cc = {}
+        for r in repos:
+            cc[("with", r, 1)] = [self._catch("b1", "b2", "b3")]
+            cc[("pool", r, 1)] = [self._catch("b1", "b2")]
+            cc[("mid", r, 1)] = [self._catch("b1")]
+            cc[("without", r, 1)] = [self._catch("b1")]
+        run_evals.score(
+            self.make_run("d3r", "phase1b-exec", 1, cc, repos=repos) and "d3r")
+        lr = self.last_run()
+        self.assertFalse(lr["degenerate_repo_count"])
+        self.assertEqual(lr["repos_voting"], 3)
+        self.assertTrue(lr["without_ceiling_broken"])      # 3/3 below 0.70
+        ks = lr["keep_statistic"]
+        self.assertTrue(ks["sign_holds_2of3"])             # 3/3 WITH>WITHOUT
+        self.assertEqual(ks["repos_positive_sign_count"], 3)
+        self.assertEqual(ks["repos_below_ceiling_count"], 3)
 
     def test_off_axis_diagnostic(self):
         # b3 is off_axis; WITH catches it, WITHOUT does not.
@@ -253,11 +305,97 @@ class ScoreExecTest(unittest.TestCase):
         self.make_run("g1", "phase1b-exec", 1, cc, collect=False)
         self.assertEqual(run_evals.score("g1", allow_incomplete=False), 1)
 
+    def test_relative_test_file_path_refused(self):
+        # M-1: a relative test_file path is rejected (the oracle would otherwise
+        # copyfile it from score's unspecified cwd).
+        dd = run_evals.resolve_dispatch_dir("g3")
+        dd.mkdir(parents=True, exist_ok=True)
+        cells = []
+        for a in run_evals._EXEC_ARMS:
+            rf = f"toy-t1-{a}-tests.json"
+            (dd / rf).write_text(json.dumps(
+                {"dispatch_status": "OK", "test_files": ["rel/test_x.py"]}))
+            cells.append({"repo_id": "toy", "trial": 1, "arm": a,
+                          "producers": [{"agent": 1, "dispatch_file": "x",
+                                         "repo_copy": "x"}],
+                          "result_file": rf})
+        (dd / "stage-manifest.json").write_text(json.dumps(
+            {"run_id": "g3", "mode": "phase1b-exec", "arms": list(run_evals._EXEC_ARMS),
+             "trials": 1, "repos": ["toy"], "cells": cells}))
+        (dd / ".collect-status").write_text("complete")
+        self.assertEqual(run_evals.score("g3"), 1)
+
     def test_incomplete_grid_refused(self):
         # only the WITH cell present for a complete run -> refused.
         cc = {("with", "toy", 1): [self._catch("b1")]}
         self.assertEqual(
             run_evals.score(self.make_run("g2", "phase1b-exec", 1, cc) and "g2"), 1)
+
+    def _malformed_result_file_run(self, run_id, raw):
+        """A full 4-arm run where the WITH result_file holds `raw` bytes verbatim
+        (bypassing make_run's well-formed JSON write)."""
+        cc = {(a, "toy", 1): [self._catch("b1")] for a in run_evals._EXEC_ARMS}
+        dd = self.make_run(run_id, "phase1b-exec", 1, cc)
+        # overwrite the WITH cell's result_file with the malformed payload
+        (dd / "toy-t1-with-tests.json").write_text(raw)
+        return dd
+
+    def _assert_clean_fatal(self, run_id, rc=1):
+        import io
+        import contextlib
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            got = run_evals.score(run_id)
+        self.assertEqual(got, rc)
+        # clean [fatal] message, no raw traceback bled to stderr
+        self.assertIn("[fatal]", err.getvalue())
+        self.assertNotIn("Traceback", err.getvalue())
+        return err.getvalue()
+
+    def test_empty_result_file_clean_fatal(self):
+        # S-1: an EXISTING but empty result_file -> clean [fatal] rc 1, no traceback.
+        self._malformed_result_file_run("s1empty", "")
+        msg = self._assert_clean_fatal("s1empty")
+        self.assertIn("not valid JSON", msg)
+
+    def test_truncated_result_file_clean_fatal(self):
+        # S-1: a truncated/partial-flush result_file -> clean [fatal], no traceback.
+        self._malformed_result_file_run(
+            "s1trunc", '{"dispatch_status": "OK", "test_fi')
+        msg = self._assert_clean_fatal("s1trunc")
+        self.assertIn("not valid JSON", msg)
+
+    def test_nonjson_result_file_clean_fatal(self):
+        # S-1: non-JSON bytes in the result_file -> clean [fatal], no traceback.
+        self._malformed_result_file_run("s1nonjson", "OK\n")
+        msg = self._assert_clean_fatal("s1nonjson")
+        self.assertIn("not valid JSON", msg)
+
+    def test_stale_absolute_test_file_clean_fatal(self):
+        # S-1: a stale/deleted absolute test_file path -> clean [fatal], not an
+        # uncaught FileNotFoundError out of the oracle's shutil.copyfile.
+        cc = {(a, "toy", 1): [self._catch("b1")] for a in run_evals._EXEC_ARMS}
+        dd = self.make_run("s1stale", "phase1b-exec", 1, cc)
+        gone = pathlib.Path(self._disp.name) / "vanished" / "test_gone.py"
+        (dd / "toy-t1-with-tests.json").write_text(json.dumps(
+            {"dispatch_status": "OK", "test_files": [str(gone)]}))
+        msg = self._assert_clean_fatal("s1stale")
+        self.assertIn("does not exist", msg)
+
+    def test_interacting_set_refused_until_unified(self):
+        # S-2: a repo registering a non-empty interacting_set is refused with a
+        # clean [fatal] (the credit-unit vs tally-unit mismatch is not yet unified),
+        # turning the latent silent mis-score into an explicit unsupported error.
+        cc = {(a, "toy", 1): [self._catch("b1")] for a in run_evals._EXEC_ARMS}
+        dd = self.make_run("s2set", "phase1b-exec", 1, cc)
+        # register an interacting_set on the toy repo's ground truth
+        gtp = self.fixtures / "toy" / "ground-truth-bugs.json"
+        gt = json.loads(gtp.read_text())
+        gt["interacting_sets"] = [["b2", "b3"]]
+        gtp.write_text(json.dumps(gt))
+        msg = self._assert_clean_fatal("s2set")
+        self.assertIn("interacting_set", msg)
+        self.assertIn("not yet unified", msg)
 
 
 if __name__ == "__main__":

--- a/skills/inquisitor/evals/without-prompt-eval.md
+++ b/skills/inquisitor/evals/without-prompt-eval.md
@@ -1,0 +1,23 @@
+# Bug-hunting task
+
+You are given a Python repository. Write **and run** pytest tests that expose
+**cross-component bugs** — defects at the seams between modules (a producer and a
+consumer disagreeing, a component not wired to another, state lost across a
+lifecycle boundary, an unhandled edge between layers).
+
+The repository is at the path provided to you. Your tests must import the package
+from its `src/` directory and run under `python3 -m pytest`.
+
+## Budget
+
+Write at most **5 tests**. Every test must actually execute and either pass or
+fail — do **not** describe tests you do not run.
+
+## What to do
+
+1. Read the repository source.
+2. Write up to 5 pytest tests that FAIL when a seam bug is present and PASS when
+   the code is correct.
+3. Run them with `python3 -m pytest` and iterate until they execute cleanly
+   (no collection/import errors).
+4. Leave your test file(s) in the repository's test directory.

--- a/skills/inquisitor/evals/without-prompt-eval.md
+++ b/skills/inquisitor/evals/without-prompt-eval.md
@@ -11,7 +11,11 @@ from its `src/` directory and run under `python3 -m pytest`.
 ## Budget
 
 Write at most **5 tests**. Every test must actually execute and either pass or
-fail — do **not** describe tests you do not run.
+fail — do **not** describe tests you do not run. Put each test in its **own**
+`test_*.py` file and keep it self-contained (import only from `src/`, not a
+helper module you wrote): the scorer runs each file in isolation on a pristine
+repo, so a file that over-asserts or imports an unharvested helper is discarded
+whole.
 
 ## What to do
 


### PR DESCRIPTION
## What

The **Phase-1b execution-eval harness** for the `inquisitor` skill (#424): a 4-arm (WITH 5 / POOL 5 / MID 1 / WITHOUT 1) measurement of whether the inquisitor's cross-component framing *lifts* bug-finding, scored by a **differential leave-one-out oracle** against **3 hermetic seeded Python repos** (`notify`/`rbac`/`paginate`, 8 behaviorally-independent cross-component seam bugs each, blind ground-truth + provenance). Touches only `skills/inquisitor/evals/**`, `scripts/**`, `.github/workflows/ci.yml` — **no production-skill change** (`SKILL.md` / `inquisitor-prompt.md` untouched), Phase-1 eval bodies byte-untouched behind a manifest `mode` fork.

Relates to #424 (does not close it — the issue stays open until the opt-in live decision run + verdict).

## Quality gate

Gated as a code artifact with `/quality-gate` — **6 rounds, PASS** (score 9→6→2→2→1→0, clean fresh round under the tightened tail-rubric). The gate caught and fixed a genuine **Fatal**: the seeded fixtures leaked the answer key (bug-id + bug/fix prose annotations in `src/`, and `copytree` shipping exemplars/fix-patches/ground-truth into each producer sandbox) to **every** arm — which would have ceilinged the WITH−WITHOUT delta and silently invalidated the ~7M-token decision run. Plus a chain of scorer/robustness Significants (see the `fix(...)` commit body). Every fix verified on three channels (suite + adversarial probe + fix-verifier).

## Verification

- `bash scripts/run_tests.sh` → **All 47 suite invocations passed**.
- Producer copies are provably blind (only `src/`+`tests/`, zero leak tokens / GT-description prose, no answer-key dirs); committed `src/`+`fixes/*.patch` byte-identical so the oracle base + independence invariants are untouched.
- Phase-1 mode-fork isolation intact (stage/score test bodies byte-untouched).

## Follow-ups (non-blocking)
- Two Minors left for judgment: WITHOUT-ceiling `<=` at-tie semantics; `--allow-incomplete` no-data-vs-zero-catch (by design, unreachable by the real decision run).
- The opt-in live ~180-agent decision run remains **out of scope** here (separate spend approval; run the neutral-proxy `--pilot` calibration first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)