### PR TITLE
feat(inquisitor): #424 soften paginate fixture into band + harden producer-blindness strip

### DIFF
--- a/scripts/check_fixture_producer_blind.py
+++ b/scripts/check_fixture_producer_blind.py
@@ -25,8 +25,17 @@ and strips ALL comments and docstrings from every copied producer-visible `*.py`
 real producer copy for every seeded repo and asserts:
   - (`_fixtures._assert_no_leak`) no answer-key path (`exemplars/`, `fixes/`,
     `manifest.json`, `ground-truth-*`) survives, no bug-identity leak TOKEN survives
-    in any copied producer-visible `*.py` (`src/` AND `tests/`), and the copied
-    `tests/` holds nothing but `conftest.py` (the documented invariant); AND
+    in any copied producer-visible `*.py` (`src/` AND `tests/`), NO bytecode
+    (`*.pyc`/`*.pyo` or a `__pycache__/` dir) survives anywhere under the
+    producer-visible subtrees, and the copied `tests/` holds nothing but
+    `conftest.py` (the documented invariant); AND
+
+The bytecode channel (S-1) is now CLOSED on both sides: `copy_repo_for_producer`
+ignores `__pycache__`/`*.pyc`/`*.pyo` on copy (so a stray compiled module in the
+committed tree can't ride into the sandbox), and `_assert_no_leak` fails loud if
+any bytecode reaches a producer copy — a `.pyc` is un-strippable and embeds every
+docstring (`co_consts`) plus the absolute source path (`co_filename`), i.e. the
+answer key, which the `*.py`-only strip and token/prose scans would all miss.
   - (`_fixtures.assert_no_description_leak`, ADVERSARIAL) no bug-DESCRIPTION prose
     survives — loaded from each repo's `ground-truth-bugs.json`, it asserts no
     >=N-word window of any bug `desc`, and no literal `"The fix"`, appears in any
@@ -95,6 +104,31 @@ def check_repo(repo_dir) -> list:
             _fixtures._assert_no_leak(copy)
         except AssertionError as e:
             violations.append(str(e))
+        # S-1: bytecode channel explicitly re-asserted here (also covered by
+        # _assert_no_leak above). A `.pyc`/`.pyo` or `__pycache__/` reaching a
+        # producer copy is un-strippable and leaks docstrings + the co_filename
+        # answer-key path, so it must never appear under a producer-visible subtree.
+        for sub in _fixtures._PRODUCER_VISIBLE:
+            sub_root = copy / sub
+            if not sub_root.exists():
+                continue
+            for p in sub_root.rglob("*"):
+                if ((p.is_dir() and p.name == "__pycache__")
+                        or (p.is_file() and p.suffix in (".pyc", ".pyo"))):
+                    violations.append(
+                        f"producer copy carries bytecode {p.relative_to(copy)} "
+                        f"(un-strippable; leaks docstrings + co_filename): {repo_dir.name}")
+        # Defense-in-depth: bytecode at the copy ROOT (outside any producer-visible
+        # subtree) is just as un-strippable a leak; catch it too (matches the
+        # root-level scan in `_fixtures._assert_no_leak`).
+        for p in copy.glob("*"):
+            if p.name in _fixtures._PRODUCER_VISIBLE:
+                continue  # covered by the subtree scan above
+            if ((p.is_dir() and p.name == "__pycache__")
+                    or (p.is_file() and p.suffix in (".pyc", ".pyo"))):
+                violations.append(
+                    f"producer copy carries bytecode {p.relative_to(copy)} "
+                    f"(un-strippable; leaks docstrings + co_filename): {repo_dir.name}")
         # ADVERSARIAL (S-1): the bug DESCRIPTIONS — not just the id token — must be
         # absent. Loaded from the source repo's GT (the copy excludes it), checked
         # WITHOUT _LEAK_RE so the guard is independent of the strip mechanism.
@@ -237,6 +271,23 @@ def selftest() -> int:
         except AssertionError:
             pass
         (copy / "src" / "pkg" / "leak.py").unlink()
+
+        # S-1 (bytecode channel): copy_repo_for_producer must NOT carry bytecode,
+        # and _assert_no_leak must fail loud if any reaches the copy. The clean copy
+        # has none; planting a `.pyc` (or a `__pycache__/` dir) trips the guard.
+        if list(copy.rglob("*.pyc")) or list(copy.rglob("__pycache__")):
+            failures.append("copy_repo_for_producer carried bytecode into the copy")
+        (copy / "src" / "pkg" / "__pycache__").mkdir()
+        (copy / "src" / "pkg" / "__pycache__" / "m.cpython-99.pyc").write_bytes(b"\x00\x01")
+        try:
+            _fixtures._assert_no_leak(copy)
+            failures.append("_assert_no_leak missed a planted .pyc / __pycache__ (S-1)")
+        except AssertionError as e:
+            if "bytecode" not in str(e) and "__pycache__" not in str(e):
+                failures.append(
+                    f"_assert_no_leak caught bytecode but not via the bytecode guard: {e}")
+        import shutil as _sh
+        _sh.rmtree(copy / "src" / "pkg" / "__pycache__")
 
         # S-1: the producer-visible tests/ subtree is in scope of BOTH guards. Drop
         # an ANNOTATED test file (leak token + a GT-desc prose window SPLIT across a

--- a/skills/inquisitor/evals/_fixtures.py
+++ b/skills/inquisitor/evals/_fixtures.py
@@ -347,7 +347,15 @@ def copy_repo_for_producer(repo_dir, dst) -> None:
         src = repo_dir / name
         if not src.exists():
             continue
-        shutil.copytree(src, dst / name)
+        # S-1: NEVER carry bytecode into the producer sandbox. A stray
+        # `__pycache__/*.pyc` (any in-place import or a pytest run without
+        # PYTHONDONTWRITEBYTECODE generates one) would otherwise be copied
+        # verbatim — and the strip below only touches `*.py`. A `.pyc` retains
+        # every docstring as `co_consts` AND bakes the absolute source path into
+        # `co_filename`, handing the producer the answer key un-strippably.
+        shutil.copytree(
+            src, dst / name,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"))
     # Strip every producer-visible subtree, not just src/: tests/ is equally
     # producer-visible (`_PRODUCER_VISIBLE`), so an annotated test file would
     # otherwise carry the answer key into the sandbox verbatim (S-1).
@@ -386,6 +394,44 @@ def _assert_no_leak(repo_copy) -> None:
                 raise AssertionError(
                     f"producer repo_copy leaks bug-identity token {m.group(0)!r} in "
                     f"{py.relative_to(repo_copy)}: {repo_copy}")
+    # S-1 (defense-in-depth): bytecode must NEVER reach a producer. A `.pyc`/`.pyo`
+    # is un-strippable and carries every docstring (`co_consts`) plus the absolute
+    # source path (`co_filename`) — i.e. the answer key. `copy_repo_for_producer`
+    # now ignores it on copy; this is the loud-failure guard against a regression
+    # (or a copy assembled some other way) that would let one slip through.
+    for sub in _PRODUCER_VISIBLE:
+        sub_root = repo_copy / sub
+        if not sub_root.exists():
+            continue
+        for p in sub_root.rglob("*"):
+            if p.is_dir() and p.name == "__pycache__":
+                raise AssertionError(
+                    f"producer repo_copy carries a __pycache__ dir (un-strippable "
+                    f"bytecode = leaked docstrings + co_filename answer-key path) at "
+                    f"{p.relative_to(repo_copy)}: {repo_copy}")
+            if p.is_file() and p.suffix in (".pyc", ".pyo"):
+                raise AssertionError(
+                    f"producer repo_copy carries a bytecode file {p.suffix!r} "
+                    f"(un-strippable; leaks docstrings + co_filename answer-key path) "
+                    f"at {p.relative_to(repo_copy)}: {repo_copy}")
+    # Defense-in-depth: also catch bytecode sitting at the repo_copy ROOT (not
+    # under any `_PRODUCER_VISIBLE` subtree). No live path places a `.pyc`/`.pyo`
+    # or a bare `__pycache__/` at the root today; this is a purely defensive
+    # tightening so a copy assembled some other way can't sneak un-strippable
+    # bytecode in just outside the subtree scan above.
+    for p in repo_copy.glob("*"):
+        if p.name in _PRODUCER_VISIBLE:
+            continue  # already covered by the subtree scan above
+        if p.is_dir() and p.name == "__pycache__":
+            raise AssertionError(
+                f"producer repo_copy carries a __pycache__ dir (un-strippable "
+                f"bytecode = leaked docstrings + co_filename answer-key path) at "
+                f"{p.relative_to(repo_copy)}: {repo_copy}")
+        if p.is_file() and p.suffix in (".pyc", ".pyo"):
+            raise AssertionError(
+                f"producer repo_copy carries a bytecode file {p.suffix!r} "
+                f"(un-strippable; leaks docstrings + co_filename answer-key path) "
+                f"at {p.relative_to(repo_copy)}: {repo_copy}")
     # Belt-and-suspenders: pin the documented `tests/` invariant ("empty dir +
     # conftest.py; arms/oracle write test files here") as a machine-checked fact.
     # The token/prose guards above already cover any annotated tests/ file; this

--- a/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b6.py
+++ b/skills/inquisitor/evals/fixtures/paginate/exemplars/pg-b6.py
@@ -1,24 +1,29 @@
-"""pg-b6: the default page size regressed from the documented value.
+"""pg-b6: the caller-facing default page size regressed from the documented value.
 
-When the caller relies on the default (limit omitted), the boundary advanced by
-the page must be the documented DEFAULT_PAGE_SIZE-th record. Read next_cursor's
-encoded id via the same codec the producer used (cursor-stable), and compare to
-the documented default size. Independent of the off-by-one emit bug because
-next_cursor keys on the last fetched id, not the emitted slice.
+When the caller omits the limit (relies on the default), the boundary the handler
+advances by must be the documented DEFAULT_PAGE_SIZE-th record. Drive the PUBLIC
+request path (list_records with no limit) and read next_cursor's encoded id via the
+same codec the producer used. next_cursor keys on the last *fetched* id, so this is
+independent of the off-by-one emit bug (which drops an emitted row, not the fetched
+boundary). Envelope-shape-agnostic so the response-shape bug cannot mask it.
 """
 import base64
 
 from paginate.store import Store
-from paginate.paginator import Paginator, DEFAULT_PAGE_SIZE
+from paginate.routes import list_records
+from paginate.paginator import DEFAULT_PAGE_SIZE
 
 
 def _decode_id(token):
     return int(base64.urlsafe_b64decode(token.encode("ascii")).decode("ascii"))
 
 
-def test_default_page_advances_by_the_documented_default_size():
-    pg = Paginator(Store())
-    page = pg.page()  # no limit -> documented default
+def _next_cursor(resp):
+    return resp["paging"]["next_cursor"] if "paging" in resp else resp["next_cursor"]
+
+
+def test_default_limit_advances_by_the_documented_default_size():
+    resp = list_records(Store(), token=None, limit=None)  # no limit -> default
     assert DEFAULT_PAGE_SIZE == 5
-    # the cursor must point at the 5th record (id 5), not the 10th
-    assert _decode_id(page["next_cursor"]) == 5
+    # the default page must end at the 5th record (id 5), not the 10th
+    assert _decode_id(_next_cursor(resp)) == DEFAULT_PAGE_SIZE

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b3.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b3.patch
@@ -1,6 +1,6 @@
 --- a/src/paginate/validate.py
 +++ b/src/paginate/validate.py
-@@ -20,5 +20,5 @@
+@@ -23,5 +23,5 @@
      # instead of being floored to the default page size, producing an empty
      # page or a reversed-slice page downstream.
      if limit < 1:

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b6.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b6.patch
@@ -1,11 +1,11 @@
---- a/src/paginate/paginator.py
-+++ b/src/paginate/paginator.py
-@@ -24,7 +24,7 @@
-             # BUG pg-b6: the documented default page size is DEFAULT_PAGE_SIZE
-             # (5); this hardcodes 10, so a caller relying on the default walks
-             # the collection in the wrong-sized pages.
--            limit = 10
-+            limit = DEFAULT_PAGE_SIZE
-         boundary_id = cursor_mod.decode_cursor(token)
-         return self.page_from_boundary(boundary_id, limit)
- 
+--- a/src/paginate/validate.py
++++ b/src/paginate/validate.py
+@@ -14,7 +14,7 @@
+         # BUG pg-b6: the caller-facing default page size regressed. Omitting the
+         # limit must yield DEFAULT_PAGE_SIZE (5); this returns 10, so a caller
+         # relying on the default walks the collection in the wrong-sized pages.
+-        return 10
++        return DEFAULT_PAGE_SIZE
+     try:
+         limit = int(limit)
+     except (TypeError, ValueError):

--- a/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b8.patch
+++ b/skills/inquisitor/evals/fixtures/paginate/fixes/pg-b8.patch
@@ -1,8 +1,11 @@
 --- a/src/paginate/app.py
 +++ b/src/paginate/app.py
-@@ -18,4 +18,4 @@
+@@ -18,7 +18,7 @@
              # BUG pg-b8: a malformed cursor is swallowed and the handler
              # silently restarts at page 1 instead of surfacing the rejection.
              # The caller can never tell a bad cursor from a real first page.
 -            return list_records(self.store, token=None, limit=limit)
 +            raise
+ 
+     def records(self, token=None, limit=None):
+         """Return one page's records via the downstream envelope consumer.

--- a/skills/inquisitor/evals/fixtures/paginate/ground-truth-bugs.provenance.md
+++ b/skills/inquisitor/evals/fixtures/paginate/ground-truth-bugs.provenance.md
@@ -20,3 +20,23 @@ catching it); off_axis:false marks an on-taxonomy seam defect.
 ## Independence
 All seeded bugs in this repo are pairwise behaviorally independent (verified by
 scripts/check_fixture_independence.py); no interacting_sets are registered.
+
+## Phase-1b pilot calibration revision (2026-06-16)
+The neutral-proxy calibration pilot put paginate below the 40–70% catch band
+(0.25), because two seeded bugs were not detectable from the blind producer copy:
+their intended behavior lived only in stripped docstrings, not in code. The bug
+*identities and descriptions are unchanged*; only their code seam was repaired so
+the intended behavior survives the producer strip:
+- **pg-b2** (response-envelope shape): added `src/paginate/client.py`, the
+  downstream consumer that reads the documented envelope
+  (`resp["data"]` / `resp["paging"]["next_cursor"]`), wired via `App.records`. The
+  consumer is the strip-surviving signal of the intended shape that previously
+  existed only in a docstring. `App.records` / `client.py` exist purely as this
+  strip-surviving consumer-seam SIGNAL for pg-b2 (a downstream consumer that must
+  be reconciled with the flat envelope `routes` returns); they are not otherwise
+  exercised by the package's default path.
+- **pg-b6** (default page size): relocated from `Paginator.page` (dead on the
+  public request path — `normalize_limit` resolved the default first) to
+  `validate.normalize_limit`, so the wrong default is observable through the public
+  API against the strip-surviving `DEFAULT_PAGE_SIZE` constant. Its fix patch and
+  exemplar were regenerated accordingly; behavioral independence re-verified.

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/app.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/app.py
@@ -19,3 +19,14 @@ class App:
             # silently restarts at page 1 instead of surfacing the rejection.
             # The caller can never tell a bad cursor from a real first page.
             return list_records(self.store, token=None, limit=limit)
+
+    def records(self, token=None, limit=None):
+        """Return one page's records via the downstream envelope consumer.
+
+        Routes through `client.page_records`, which reads the published envelope
+        (`resp["data"]` / `resp["paging"]["next_cursor"]`), so this exercises the
+        documented envelope contract across the producer<->consumer seam.
+        """
+        from .client import page_records
+        items, _next_cursor = page_records(self, token=token, limit=limit)
+        return items

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/client.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/client.py
@@ -1,0 +1,13 @@
+"""Downstream client for the list endpoint.
+
+Reads the published response envelope: the records live under ``resp["data"]``
+and the continuation token under ``resp["paging"]["next_cursor"]``. A consumer
+that drives pagination relies on exactly this envelope shape.
+"""
+
+
+def page_records(app, token=None, limit=None):
+    """Call the list endpoint and return ``(records, next_cursor)`` read from the
+    response envelope (``resp["data"]`` / ``resp["paging"]["next_cursor"]``)."""
+    resp = app.list(token=token, limit=limit)
+    return resp["data"], resp["paging"]["next_cursor"]

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/paginator.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/paginator.py
@@ -21,10 +21,10 @@ class Paginator:
         Returns {"items": [...], "next_cursor": <token-or-None>}.
         """
         if limit is None:
-            # BUG pg-b6: the documented default page size is DEFAULT_PAGE_SIZE
-            # (5); this hardcodes 10, so a caller relying on the default walks
-            # the collection in the wrong-sized pages.
-            limit = 10
+            # The standalone-paginator default when no limit is supplied. The
+            # public request path resolves the caller-facing default earlier
+            # (normalize_limit); this internal default must equal that value.
+            limit = DEFAULT_PAGE_SIZE
         boundary_id = cursor_mod.decode_cursor(token)
         return self.page_from_boundary(boundary_id, limit)
 

--- a/skills/inquisitor/evals/fixtures/paginate/src/paginate/validate.py
+++ b/skills/inquisitor/evals/fixtures/paginate/src/paginate/validate.py
@@ -11,7 +11,10 @@ def normalize_limit(limit):
     floored to the default), never passed through to the slice as-is.
     """
     if limit is None:
-        return DEFAULT_PAGE_SIZE
+        # BUG pg-b6: the caller-facing default page size regressed. Omitting the
+        # limit must yield DEFAULT_PAGE_SIZE (5); this returns 10, so a caller
+        # relying on the default walks the collection in the wrong-sized pages.
+        return 10
     try:
         limit = int(limit)
     except (TypeError, ValueError):

--- a/skills/inquisitor/evals/test_fixtures.py
+++ b/skills/inquisitor/evals/test_fixtures.py
@@ -257,6 +257,58 @@ class ProducerCopyTest(unittest.TestCase):
         # tests/ = conftest.py only passes the guard
         _fixtures._assert_no_leak(copy)
 
+    def test_bytecode_never_reaches_producer_copy(self):
+        # S-1: a stray `src/<pkg>/__pycache__/*.pyc` in the committed tree (any
+        # in-place import or a pytest run w/o PYTHONDONTWRITEBYTECODE generates one)
+        # must NOT ride into the producer sandbox. A `.pyc` is un-strippable and
+        # retains every docstring (co_consts) + the absolute source path
+        # (co_filename) = the answer key. copy_repo_for_producer ignores bytecode on
+        # copy, and _assert_no_leak fails loud if any bytecode reaches a copy.
+        import py_compile
+        pkg = self.repo / "src" / "toy"
+        # a real compiled module whose .pyc genuinely embeds a docstring
+        (pkg / "tainted.py").write_text(
+            '"""' + self.DESC + ' (nt-b8). The fix clamps it."""\n'
+            'VALUE = 1\n')
+        py_compile.compile(str(pkg / "tainted.py"), doraise=True)
+        cache = pkg / "__pycache__"
+        self.assertTrue(cache.exists() and any(cache.glob("*.pyc")),
+                        "precondition: a .pyc was generated in the source tree")
+
+        copy = pathlib.Path(self._tmp.name) / "copy_bytecode"
+        _fixtures.copy_repo_for_producer(self.repo, copy)
+
+        # (a) NO bytecode rode into the producer copy
+        self.assertEqual(list(copy.rglob("*.pyc")), [])
+        self.assertEqual(list(copy.rglob("*.pyo")), [])
+        self.assertEqual(list(copy.rglob("__pycache__")), [])
+        # (b) _assert_no_leak passes on the clean copy
+        _fixtures._assert_no_leak(copy)
+        # (c) ... and RAISES if a .pyc is planted into the copy (bytecode guard)
+        planted = copy / "src" / "toy" / "__pycache__"
+        planted.mkdir()
+        (planted / "m.cpython-99.pyc").write_bytes(b"\x00\x01\x02")
+        with self.assertRaises(AssertionError) as cm:
+            _fixtures._assert_no_leak(copy)
+        self.assertIn("bytecode", str(cm.exception).lower())
+        (planted / "m.cpython-99.pyc").unlink()
+        planted.rmdir()
+        # (d) ... and RAISES on a bare __pycache__ dir too
+        bare = copy / "tests" / "__pycache__"
+        bare.mkdir()
+        with self.assertRaises(AssertionError) as cm2:
+            _fixtures._assert_no_leak(copy)
+        self.assertIn("__pycache__", str(cm2.exception))
+        bare.rmdir()
+        # (e) defense-in-depth: a `.pyc` planted at the copy ROOT (outside any
+        # producer-visible subtree) also trips the guard
+        root_pyc = copy / "stray.cpython-99.pyc"
+        root_pyc.write_bytes(b"\x00\x01\x02")
+        with self.assertRaises(AssertionError) as cm3:
+            _fixtures._assert_no_leak(copy)
+        self.assertIn("bytecode", str(cm3.exception).lower())
+        root_pyc.unlink()
+
     def test_missing_patch_cleans_up_tmp(self):
         # M-1: the missing-patch error path rmtrees its temp dir before raising,
         # matching its two sibling error paths (timeout, patch-reject). Manifest


### PR DESCRIPTION
## What

Pilot calibration for the #424 Phase-1b execution eval brought the **paginate** fixture from a 0.25 WITHOUT-arm band into the **0.40–0.70 target band** (re-pilot: 0.50 in-band), plus a quality-gate-caught hardening of the producer-blindness strip.

### Paginate softening (principled, not band-gaming)
- **pg-b2** (flat vs nested envelope) was uncatchable blind — its intended shape lived only in a stripped docstring. Add `src/paginate/client.py` (downstream consumer reading `resp["data"]` / `resp["paging"]["next_cursor"]`) + `App.records` wiring = a strip-surviving consumer-seam signal.
- **pg-b6** (default page size) was dead code on the public path (`normalize_limit` resolved `None→5` before `Paginator.page`'s buggy `10`). Relocate to `validate.normalize_limit(None)→10`, observable via `App.list()` against the strip-surviving `DEFAULT_PAGE_SIZE=5`; de-bug `Paginator.page`. Regenerate pg-b6/pg-b3/pg-b8 patches; rewrite `exemplars/pg-b6.py`.

### Blindness-strip hardening (quality-gate Significant)
The producer-blindness strip was defeated through the **Python bytecode channel**: `copy_repo_for_producer` copytree'd `__pycache__`/`*.pyc` into the producer sandbox and stripped only `*.py`; a `.pyc` retains docstrings (`co_consts`) + the absolute `co_filename` answer-key path. Fix: `copytree(ignore=ignore_patterns("__pycache__","*.pyc","*.pyo"))` + a loud bytecode guard in `_assert_no_leak` (subtree + root) + the same guard in `scripts/check_fixture_producer_blind.py` + a regression test. (The scored pilot runs were **not** tainted — the committed tree was clean at stage time.)

## Verification
- `bash scripts/run_tests.sh` — 47/47 green
- All 4 fixture checkers green
- Code `/quality-gate` — PASS, 2 rounds (LookHarder round 1 caught the bytecode-channel Significant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)