### PR TITLE
feat(evals): #425 Phase-2 live A/B — minimalism ladder verdict SKIP

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -107,6 +107,31 @@ Each arm's test files are harvested and re-run by a **leave-one-out differential
 
 **The lift is breadth, not taxonomy.** WITH and POOL tie exactly at the aggregate rate (both 15/24), and their *paired* delta is a small +0.05 that does not clear the re-run band (MDE 0.048, `beyond_spread` false) — so no taxonomy lift is resolvable at this sample size, not a demonstrated zero. Both score above the single-agent arms. The value comes from running **five parallel test-writers**, not from the dimension *labels* that tell each one what to look for — a single agent given the full inquisitor framing (MID, 0.458) beats the bare baseline by only +0.08 (arm-mean). So Phase 1's finding survives in a sharper form: **no dimension-taxonomy lift is resolvable here, but the parallel execution breadth adds a real +29 pp** — exactly the half Phase 1 could not see because it stubbed the test-running and ceilinged the baseline. The verdict binds the **detection axis** only (triage/aggregation and the fix-cycle were out of scope and are not condemned). The breadth-vs-structure result carries forward to the minimalism investigation (#425).
 
+## Minimalism Ladder Phase 2: Live WITH/WITHOUT A/B — Verdict SKIP (#425, Claude Opus 4.8)
+
+The #425 investigation asked whether a ponytail-inspired **"Minimalism Ladder"** — a rung-0 carve-out precondition plus an ordered rungs-1–5 pre-write YAGNI gate — earns a slot in `/build`'s implementer prompt, *measured before adoption*. Phase 1 (PR #435) shipped the harness only: a standalone **live-codegen → execute → count-LOC** scorer (`skills/build/evals/minimalism-ladder/`) with a pluggable `codegen` seam. Phase 2 wired live generation into that seam and ran the real A/B.
+
+**Setup.** Two arms over the two pilot tasks (`cli_wordcount`, `fixture_loader`), **n=5 independent trials per arm** = **20 live Opus 4.8 codegen agents**, each blind and independent (it sees only the task requirement + its arm's minimalism block, never the assertions or test inputs):
+
+- **WITHOUT** — today's implementer minimalism DNA only (`build-implementer-prompt.md` GREEN + self-review YAGNI).
+- **WITH** — the *same* DNA + the Minimalism Ladder (rung 0 + rungs 1–5), differing in **exactly** that block.
+
+Each solution is scored on two axes at once: **non-test source LOC** (the claimed win, lower-is-better) and a **frozen correctness-assertion suite** that includes an **absolute carve-out gate** — every counted WITH trial must pass 100% of its validation/security carve-out assertions (reject missing-arg + path-traversal for the CLI; reject non-string/missing `id` for the loader), so the ladder cannot "win" by deleting a guard. The gated `decision.decide()` rule is applied **per task** (raw-LOC distributions can't be pooled across a 14-line and a 6-line task) and combined conservatively (reject if any task rejects → expand if any borderline → adopt only if all adopt → else skip). Ecological-validity note: `/build` dispatches its implementer on **`model: opus`** (`build-implementer-prompt.md:9`), so Opus is the only model an adoption would actually run on.
+
+**Result (n=5, live Opus codegen):**
+
+| Task | WITHOUT median LOC | WITH median LOC | Reduction | Non-carve correctness | Carve-out gate | Verdict |
+|------|--------------------|-----------------|-----------|-----------------------|----------------|---------|
+| `cli_wordcount` | 14 `[14,14,12,14,14]` | 13 `[12,14,14,13,12]` | **+7.1%** | 100% both arms | ✅ all trials, both arms | SKIP |
+| `fixture_loader` | 6 `[6,6,6,6,6]` | 6 `[6,6,6,6,6]` | **+0.0%** | 100% both arms | ✅ all trials, both arms | SKIP |
+| **Overall** | | | | | | **SKIP** |
+
+**Verdict: SKIP — do not adopt the ladder.** Both tasks miss the 15%-reduction adoption bar outright (+7.1% and +0.0%), so `decide()` routes to skip at the reduction gate **before** the borderline/expand branch — this is a **terminal** skip, **not** a borderline case that the n=5 floor says to re-measure at n=10 (a 0%/7.1% signal does not become ≥15% at higher n). Both arms produced fully correct, carve-out-preserving solutions; the WITH solutions were genuinely different (one folded the missing-path and traversal guards into a single check) but no smaller in aggregate.
+
+**Why this is the expected, honest outcome — not a harness failure.** This is exactly the **inverse-capability** prediction the design called: on Opus 4.8, today's minimalism DNA already produces minimal, carve-out-safe code, so an ordered ladder restating the same goal earns no measurable LOC slot. It dovetails with #424's sharpened finding above — *structure/taxonomy* in a prompt adds little resolvable lift on a strong model; what helps is breadth/execution, which a single pre-write checklist does not provide. The harness did its job: it told us **not** to ship, and nothing was wired into `implementer-common.md` / `build-implementer-prompt.md`.
+
+**Honest scope of the negative result.** (1) **2-task pilot** — a directional adopt/skip signal, not a breadth claim. (2) `fixture_loader` **saturated at 6 LOC across all 10 trials** (a guarded JSON one-liner has essentially one minimal form), so it has no headroom to separate the arms — only `cli_wordcount` carried real variation, and it still missed the bar. (3) **Opus-only** — the design predicts a larger lift on weaker models (Sonnet/Haiku), which is **unmeasured here**; but since there is no model-conditional prompt-injection mechanism and `/build` runs implementers on Opus, a weaker-model win could not drive adoption without separate work. (4) The gate proves **functional parity + the *asserted* carve-outs**, not "no quality cut" in general. The investigation closes on this measured null.
+
 ## Sequence Evals: Ordering Discipline Under Pressure (Claude Opus 4.6)
 
 Execution evals test whether a skill works once invoked. Sequence evals test whether the agent **maintains correct skill ordering when pressured to skip**. Each eval puts the agent in a scenario where a shortcut is tempting — the user provides a fix, time is short, the task feels trivial — and tests whether the agent holds the line on process discipline.

--- a/skills/build/evals/minimalism-ladder/README.md
+++ b/skills/build/evals/minimalism-ladder/README.md
@@ -11,10 +11,29 @@ mocks dispatch and checks orchestration behaviour against recorded expectations.
 This subdir instead *runs real code* in a subprocess-free, in-process scorer and
 counts its LOC. It deliberately reuses **none** of those parent modules.
 
-> **Phase 1 scope:** the harness only. There is **no live LLM codegen** here yet
-> — Phase 1 scores pre-generated fixture solution dirs. Wiring a real generator
-> into the `codegen` seam, running the WITH/WITHOUT measurement, and any ladder
-> *adoption* are Phase 2 of `#425`.
+> **Phase 1 scope:** the harness only — Phase 1 scores pre-generated fixture
+> solution dirs. **Phase 2 has now run** (see below): it drove live Opus codegen
+> through the WITH/WITHOUT arms and applied `decision.decide()`.
+>
+> **Phase 2 verdict: SKIP** (`#425`, Opus 4.8) — `cli_wordcount` +7.1% / 0 carve
+> regressions, `fixture_loader` +0.0%; both miss the 15% adoption bar (terminal
+> skip, not borderline → no n=10). Today's minimalism DNA already suffices on the
+> model `/build` runs implementers on, so **nothing was wired into the implementer
+> prompt**. Full write-up: `docs/evals.md` › "Minimalism Ladder Phase 2".
+
+## Phase-2 driver (the live A/B)
+
+- **`phase2_arm_baseline.md`** / **`phase2_arm_ladder.md`** — the two codegen
+  instruction blocks (WITHOUT = today's DNA; WITH = DNA + the ladder, differing in
+  exactly the ladder block). These are the experimental record.
+- **`phase2_driver.py`** — scores already-generated solution dirs under a run root
+  (`<root>/<arm>/<task>/trial<k>/solution.py`) via the **untouched** Phase-1
+  `score_solution(..., codegen=None)` contract, applies `decide()` per task, and
+  combines conservatively. Run: `python3 phase2_driver.py <run_root>`.
+
+> The driver consumes an **ephemeral** run root (the live-generated solution dirs
+> are not committed — public repo, by-design throwaway artifacts), so it is **not**
+> wired into `run_tests.sh`; only the Phase-1 pytest suite gates in CI.
 
 ## Public API (importable as flat top-level names)
 

--- a/skills/build/evals/minimalism-ladder/phase2_arm_baseline.md
+++ b/skills/build/evals/minimalism-ladder/phase2_arm_baseline.md
@@ -1,0 +1,9 @@
+<!-- Phase-2 WITHOUT arm: today's implementer minimalism DNA only (build-implementer-prompt.md GREEN + self-review). No Minimalism Ladder. -->
+You are a Crucible `/build` implementer at the GREEN step. Write the minimal code
+that makes the requirement pass.
+
+**Minimalism (today's DNA):**
+- Write MINIMAL code to satisfy the requirement. Run it in your head; confirm it works.
+- Avoid overbuilding (YAGNI). Build only what was requested — no speculative features,
+  no abstractions for a single call site, no error handling for impossible scenarios.
+- Keep the solution to the minimum necessary code. Clarity is never traded for terseness.

--- a/skills/build/evals/minimalism-ladder/phase2_arm_ladder.md
+++ b/skills/build/evals/minimalism-ladder/phase2_arm_ladder.md
@@ -1,0 +1,32 @@
+<!-- Phase-2 WITH arm: today's DNA + the Minimalism Ladder (rung 0 + rungs 1-5), verbatim from docs/plans/2026-06-14-minimalism-ladder-design.md "The Minimalism Ladder (the content)". Differs from the baseline arm in EXACTLY this ladder block and nothing else. -->
+You are a Crucible `/build` implementer at the GREEN step. Write the minimal code
+that makes the requirement pass.
+
+**Minimalism (today's DNA):**
+- Write MINIMAL code to satisfy the requirement. Run it in your head; confirm it works.
+- Avoid overbuilding (YAGNI). Build only what was requested — no speculative features,
+  no abstractions for a single call site, no error handling for impossible scenarios.
+- Keep the solution to the minimum necessary code. Clarity is never traded for terseness.
+
+**The Minimalism Ladder** (the ordered procedure for reaching that minimal code):
+
+**Rung 0 (precondition — always applies, never minimized, never deferred):**
+Before applying any rung below, the following properties are mandatory and **out
+of scope for minimization**: trust-boundary / input validation, data-integrity &
+data-loss handling, security, correctness of the test assertions, and
+accessibility. The ladder orders only *incidental* code; it never trades away
+these. This rung is not part of the "stop at the first rung that applies"
+control flow — it is a standing constraint on every rung.
+
+Then, for the incidental code of a unit, step through rungs 1–5 top to bottom and
+stop at the first rung that applies:
+
+1. **Does this need to exist?** If the requirement is already met, or the
+   abstraction has a single call site, don't build it (YAGNI).
+2. **Standard library?** Prefer stdlib over a hand-rolled equivalent.
+3. **Native platform feature?** Prefer a built-in language/framework/runtime
+   capability over re-implementing it.
+4. **Already-installed dependency?** Reuse an existing dep before adding code or
+   a new dep.
+5. **Otherwise:** the minimum code that fully and correctly works — a one-line form
+   if one is correct *and clear* (clarity is never traded for terseness).

--- a/skills/build/evals/minimalism-ladder/phase2_driver.py
+++ b/skills/build/evals/minimalism-ladder/phase2_driver.py
@@ -1,0 +1,102 @@
+"""Phase-2 live-A/B driver for the minimalism-ladder eval (#425).
+
+Scores already-generated solution dirs (one `solution.py` per trial, produced by
+live codegen under the WITH/WITHOUT arms) using the UNTOUCHED Phase-1 contract
+(`scorer.score_solution(task, dir, codegen=None)`), then applies the gated
+`decision.decide()` rule PER TASK and combines conservatively.
+
+Run layout (produced by the dispatch step, kept out of git under /tmp):
+
+    <run_root>/<arm>/<task>/trial<k>/solution.py        # arm in {without, with}
+    <run_root>/<arm>/cli_wordcount/trial<k>/fixtures_data/...   # provisioned inputs
+
+decide() compares raw LOC distributions, so it CANNOT pool a ~14-line task with a
+6-line task — it is applied per task. The overall verdict is a conservative
+combine: reject if ANY task rejects; else expand if ANY task is borderline; else
+adopt only if ALL tasks adopt; else skip.
+
+Usage:  python3 phase2_driver.py [run_root]   (default /tmp/ml-phase2)
+"""
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from pathlib import Path
+
+import decision
+import tasks
+from scorer import score_solution
+
+ARMS = ("without", "with")
+TASK_NAMES = ("cli_wordcount", "fixture_loader")
+
+
+def _score_arm(task, arm_dir: Path):
+    results = []
+    for trial_dir in sorted(arm_dir.iterdir(), key=lambda p: int("".join(c for c in p.name if c.isdigit()) or 0)):
+        if not (trial_dir / task.entry_module).exists():
+            raise FileNotFoundError(f"missing {task.entry_module} in {trial_dir}")
+        results.append(score_solution(task, trial_dir))
+    return results
+
+
+def _summ(results):
+    locs = [r.non_test_source_loc for r in results]
+    return {
+        "n": len(results),
+        "loc": locs,
+        "loc_median": statistics.median(locs),
+        "mean_noncarve_pass_rate": statistics.mean(r.assertion_pass_rate for r in results),
+        "carve_out_all_passed": all(r.carve_out_passed for r in results),
+        "carve_out_per_trial": [r.carve_out_passed for r in results],
+    }
+
+
+def _combine(verdicts: dict) -> str:
+    vals = set(verdicts.values())
+    if "reject" in vals:
+        return "reject"
+    if "expand" in vals:
+        return "expand"
+    if vals == {"adopt"}:
+        return "adopt"
+    return "skip"
+
+
+def main(run_root: Path) -> dict:
+    report = {"run_root": str(run_root), "tasks": {}}
+    for name in TASK_NAMES:
+        task = tasks.load_task(name)
+        arm_results = {arm: _score_arm(task, run_root / arm / name) for arm in ARMS}
+        verdict = decision.decide(arm_results["with"], arm_results["without"], band="iqr")
+        report["tasks"][name] = {
+            "verdict": verdict,
+            "without": _summ(arm_results["without"]),
+            "with": _summ(arm_results["with"]),
+        }
+    report["overall"] = _combine({k: v["verdict"] for k, v in report["tasks"].items()})
+    return report
+
+
+def _print(report: dict) -> None:
+    print(f"\n=== minimalism-ladder Phase-2 verdict  (run_root={report['run_root']}) ===")
+    for name, t in report["tasks"].items():
+        w, wo = t["with"], t["without"]
+        red = (wo["loc_median"] - w["loc_median"]) / wo["loc_median"] if wo["loc_median"] else 0.0
+        print(f"\n[{name}]  verdict: {t['verdict'].upper()}")
+        print(f"  WITHOUT  loc={wo['loc']}  median={wo['loc_median']}  "
+              f"noncarve_pass={wo['mean_noncarve_pass_rate']:.3f}  carve_all={wo['carve_out_all_passed']}")
+        print(f"  WITH     loc={w['loc']}  median={w['loc_median']}  "
+              f"noncarve_pass={w['mean_noncarve_pass_rate']:.3f}  carve_all={w['carve_out_all_passed']}")
+        print(f"  LOC median reduction (WITH vs WITHOUT): {red*100:+.1f}%  (adopt needs >=15%)")
+    print(f"\n=== OVERALL: {report['overall'].upper()} ===\n")
+
+
+if __name__ == "__main__":
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/tmp/ml-phase2")
+    rep = main(root)
+    _print(rep)
+    out = root / "phase2_report.json"
+    out.write_text(json.dumps(rep, indent=2, default=str))
+    print(f"report written: {out}")


### PR DESCRIPTION
## What & why

Phase 2 of the **#425 minimalism-ladder investigation** — the *decision*. Phase 1 (PR #435) shipped the live-codegen→execute→count-LOC eval harness with a pluggable `codegen` seam. This PR wires live Opus codegen into that seam, runs the real WITH/WITHOUT A/B, scores it with the **untouched** Phase-1 `score_solution`/`decision.decide()` contract, and records the adopt/skip verdict that closes the investigation.

**Verdict: SKIP — do not adopt the ladder.**

## The run

2 pilot tasks × 2 arms × n=5 independent trials = **20 live Opus 4.8 codegen agents**, each blind (sees only the task requirement + its arm's minimalism block).
- **WITHOUT** = today's implementer minimalism DNA. **WITH** = same DNA + the Minimalism Ladder (rung 0 + rungs 1–5), differing in *exactly* that block (no A/B confound).

| Task | WITHOUT median LOC | WITH median LOC | Reduction | Correctness | Carve-outs | Verdict |
|---|---|---|---|---|---|---|
| `cli_wordcount` | 14 `[14,14,12,14,14]` | 13 `[12,14,14,13,12]` | **+7.1%** | 100% both | ✅ all trials | SKIP |
| `fixture_loader` | 6 `[6,6,6,6,6]` | 6 `[6,6,6,6,6]` | **+0.0%** | 100% both | ✅ all trials | SKIP |
| **Overall** | | | | | | **SKIP** |

Both miss the 15% adoption bar — a **terminal** skip at `decide()`'s reduction gate, not a borderline case (no n=10 expansion). Exactly the **inverse-capability** prediction: on Opus 4.8 — the model `/build` dispatches implementers on (`build-implementer-prompt.md:9`) — today's DNA already produces minimal, carve-out-safe code, so the ordered ladder earns no measurable LOC slot. Dovetails with #424 (lift is breadth/execution, not prompt taxonomy). **No adoption edits made** — nothing wired into the implementer prompts.

## What's in the PR

- `phase2_driver.py` — scores generated solution dirs via the Phase-1 contract, applies `decide()` per task, combines conservatively. Consumes an **ephemeral `/tmp` run root** (live solutions are throwaway, not committed — public repo), so it's deliberately **not** wired into `run_tests.sh`; only the Phase-1 pytest suite gates in CI.
- `phase2_arm_baseline.md` / `phase2_arm_ladder.md` — the two codegen instruction blocks (the experimental record).
- `docs/evals.md` — the SKIP write-up with full honest-scope caveats (2-task pilot, `fixture_loader` saturated at 6 LOC, Opus-only).
- `README.md` — Phase-2 documentation.

## Gates

- **quality-gate PASS** — round-1 red-team (Opus) + look-harder (fresh Opus, tightened rubric) both 0 Fatal / 0 Significant; each reproduced the run and hand-traced `decide()`'s control flow. 2 cosmetic Minors fixed via the fix-agent.
- **Full suite 48/48** (`bash scripts/run_tests.sh`).

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)