### PR TITLE
feat(ledger): #400 #402 read-path observability — skip-and-count identity-less rows, surface corruption, add ledger doctor

### DIFF
--- a/scripts/brier_advisory.py
+++ b/scripts/brier_advisory.py
@@ -223,6 +223,10 @@ def _render_advice(skill, brier_line, fals_hits, grudge_hits):
 # IO / CLI layer (central-store resolution + mtime; NOT unit-tested)          #
 # --------------------------------------------------------------------------- #
 
+def _warn(msg: str) -> None:
+    print(f"[brier_advisory WARN] {msg}", file=sys.stderr)
+
+
 def _disabled() -> bool:
     return os.environ.get("CRUCIBLE_CALIBRATION_DISABLED") == "1"
 
@@ -246,13 +250,27 @@ def _staleness_days(path: str, *, now: Optional[float] = None) -> Optional[float
 
 
 def _load_brier(path: str) -> dict:
-    """Load brier-rolling.json; {} on any missing/unreadable/malformed file."""
+    """Load brier-rolling.json; {} on any missing/unreadable/malformed file.
+
+    #400: a MISSING file is the normal pre-bootstrap state (silent), but a file
+    that exists yet is corrupt/non-dict means the reconciler's output was torn —
+    the advisory would otherwise just vanish. Warn once so the corruption is
+    surfaced rather than silently degrading the calibration signal to empty.
+    """
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        return data if isinstance(data, dict) else {}
-    except (OSError, ValueError):
+    except FileNotFoundError:
         return {}
+    except (OSError, ValueError) as e:
+        _warn(f"brier-rolling.json unreadable/corrupt ({path}): {e}; "
+              f"calibration advisory degraded to silent")
+        return {}
+    if not isinstance(data, dict):
+        _warn(f"brier-rolling.json is not a JSON object ({path}); "
+              f"calibration advisory degraded to silent")
+        return {}
+    return data
 
 
 def _runs_path() -> str:

--- a/scripts/grudge_query.py
+++ b/scripts/grudge_query.py
@@ -121,15 +121,19 @@ def load_grudges(repo: str, repo_root: str, base_dir: Optional[str] = None) -> L
     out: List[Dict] = []
     if not os.path.isdir(d):
         return out
+    unparseable = 0  # #400: surface corrupt grudge files instead of silent skip
     for name in sorted(os.listdir(d)):
         if not name.endswith(".md"):
             continue
         g = parse_grudge(os.path.join(d, name))
         if g is None:
+            unparseable += 1
             continue
         if os.path.realpath(g.get("repo_root", "")) != os.path.realpath(repo_root):
             continue
         out.append(g)
+    if unparseable:
+        _qwarn(f"skipped {unparseable} unparseable grudge file(s) in {d}")
     return out
 
 

--- a/scripts/ledger_append.py
+++ b/scripts/ledger_append.py
@@ -130,6 +130,8 @@ def caller_dedup(ledger_path: str, run_id: str, skill: str) -> bool:
     """
     if not os.path.exists(ledger_path):
         return False
+    found = False
+    skipped = 0  # #400: count corrupt lines instead of silently weakening dedup
     try:
         with open(ledger_path, "rb") as f:
             for raw_line in f:
@@ -139,12 +141,16 @@ def caller_dedup(ledger_path: str, run_id: str, skill: str) -> bool:
                 try:
                     obj = json.loads(line)
                 except (json.JSONDecodeError, UnicodeDecodeError):
+                    skipped += 1
                     continue
                 if obj.get("run_id") == run_id and obj.get("skill") == skill:
-                    return True
+                    found = True
+                    break
     except OSError:
         return False
-    return False
+    if skipped:
+        _warn(f"caller_dedup: skipped {skipped} unparseable line(s) in {ledger_path}")
+    return found
 
 
 def _try_stale_recovery(lockdir: str) -> bool:

--- a/scripts/ledger_doctor.py
+++ b/scripts/ledger_doctor.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""`ledger doctor` — on-demand consistency check for the calibration + grudge
+stores (#400).
+
+The calibration ledger is "the epistemic backbone": every reader degrades
+SILENTLY on a torn / unparseable line, so a single corrupt write permanently and
+invisibly degrades calibration accuracy and the grudge preflight — "the only
+symptom is the advisory stopped showing up." `compass.py` already ships a
+`doctor`; this is its analogue for the ledger and grudge stores, reporting
+unparseable-line counts and #402 identity-less rows.
+
+On-demand only — it gates NOTHING. Pure stdlib; reads the central machine-local
+store by default (override via CRUCIBLE_LEDGER_DIR / --ledger-dir / --grudge-dir).
+
+Exit codes (mirrors compass doctor): 0 = healthy, 1 = corruption found.
+"""
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from scripts.ledger_append import default_ledger_dir, _valid_identity  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# PURE scanners (deterministic; unit-tested)                                  #
+# --------------------------------------------------------------------------- #
+
+def scan_jsonl(path: str, *, identity: bool = False) -> dict:
+    """Scan a JSONL store. Returns counts WITHOUT mutating anything.
+
+    Reads exactly as every production reader does (render_ledger.load_runs /
+    ledger_reduce.reduce / reconcile_ledger.load_jsonl): BYTE mode, split on
+    b"\\n", drop a partial trailing line (no terminating newline — crash-mid-
+    append), skip only a TRULY empty chunk, and feed each remaining RAW chunk to
+    json.loads. A whitespace-only chunk and an invalid-UTF-8 chunk therefore
+    count as unparseable, exactly as the readers count them — the doctor's whole
+    job is to surface the corruption the readers degrade silently on.
+
+    Keys: exists, total (non-empty chunks scanned == parseable + unparseable),
+    parseable, unparseable, and — when `identity` is set — identityless
+    (parseable object rows lacking a valid (run_id, skill) join key, the #402
+    collision risk). A non-object parseable chunk counts as unparseable (a store
+    row must be a JSON object). A present-but-unreadable store (OSError on open/
+    read — e.g. a directory or permission-denied) is reported as one unparseable
+    line, NOT healthy: the doctor must be more honest than the readers, which
+    swallow OSError.
+    """
+    rep = {"exists": False, "total": 0, "parseable": 0, "unparseable": 0,
+           "identityless": 0}
+    if not path or not os.path.exists(path):
+        return rep
+    rep["exists"] = True
+    try:
+        with open(path, "rb") as f:
+            raw = f.read()
+    except OSError:
+        # File exists but cannot be read (directory, permission-denied). The
+        # readers return [] silently; the doctor surfaces it as corruption.
+        rep["total"] += 1
+        rep["unparseable"] += 1
+        return rep
+    if not raw:
+        return rep
+    parts = raw.split(b"\n")
+    if not raw.endswith(b"\n"):
+        # Last element is a partial trailing line (crash-mid-append) — drop it,
+        # matching the readers.
+        parts = parts[:-1]
+    for chunk in parts:
+        if not chunk:  # only a TRULY empty chunk is skipped (matches readers)
+            continue
+        rep["total"] += 1
+        try:
+            obj = json.loads(chunk)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            rep["unparseable"] += 1
+            continue
+        if not isinstance(obj, dict):
+            rep["unparseable"] += 1
+            continue
+        rep["parseable"] += 1
+        if identity and not (
+            _valid_identity(obj.get("run_id"))
+            and _valid_identity(obj.get("skill"))
+        ):
+            rep["identityless"] += 1
+    return rep
+
+
+def scan_brier(path: str) -> dict:
+    """Scan brier-rolling.json. Keys: exists, ok (parses to a JSON object)."""
+    rep = {"exists": False, "ok": False}
+    if not path or not os.path.exists(path):
+        return rep
+    rep["exists"] = True
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        rep["ok"] = isinstance(data, dict)
+    except (OSError, ValueError):
+        rep["ok"] = False
+    return rep
+
+
+def scan_grudges(grudge_dir: str) -> dict:
+    """Scan a grudge store directory of `*.md` files. Keys: exists, total,
+    unparseable (files `grudge_query.parse_grudge` rejects)."""
+    rep = {"exists": False, "total": 0, "unparseable": 0}
+    if not grudge_dir or not os.path.isdir(grudge_dir):
+        return rep
+    rep["exists"] = True
+    # Imported lazily: grudge_query pulls in grudge_append; keep doctor importable
+    # even if the grudge subsystem is absent.
+    try:
+        from scripts.grudge_query import parse_grudge
+    except Exception:  # noqa: BLE001 — grudge subsystem unavailable
+        return rep
+    for name in sorted(os.listdir(grudge_dir)):
+        if not name.endswith(".md"):
+            continue
+        rep["total"] += 1
+        if parse_grudge(os.path.join(grudge_dir, name)) is None:
+            rep["unparseable"] += 1
+    return rep
+
+
+# --------------------------------------------------------------------------- #
+# Report                                                                      #
+# --------------------------------------------------------------------------- #
+
+def _default_grudge_dir() -> "str | None":
+    """Best-effort grudge store for the cwd's repo, or None if undeterminable
+    (not in a git repo, grudge subsystem absent). Never raises."""
+    try:
+        from scripts.grudge_append import grudges_dir, resolve_repo
+        repo, _repo_root = resolve_repo()
+        return grudges_dir(repo)
+    except Exception:  # noqa: BLE001 — best-effort
+        return None
+
+
+def doctor(ledger_dir: str, grudge_dir: "str | None") -> int:
+    """Print the consistency report; return 0 healthy / 1 corruption found."""
+    runs = scan_jsonl(os.path.join(ledger_dir, "runs.jsonl"), identity=True)
+    fals = scan_jsonl(os.path.join(ledger_dir, "falsification.jsonl"))
+    brier = scan_brier(os.path.join(ledger_dir, "brier-rolling.json"))
+    grudges = scan_grudges(grudge_dir) if grudge_dir else {"exists": False}
+
+    info, warnings, issues = [], [], []
+
+    info.append(f"ledger-dir: {ledger_dir}")
+
+    if not runs["exists"]:
+        info.append("runs.jsonl — not present (no gating runs captured yet)")
+    else:
+        line = (f"runs.jsonl — {runs['parseable']}/{runs['total']} parseable")
+        if runs["unparseable"]:
+            issues.append(f"runs.jsonl: {runs['unparseable']} unparseable line(s)")
+        else:
+            info.append(line)
+        if runs["identityless"]:
+            warnings.append(
+                f"runs.jsonl: {runs['identityless']} row(s) lack a valid "
+                f"(run_id, skill) identity — skipped by consumers (#402)")
+
+    if not fals["exists"]:
+        info.append("falsification.jsonl — not present (reconciler not run yet)")
+    elif fals["unparseable"]:
+        issues.append(
+            f"falsification.jsonl: {fals['unparseable']} unparseable line(s)")
+    else:
+        info.append(
+            f"falsification.jsonl — {fals['parseable']}/{fals['total']} parseable")
+
+    if not brier["exists"]:
+        info.append("brier-rolling.json — not present (reconciler not run yet)")
+    elif not brier["ok"]:
+        issues.append("brier-rolling.json: corrupt or not a JSON object")
+    else:
+        info.append("brier-rolling.json — OK")
+
+    if not grudges["exists"]:
+        info.append("grudge store — not present / not resolvable")
+    elif grudges["unparseable"]:
+        issues.append(
+            f"grudge store: {grudges['unparseable']}/{grudges['total']} "
+            f"unparseable file(s)")
+    else:
+        info.append(f"grudge store — {grudges['total']} grudge(s), all parseable")
+
+    print("=== ledger doctor ===")
+    for line in info:
+        print(f"  [ok] {line}")
+    for line in warnings:
+        print(f"  [warn] {line}")
+    for line in issues:
+        print(f"  [FAIL] {line}")
+    if issues:
+        print(f"  --- {len(issues)} issue(s) found ---")
+    else:
+        print("  --- healthy ---")
+    return 1 if issues else 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Consistency check for the calibration + grudge stores (#400).")
+    parser.add_argument(
+        "--ledger-dir", default=default_ledger_dir(),
+        help="ledger store dir (default: central ~/.claude/crucible/ledger)")
+    parser.add_argument(
+        "--grudge-dir", default=None,
+        help="grudge store dir of *.md files (default: derive from cwd repo)")
+    args = parser.parse_args(argv)
+
+    grudge_dir = args.grudge_dir if args.grudge_dir is not None \
+        else _default_grudge_dir()
+    return doctor(args.ledger_dir, grudge_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ledger_reduce.py
+++ b/scripts/ledger_reduce.py
@@ -12,6 +12,10 @@ import sys
 from typing import Dict
 
 
+def _warn(msg: str) -> None:
+    print(f"[ledger_reduce WARN] {msg}", file=sys.stderr)
+
+
 def reduce(falsification_path: str) -> Dict[str, dict]:
     """Return dict keyed by ledger_entry_hash with the latest entry per hash.
 
@@ -37,17 +41,27 @@ def reduce(falsification_path: str) -> Dict[str, dict]:
         parts = parts[:-1]
 
     out: Dict[str, dict] = {}
+    skipped = 0  # #400: surface corruption instead of degrading silently
     for chunk in parts:
         if not chunk:
             continue
         try:
             obj = json.loads(chunk)
         except (json.JSONDecodeError, UnicodeDecodeError):
+            skipped += 1
+            continue
+        if not isinstance(obj, dict):
+            # #400: a valid-JSON-but-non-object line (e.g. `[1,2,3]`, `42`) has
+            # no `.get` — the obj.get below would AttributeError. Count it as
+            # corruption, same as render_ledger.load_runs.
+            skipped += 1
             continue
         key = obj.get("ledger_entry_hash")
         if key is None:
             continue
         out[key] = obj  # later positions overwrite earlier ones (L-9)
+    if skipped:
+        _warn(f"reduce: skipped {skipped} unparseable line(s) in {falsification_path}")
     return out
 
 

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -43,6 +43,7 @@ from scripts.ledger_append import (  # noqa: E402
     append as _ledger_append,
     default_ledger_dir,
     default_ledger_path,
+    _valid_identity,
 )
 from scripts.atomic_write import atomic_write_text  # noqa: E402
 
@@ -94,6 +95,10 @@ def _now_iso() -> str:
     return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _warn(msg: str) -> None:
+    print(f"[reconcile_ledger WARN] {msg}", file=sys.stderr)
+
+
 # --------------------------------------------------------------------------- #
 # PURE core                                                                   #
 # --------------------------------------------------------------------------- #
@@ -122,13 +127,24 @@ def load_jsonl(path: str) -> List[dict]:
     if not raw.endswith(b"\n"):
         parts = parts[:-1]  # drop the partial trailing line
     out: List[dict] = []
+    skipped = 0
     for chunk in parts:
         if not chunk:
             continue
         try:
-            out.append(json.loads(chunk))
+            obj = json.loads(chunk)
         except (json.JSONDecodeError, UnicodeDecodeError):
+            skipped += 1  # #400: corruption is counted, not silently dropped
             continue
+        if not isinstance(obj, dict):
+            # #400: a valid-JSON-but-non-object line (e.g. `[1,2,3]`, `42`) has
+            # no `.get` — downstream e.get(...) would AttributeError. Count it
+            # as corruption, same as render_ledger.load_runs.
+            skipped += 1
+            continue
+        out.append(obj)
+    if skipped:
+        _warn(f"load_jsonl: skipped {skipped} unparseable line(s) in {path}")
     return out
 
 
@@ -191,14 +207,24 @@ def reconcile(
     manual = read_manual_attribution(manual_attribution_path)
 
     # Pre-sort ledger entries by timestamp ascending so "earliest match" is the
-    # first qualifying entry we encounter per candidate.
+    # first qualifying entry we encounter per candidate. #402 read-side: drop
+    # rows lacking a valid (run_id, skill) join key HERE (once per entry, not
+    # once per candidate) so the walkback never hashes one into the shared
+    # "unknown:unknown" bucket and mis-attributes a fix to it.
     indexed = []
+    skipped_identityless = 0
     for e in entries:
         ts = _parse_iso(e.get("timestamp"))
         if ts is None:
             continue
+        if not (_valid_identity(e.get("run_id")) and _valid_identity(e.get("skill"))):
+            skipped_identityless += 1
+            continue
         indexed.append((ts, e))
     indexed.sort(key=lambda pair: pair[0])
+    if skipped_identityless:
+        _warn(f"reconcile: skipped {skipped_identityless} ledger row(s) lacking "
+              f"a valid (run_id, skill) identity (#402)")
 
     appended: List[dict] = []
     # Track hashes already attributed in THIS run so one verdict isn't
@@ -270,9 +296,9 @@ def reconcile(
             # (b) entry timestamp < candidate merge_time
             if merge_dt is not None and not (ts < merge_dt):
                 continue
-            run_id = e.get("run_id", "unknown")
-            skill = e.get("skill", "unknown")
-            h = ledger_entry_hash(run_id, skill)
+            # run_id/skill are guaranteed valid: identity-less rows were dropped
+            # when `indexed` was built (#402).
+            h = ledger_entry_hash(e["run_id"], e["skill"])
             # Skip already-attributed verdicts (manual pass or a prior
             # candidate this run); keep scanning for the next-earliest unseen.
             if h in seen_hashes:
@@ -368,12 +394,19 @@ def compute_brier(
 
     # accumulate squared errors per skill
     acc: Dict[str, List[float]] = {}
+    skipped_identityless = 0
 
     for e in ledger_entries:
+        # #402 read-side: a row lacking a valid (run_id, skill) join key would
+        # otherwise hash to the shared "unknown:unknown" bucket and pollute an
+        # "unknown" skill's Brier with unrelated runs. Skip + count it instead.
+        run_id = e.get("run_id")
+        skill = e.get("skill")
+        if not (_valid_identity(run_id) and _valid_identity(skill)):
+            skipped_identityless += 1
+            continue
         # Hoist the falsification lookup ABOVE the artifact_type gate so the
         # #342 non-code admission can consult it.
-        run_id = e.get("run_id", "unknown")
-        skill = e.get("skill", "unknown")
         h = ledger_entry_hash(run_id, skill)
         fals = falsification_map.get(h)
 
@@ -437,6 +470,10 @@ def compute_brier(
 
         sq_err = (float(confidence) - actual) ** 2
         acc.setdefault(skill, []).append(sq_err)
+
+    if skipped_identityless:
+        _warn(f"compute_brier: skipped {skipped_identityless} ledger row(s) "
+              f"lacking a valid (run_id, skill) identity (#402)")
 
     out: Dict[str, dict] = {}
     last = _now_iso() if now_dt is None else now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -696,12 +733,19 @@ def reconcile_predicates(
     reference_candidates = reference_candidates or []
     classifications: List[dict] = []
     appended: List[dict] = []
+    skipped_identityless = 0
     for e in ledger_entries:
         pf = e.get("predicted_falsifier")
         if pf is None:
             continue
-        run_id = e.get("run_id", "unknown")
-        skill = e.get("skill", "unknown")
+        # #402 read-side: an identity-less predicate row has no stable join key
+        # to attribute a fired falsifier to — skip + count rather than hash it
+        # into the shared "unknown:unknown" bucket.
+        run_id = e.get("run_id")
+        skill = e.get("skill")
+        if not (_valid_identity(run_id) and _valid_identity(skill)):
+            skipped_identityless += 1
+            continue
         h = ledger_entry_hash(run_id, skill)
 
         if pf == PREDICATE_SENTINEL:
@@ -776,6 +820,10 @@ def reconcile_predicates(
             }
             _ledger_append(falsification_path, entry)
             appended.append(entry)
+
+    if skipped_identityless:
+        _warn(f"reconcile_predicates: skipped {skipped_identityless} predicate "
+              f"row(s) lacking a valid (run_id, skill) identity (#402)")
 
     return classifications, appended
 

--- a/scripts/render_ledger.py
+++ b/scripts/render_ledger.py
@@ -28,7 +28,7 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from scripts.ledger_reduce import reduce as _falsification_reduce  # noqa: E402
-from scripts.ledger_append import default_ledger_dir  # noqa: E402
+from scripts.ledger_append import default_ledger_dir, _valid_identity  # noqa: E402
 from scripts.atomic_write import atomic_write_text  # noqa: E402
 from scripts.reconcile_ledger import (  # noqa: E402
     parse_predicate,
@@ -64,6 +64,10 @@ VAGUENESS_RATE_THRESHOLD = 0.5
 # Loading                                                                     #
 # --------------------------------------------------------------------------- #
 
+def _warn(msg: str) -> None:
+    print(f"[render_ledger WARN] {msg}", file=sys.stderr)
+
+
 def load_runs(path: str) -> list:
     """Tolerant read of runs.jsonl, deduped by (run_id, skill) latest-wins.
 
@@ -89,19 +93,24 @@ def load_runs(path: str) -> list:
 
     by_key = {}  # (run_id, skill) -> entry; later positions overwrite earlier
     order = []   # preserve first-seen order of keys for stable output
+    skipped = 0  # #400: count corrupt lines instead of degrading silently
     for chunk in parts:
         if not chunk:
             continue
         try:
             obj = json.loads(chunk)
         except (json.JSONDecodeError, UnicodeDecodeError):
+            skipped += 1
             continue
         if not isinstance(obj, dict):
+            skipped += 1
             continue
         key = (obj.get("run_id"), obj.get("skill"))
         if key not in by_key:
             order.append(key)
         by_key[key] = obj
+    if skipped:
+        _warn(f"load_runs: skipped {skipped} unparseable line(s) in {path}")
     return [by_key[k] for k in order]
 
 
@@ -170,8 +179,15 @@ def week_summary(entries: list) -> dict:
     """
     per_skill = {}
     backfilled = 0
+    skipped_identityless = 0
     for e in entries:
-        skill = e.get("skill") or "unknown"
+        # #402 read-side: a row lacking a valid (run_id, skill) join key would
+        # merge into a single "unknown" skill bucket, conflating unrelated runs
+        # in the severity table. Skip + count it instead.
+        if not (_valid_identity(e.get("run_id")) and _valid_identity(e.get("skill"))):
+            skipped_identityless += 1
+            continue
+        skill = e["skill"]
         slot = per_skill.setdefault(
             skill,
             {"findings": 0, "fatal": 0, "significant": 0,
@@ -193,6 +209,10 @@ def week_summary(entries: list) -> dict:
         slot["fatal"] += f
         slot["significant"] += s
         slot["forward_entries"] += 1
+
+    if skipped_identityless:
+        _warn(f"week_summary: skipped {skipped_identityless} ledger row(s) "
+              f"lacking a valid (run_id, skill) identity (#402)")
 
     for slot in per_skill.values():
         total = slot["findings"]
@@ -359,6 +379,7 @@ def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
     grace_cutoff = (now_dt - _dt.timedelta(days=GRACE_DAYS)) if now_dt else None
 
     per_skill = {}
+    skipped_identityless = 0
     for e in entries:
         pf = e.get("predicted_falsifier")
         if pf is None:
@@ -368,7 +389,12 @@ def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
         # predicate data to report).
         if pf == PREDICATE_SENTINEL:
             continue
-        skill = e.get("skill") or "unknown"
+        # #402 read-side: an identity-less row has no stable join key into the
+        # falsification map — skip + count rather than bucket it under "unknown".
+        if not (_valid_identity(e.get("run_id")) and _valid_identity(e.get("skill"))):
+            skipped_identityless += 1
+            continue
+        skill = e["skill"]
         slot = per_skill.setdefault(skill, {
             "total_non_null": 0, "parseable": 0, "uncheckable": 0,
             "unparseable": 0, "hit_count": 0,
@@ -393,12 +419,16 @@ def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
         if not outside_grace:
             continue
         slot["parseable"] += 1
-        h = ledger_entry_hash(e.get("run_id", "unknown"), skill)
+        h = ledger_entry_hash(e["run_id"], skill)
         fals = falsification_reduced.get(h)
         if fals is not None:
             via = fals.get("via") or (fals.get("falsified_by") or {}).get("via")
             if bool(fals.get("falsified")) and via == "predicate":
                 slot["hit_count"] += 1
+
+    if skipped_identityless:
+        _warn(f"predicate_rates: skipped {skipped_identityless} predicate row(s) "
+              f"lacking a valid (run_id, skill) identity (#402)")
 
     out = {}
     for skill, s in per_skill.items():

--- a/scripts/test_ledger_core.py
+++ b/scripts/test_ledger_core.py
@@ -22,7 +22,9 @@ Pure stdlib `unittest`. Machine-local central store is NEVER touched — every
 case writes to a tmp dir (the pure functions take explicit paths; append() is
 pointed at a tmp ledger_path). No git, no subprocess.
 """
+import contextlib
 import hashlib
+import io
 import json
 import os
 import sys
@@ -1135,6 +1137,209 @@ class ParsePredicateTest(unittest.TestCase):
         self.assertIsNone(rl.parse_predicate(None))
         self.assertIsNone(rl.parse_predicate(""))
         self.assertIsNone(rl.parse_predicate(123))
+
+
+# --------------------------------------------------------------------------- #
+# #402 read-side: identity-less rows are SKIPPED + counted, never bucketed     #
+# under the shared sha256("unknown:unknown") join key. The PR-A write gate     #
+# refuses NEW identity-less rows; these tests cover already-on-disk legacy     #
+# rows reaching the consumers (the M-1 residual the PR-A red-team flagged).    #
+# --------------------------------------------------------------------------- #
+
+class IdentitySkipReconcileTest(unittest.TestCase):
+    NOW = "2026-06-01T00:00:00Z"
+    OLD = "2026-01-01T00:00:00Z"
+
+    def _capture(self, fn):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            result = fn()
+        return result, buf.getvalue()
+
+    def test_compute_brier_skips_identityless_row(self):
+        # A code PASS that WOULD score, but with no run_id/skill: must be skipped
+        # (not bucketed under an "unknown" skill) and counted via a warning.
+        e = {"verdict": "PASS", "confidence": 0.9, "timestamp": self.OLD,
+             "artifact_type": "code", "backfilled": False}
+        out, err = self._capture(lambda: rl.compute_brier([e], {}, now=self.NOW))
+        self.assertEqual(out, {})
+        self.assertNotIn("unknown", out)
+        self.assertIn("skipped 1", err)
+
+    def test_compute_brier_partial_identity_skipped(self):
+        # run_id present but skill missing → still identity-less (both halves of
+        # the join key are required).
+        e = {"run_id": "r1", "verdict": "PASS", "confidence": 0.9,
+             "timestamp": self.OLD, "artifact_type": "code", "backfilled": False}
+        out, _ = self._capture(lambda: rl.compute_brier([e], {}, now=self.NOW))
+        self.assertEqual(out, {})
+
+    def test_compute_brier_valid_rows_unaffected(self):
+        good = {"run_id": "r1", "skill": "siege", "verdict": "PASS",
+                "confidence": 0.9, "timestamp": self.OLD,
+                "artifact_type": "code", "backfilled": False}
+        bad = {"verdict": "PASS", "confidence": 0.9, "timestamp": self.OLD,
+               "artifact_type": "code", "backfilled": False}
+        out, err = self._capture(
+            lambda: rl.compute_brier([good, bad], {}, now=self.NOW))
+        self.assertEqual(out["siege"]["n"], 1)
+        self.assertNotIn("unknown", out)
+        self.assertIn("skipped 1", err)
+
+    def test_reconcile_skips_identityless_ledger_row(self):
+        with tempfile.TemporaryDirectory() as d:
+            ledger = os.path.join(d, "runs.jsonl")
+            fals = os.path.join(d, "falsification.jsonl")
+            manual = os.path.join(d, "manual.jsonl")
+            # One identity-less code verdict overlapping the candidate's files.
+            with open(ledger, "w") as f:
+                f.write(json.dumps({
+                    "gated_files": ["a.py"], "artifact_type": "code",
+                    "timestamp": self.OLD, "backfilled": False}) + "\n")
+            cand = [{"commit": "deadbeef", "touched_files": ["a.py"],
+                     "merge_time": self.NOW}]
+            appended, err = self._capture(lambda: rl.reconcile(
+                ledger, fals, manual, cand, cross_cut_threshold=20, now=self.NOW))
+            self.assertEqual(appended, [])  # nothing attributable
+            self.assertIn("skipped 1", err)
+
+    def test_reconcile_predicates_skips_identityless(self):
+        with tempfile.TemporaryDirectory() as d:
+            fals = os.path.join(d, "falsification.jsonl")
+            e = {"predicted_falsifier": "fix touching a.py within 14d",
+                 "artifact_type": "code", "timestamp": self.OLD,
+                 "gated_files": ["a.py"]}
+            cand = [{"commit": "c1", "touched_files": ["a.py"],
+                     "merge_time": "2026-01-05T00:00:00Z"}]
+            (classifications, appended), err = self._capture(
+                lambda: rl.reconcile_predicates([e], cand, fals, now=self.NOW))
+            self.assertEqual(classifications, [])  # identity-less → no classification
+            self.assertEqual(appended, [])
+            self.assertIn("skipped 1", err)
+
+
+# --------------------------------------------------------------------------- #
+# #400 corruption surfacing: tolerant readers count unparseable lines and warn #
+# ONCE per read (a torn central store of thousands of lines → one summary line,#
+# not thousands). The skip behavior itself is unchanged (characterization).    #
+# --------------------------------------------------------------------------- #
+
+class TolerantReaderWarnTest(unittest.TestCase):
+    def _capture_stderr(self, fn):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            result = fn()
+        return result, buf.getvalue()
+
+    def test_reduce_warns_once_with_count(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "falsification.jsonl")
+            with open(p, "w") as f:
+                f.write(json.dumps({"ledger_entry_hash": "h1",
+                                    "falsified": True}) + "\n")
+                f.write("{not json\n")
+                f.write("also broken\n")
+            out, err = self._capture_stderr(lambda: lr.reduce(p))
+            self.assertEqual(len(out), 1)             # good line still parsed
+            self.assertEqual(err.count("[ledger_reduce WARN]"), 1)  # warn ONCE
+            self.assertIn("skipped 2", err)           # both bad lines counted
+
+    def test_reduce_clean_file_silent(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "falsification.jsonl")
+            with open(p, "w") as f:
+                f.write(json.dumps({"ledger_entry_hash": "h1"}) + "\n")
+            _, err = self._capture_stderr(lambda: lr.reduce(p))
+            self.assertEqual(err, "")
+
+    def test_caller_dedup_warns_on_corrupt_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "w") as f:
+                f.write("{broken\n")
+                f.write(json.dumps({"run_id": "r1", "skill": "siege"}) + "\n")
+            found, err = self._capture_stderr(
+                lambda: la.caller_dedup(p, "r1", "siege"))
+            self.assertTrue(found)                    # good line still matched
+            self.assertIn("skipped 1", err)
+
+    def test_load_jsonl_warns_on_corrupt_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "w") as f:
+                f.write(json.dumps({"a": 1}) + "\n")
+                f.write("garbage\n")
+            out, err = self._capture_stderr(lambda: rl.load_jsonl(p))
+            self.assertEqual(out, [{"a": 1}])
+            self.assertIn("skipped 1", err)
+
+
+# --------------------------------------------------------------------------- #
+# #400 corruption tolerance — symmetry fix: a valid-JSON-but-NON-OBJECT line   #
+# (`[1,2,3]`, `42`) has no `.get`, so it must be skipped+counted (folded into  #
+# the same `skipped` warn count) by the reconcile-path readers, exactly as     #
+# render_ledger.load_runs already does — NOT kept as an "entry" that then       #
+# AttributeErrors in compute_brier / reconcile / ledger_reduce.reduce.         #
+# --------------------------------------------------------------------------- #
+
+class NonObjectLineToleranceTest(unittest.TestCase):
+    def _capture_stderr(self, fn):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            result = fn()
+        return result, buf.getvalue()
+
+    def test_load_jsonl_skips_and_counts_non_dict_line(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "w") as f:
+                f.write(json.dumps({"run_id": "r1", "skill": "siege"}) + "\n")
+                f.write("[1, 2, 3]\n")   # valid JSON, not an object
+                f.write("42\n")          # valid JSON, not an object
+            out, err = self._capture_stderr(lambda: rl.load_jsonl(p))
+            self.assertEqual(out, [{"run_id": "r1", "skill": "siege"}])
+            self.assertEqual(err.count("[reconcile_ledger WARN]"), 1)  # once
+            self.assertIn("skipped 2", err)  # both non-dict lines counted
+
+    def test_load_jsonl_non_dict_does_not_crash_compute_brier(self):
+        # The whole point of the fix: load → compute_brier must not raise.
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "w") as f:
+                f.write("[1, 2, 3]\n")
+            entries, _ = self._capture_stderr(lambda: rl.load_jsonl(p))
+            # Belt-and-suspenders: even a stray non-dict reaching compute_brier
+            # directly must be tolerated (the guard lives in load_jsonl, but the
+            # contract is no AttributeError on this corruption class).
+            out = rl.compute_brier(entries, {}, now="2026-06-01T00:00:00Z")
+            self.assertEqual(out, {})
+
+    def test_reconcile_tolerates_non_dict_ledger_line(self):
+        with tempfile.TemporaryDirectory() as d:
+            ledger = os.path.join(d, "runs.jsonl")
+            fals = os.path.join(d, "falsification.jsonl")
+            manual = os.path.join(d, "manual.jsonl")
+            with open(ledger, "w") as f:
+                f.write("[1, 2, 3]\n")  # non-dict corruption line
+            cand = [{"commit": "deadbeef", "touched_files": ["a.py"],
+                     "merge_time": "2026-06-01T00:00:00Z"}]
+            appended, _ = self._capture_stderr(lambda: rl.reconcile(
+                ledger, fals, manual, cand, cross_cut_threshold=20,
+                now="2026-06-01T00:00:00Z"))
+            self.assertEqual(appended, [])  # nothing attributable, no crash
+
+    def test_reduce_skips_and_counts_non_dict_line(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "falsification.jsonl")
+            with open(p, "w") as f:
+                f.write(json.dumps({"ledger_entry_hash": "h1",
+                                    "falsified": True}) + "\n")
+                f.write("[1, 2, 3]\n")  # valid JSON, not an object
+            out, err = self._capture_stderr(lambda: lr.reduce(p))
+            self.assertEqual(len(out), 1)   # good line still reduced
+            self.assertIn("h1", out)
+            self.assertEqual(err.count("[ledger_reduce WARN]"), 1)  # once
+            self.assertIn("skipped 1", err)  # non-dict line counted
 
 
 if __name__ == "__main__":

--- a/scripts/test_stores.py
+++ b/scripts/test_stores.py
@@ -18,7 +18,9 @@ Pure stdlib `unittest`. Every store path is a tmp dir; the machine-local central
 stores (`~/.claude/crucible/{grudge,ledger}`) are never touched. `filter_ignored`
 runs against a throwaway `git init` repo, never the crucible repo.
 """
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -41,6 +43,8 @@ from scripts import grudge_append as ga  # noqa: E402
 from scripts import grudge_query as gq  # noqa: E402
 from scripts import render_ledger as rl  # noqa: E402
 from scripts import atomic_write as aw  # noqa: E402
+from scripts import brier_advisory as ba  # noqa: E402
+from scripts import ledger_doctor as ld  # noqa: E402
 
 # backfill-ledger.py is hyphenated → not importable by name; load it from path.
 _bf_spec = importlib.util.spec_from_file_location(
@@ -258,6 +262,25 @@ class LoadGrudgesRepoRootFilterTest(unittest.TestCase):
             loaded = gq.load_grudges("myrepo", repo_root, base)
             self.assertEqual(len(loaded), 1)
             self.assertEqual(loaded[0]["files_touched"], ["a.py"])
+
+    def test_unparseable_grudge_file_is_counted(self):
+        # #400: a corrupt grudge file (no frontmatter) must be counted + warned,
+        # not silently vanish from the DO-NOT-REPEAT preflight.
+        with tempfile.TemporaryDirectory() as base, \
+                tempfile.TemporaryDirectory() as repo_root:
+            gdir = ga.grudges_dir("myrepo", base)
+            os.makedirs(gdir)
+            good = ('---\nrepo_root: %s\nfiles_touched: ["a.py"]\n'
+                    'anti_pattern_signature: ""\n---\nbody\n' % repo_root)
+            with open(os.path.join(gdir, "good.md"), "w") as f:
+                f.write(good)
+            with open(os.path.join(gdir, "broken.md"), "w") as f:
+                f.write("no frontmatter at all\n")
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                loaded = gq.load_grudges("myrepo", repo_root, base)
+            self.assertEqual(len(loaded), 1)
+            self.assertIn("skipped 1", buf.getvalue())
 
 
 class SignatureHitTest(unittest.TestCase):
@@ -660,6 +683,213 @@ class GrudgeAtomicWriteTest(unittest.TestCase):
         # the store dir holds only finished *.md grudges — no .atomic-* temp.
         self.assertTrue(all(n.endswith(".md") for n in os.listdir(store_dir)),
                         os.listdir(store_dir))
+
+
+# --------------------------------------------------------------------------- #
+# render_ledger — #402 identity-skip + #400 tolerant-read warn                 #
+# --------------------------------------------------------------------------- #
+
+def _capture(fn):
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        result = fn()
+    return result, buf.getvalue()
+
+
+class RenderLedgerIdentitySkipTest(unittest.TestCase):
+    OLD = "2026-01-01T00:00:00Z"
+
+    def test_week_summary_skips_identityless_skill(self):
+        good = {"run_id": "r1", "skill": "siege", "timestamp": self.OLD,
+                "backfilled": False, "would_have_shipped_without_gate": True,
+                "severity_histogram": {"fatal": 0, "significant": 1, "minor": 0,
+                                       "nit": 0}}
+        bad = {"run_id": "r2", "timestamp": self.OLD, "backfilled": False,
+               "severity_histogram": {"fatal": 0, "significant": 1, "minor": 0,
+                                      "nit": 0}}
+        summary, err = _capture(lambda: rl.week_summary([good, bad]))
+        self.assertIn("siege", summary["per_skill"])
+        self.assertNotIn("unknown", summary["per_skill"])
+        self.assertIn("skipped 1", err)
+
+    def test_load_runs_warns_on_corrupt_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "w") as f:
+                f.write(json.dumps({"run_id": "r1", "skill": "siege"}) + "\n")
+                f.write("{broken\n")
+            out, err = _capture(lambda: rl.load_runs(p))
+            self.assertEqual(len(out), 1)
+            self.assertIn("skipped 1", err)
+
+
+# --------------------------------------------------------------------------- #
+# brier_advisory — corrupt brier-rolling.json surfaces (was silent {})         #
+# --------------------------------------------------------------------------- #
+
+class BrierLoadWarnTest(unittest.TestCase):
+    def test_missing_file_is_silent(self):
+        with tempfile.TemporaryDirectory() as d:
+            out, err = _capture(
+                lambda: ba._load_brier(os.path.join(d, "nope.json")))
+            self.assertEqual(out, {})
+            self.assertEqual(err, "")
+
+    def test_corrupt_json_warns(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "brier-rolling.json")
+            with open(p, "w") as f:
+                f.write("{not valid json")
+            out, err = _capture(lambda: ba._load_brier(p))
+            self.assertEqual(out, {})
+            self.assertIn("[brier_advisory WARN]", err)
+
+    def test_valid_json_silent(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "brier-rolling.json")
+            with open(p, "w") as f:
+                f.write(json.dumps({"siege": {"n": 5, "brier": 0.3}}))
+            out, err = _capture(lambda: ba._load_brier(p))
+            self.assertEqual(out, {"siege": {"n": 5, "brier": 0.3}})
+            self.assertEqual(err, "")
+
+
+# --------------------------------------------------------------------------- #
+# ledger_doctor — on-demand consistency check (#400)                           #
+# --------------------------------------------------------------------------- #
+
+class LedgerDoctorScanTest(unittest.TestCase):
+    def test_scan_jsonl_counts_unparseable_and_identityless(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "w") as f:
+                f.write(json.dumps({"run_id": "r1", "skill": "siege"}) + "\n")
+                f.write(json.dumps({"run_id": "r2"}) + "\n")   # no skill
+                f.write("{broken\n")                            # unparseable
+            rep = ld.scan_jsonl(p, identity=True)
+            self.assertEqual(rep["total"], 3)
+            self.assertEqual(rep["parseable"], 2)
+            self.assertEqual(rep["unparseable"], 1)
+            self.assertEqual(rep["identityless"], 1)
+
+    def test_scan_jsonl_missing_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ld.scan_jsonl(os.path.join(d, "nope.jsonl"))
+            self.assertFalse(rep["exists"])
+
+    def test_scan_jsonl_whitespace_only_line_is_unparseable(self):
+        # S-1: a whitespace-only line is fed RAW to json.loads by every reader
+        # (byte mode, no .strip()) -> ValueError -> unparseable. The doctor must
+        # count it identically, not skip it as "blank".
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "wb") as f:
+                f.write(json.dumps({"run_id": "r1", "skill": "siege"}).encode()
+                        + b"\n")
+                f.write(b"   \n")    # space-only
+                f.write(b"\t\n")     # tab-only
+            rep = ld.scan_jsonl(p, identity=True)
+            self.assertEqual(rep["total"], 3)
+            self.assertEqual(rep["parseable"], 1)
+            self.assertEqual(rep["unparseable"], 2)
+            # Cross-check: the canonical reader skips exactly those 2 chunks.
+            _, err = _capture(lambda: rl.load_runs(p))
+            self.assertIn("skipped 2 unparseable line(s)", err)
+
+    def test_scan_jsonl_drops_unterminated_trailing_line(self):
+        # S-1: a partial trailing line (no final newline — crash mid-append) is
+        # DROPPED by the byte-mode readers; the doctor must drop it too, not count
+        # it as a line.
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "wb") as f:
+                f.write(json.dumps({"run_id": "r1", "skill": "siege"}).encode()
+                        + b"\n")
+                f.write(b'{"run_id": "r2", "ski')   # torn, no newline
+            rep = ld.scan_jsonl(p, identity=True)
+            self.assertEqual(rep["total"], 1)
+            self.assertEqual(rep["parseable"], 1)
+            self.assertEqual(rep["unparseable"], 0)
+            # Reader also keeps only the one complete row (no skip warning).
+            self.assertEqual(len(rl.load_runs(p)), 1)
+
+    def test_scan_jsonl_invalid_utf8_is_unparseable(self):
+        # S-1: invalid UTF-8 raises UnicodeDecodeError in byte-mode readers ->
+        # unparseable. (Text-mode errors="replace" would have masked it.)
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            with open(p, "wb") as f:
+                f.write(json.dumps({"run_id": "r1", "skill": "siege"}).encode()
+                        + b"\n")
+                f.write(b'"\xff\xfe bad utf8"\n')
+            rep = ld.scan_jsonl(p)
+            self.assertEqual(rep["total"], 2)
+            self.assertEqual(rep["parseable"], 1)
+            self.assertEqual(rep["unparseable"], 1)
+
+    def test_scan_jsonl_present_but_unreadable_is_unhealthy(self):
+        # M-1: a present-but-unreadable store (here: runs.jsonl is a directory)
+        # must be reported as corruption, not "not present / healthy".
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "runs.jsonl")
+            os.mkdir(p)
+            rep = ld.scan_jsonl(p, identity=True)
+            self.assertTrue(rep["exists"])
+            self.assertEqual(rep["unparseable"], 1)
+
+    def test_doctor_present_but_unreadable_store_exits_1(self):
+        # M-1 end-to-end: doctor() must render it under [FAIL] and return 1.
+        with tempfile.TemporaryDirectory() as d, \
+                tempfile.TemporaryDirectory() as g:
+            os.mkdir(os.path.join(d, "runs.jsonl"))  # present, unreadable
+            rc, _ = _capture(lambda: ld.main(["--ledger-dir", d, "--grudge-dir", g]))
+            self.assertEqual(rc, 1)
+
+    def test_scan_brier_corrupt(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "brier-rolling.json")
+            with open(p, "w") as f:
+                f.write("{nope")
+            rep = ld.scan_brier(p)
+            self.assertTrue(rep["exists"])
+            self.assertFalse(rep["ok"])
+
+    def test_scan_brier_valid(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "brier-rolling.json")
+            with open(p, "w") as f:
+                f.write(json.dumps({"siege": {"n": 5, "brier": 0.3}}))
+            rep = ld.scan_brier(p)
+            self.assertTrue(rep["ok"])
+
+    def test_scan_grudges_counts_unparseable(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "good.md"), "w") as f:
+                f.write('---\nfiles_touched: ["a.py"]\n---\nbody\n')
+            with open(os.path.join(d, "bad.md"), "w") as f:
+                f.write("no frontmatter here\n")
+            rep = ld.scan_grudges(d)
+            self.assertEqual(rep["total"], 2)
+            self.assertEqual(rep["unparseable"], 1)
+
+    def test_doctor_report_clean_is_healthy(self):
+        # Explicit empty --grudge-dir keeps the result independent of the host's
+        # machine-local grudge store.
+        with tempfile.TemporaryDirectory() as d, \
+                tempfile.TemporaryDirectory() as g:
+            with open(os.path.join(d, "runs.jsonl"), "w") as f:
+                f.write(json.dumps({"run_id": "r1", "skill": "siege",
+                                    "timestamp": "2026-01-01T00:00:00Z"}) + "\n")
+            rc, _ = _capture(lambda: ld.main(["--ledger-dir", d, "--grudge-dir", g]))
+            self.assertEqual(rc, 0)
+
+    def test_doctor_report_corrupt_is_unhealthy(self):
+        with tempfile.TemporaryDirectory() as d, \
+                tempfile.TemporaryDirectory() as g:
+            with open(os.path.join(d, "runs.jsonl"), "w") as f:
+                f.write("{broken\n")
+            rc, _ = _capture(lambda: ld.main(["--ledger-dir", d, "--grudge-dir", g]))
+            self.assertEqual(rc, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PR B of the ledger-honesty thread (PR A = #432, merged). The read-path / observability half.

## What this delivers
Three slices, all in `scripts/` (mirrors PR A's pattern):

1. **#402 read-side — skip-and-count identity-less rows.** At each read-path join site, a row lacking a valid `(run_id, skill)` identity (both halves non-empty non-whitespace, via `ledger_append._valid_identity`) is skipped and counted, warning once per call — instead of bucketing under `sha256("unknown:unknown")`. Sites: `reconcile_ledger.{reconcile,compute_brier,reconcile_predicates}`, `render_ledger.{week_summary,predicate_rates}`. Closes PR A's M-1 residual (the `compute_brier` "unknown" fallback).

2. **#400 corruption surfacing — count + warn-once-per-read.** Tolerant readers count unparseable/non-dict lines and emit one summary warn per call: `ledger_reduce.reduce`, `ledger_append.caller_dedup`, `reconcile_ledger.load_jsonl`, `render_ledger.load_runs`, `grudge_query.load_grudges`, `brier_advisory._load_brier` (silent on missing file). Replaces the silent degradation where a single torn line invisibly degrades calibration.

3. **#400 `scripts/ledger_doctor.py` (new)** — on-demand consistency check (gates nothing) mirroring `compass.py doctor`. Pure scanners `scan_jsonl`/`scan_brier`/`scan_grudges`; `main(["--ledger-dir", D, "--grudge-dir", G])` prints a compass-style report, exit 0 healthy / 1 corruption. `scan_jsonl` is byte-mode and mirrors the readers exactly so its corruption counts match what the readers see.

## Quality gate
PASS (3 rounds). The gate caught and fixed two Significants the pre-implementation check missed:
- **S1** — `load_jsonl`/`reduce` lacked `render_ledger.load_runs`'s non-dict guard → a non-object JSON line (`[1,2,3]`) crashed `compute_brier`/`reconcile` with `AttributeError`, the exact corruption class #400 set out to tolerate.
- **S-1** (look-harder) — the new doctor's `scan_jsonl` read text-mode + `.strip()`, diverging from the byte-mode readers on whitespace-only / invalid-UTF-8 / torn-trailing lines → reported corrupt stores "healthy". Fixed by rewriting `scan_jsonl` to mirror `load_runs` byte-for-byte.

5 Minors reviewed and accepted as benign/cosmetic/by-design.

## Testing
- Full gating suite `bash scripts/run_tests.sh` → 47/47 invocations pass.
- Targeted `pytest scripts/test_ledger_core.py scripts/test_stores.py` → 183 passed (+9 over base).

Closes #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)