### PR TITLE
fix(rcpt_verify): #412 BS1 — spec-truth + documented non-gate for EDIT/WROTE hashes

### DIFF
--- a/scripts/rcpt_verify.py
+++ b/scripts/rcpt_verify.py
@@ -245,13 +245,18 @@ def lint_receipt(text):
             if not m:
                 raise LintError(f"{entry['verb']} missing sha256: {entry['args']}")
             if m.group(1) not in {a["hash"] for a in artifacts.values()}:
-                # artifact may be an on-disk path not re-declared; for lint purposes accept
-                # only if the entry's path itself is in ARTIFACTS as key
+                # DELIBERATE NON-GATE (#412 / BS1), NOT a TODO: the EDIT/WROTE hash is
+                # provenance, not a verified claim. It is intentionally NOT required to
+                # appear in ARTIFACTS — 0000…0 placeholders are the norm, and the dominant
+                # legitimate pattern (EDIT src/foo.ts while only patch.diff is declared) is
+                # structurally identical to a fabricated one, so gating here would flip
+                # committed clean-pass fixtures and the canonical example. Effects are
+                # verified via declared ARTIFACTS (disk-verified under --strict), the
+                # WITNESS, and the receipt-ledger — never via this hash. See
+                # return-convention.md "for each EDIT / WROTE in TRACE".
                 path_m = re.match(r"^(\S+)", entry["args"])
                 if path_m and path_m.group(1) not in artifacts:
-                    # Allow it — file may not be re-emitted as an ARTIFACT; a tightening
-                    # is left as future work. For pilot, we don't hard-fail here.
-                    pass
+                    pass  # accept — deliberate non-gate per the note above (#412)
         elif entry["verb"] == "DISPATCHED":
             if not re.search(r"rcpt-sha256:[0-9a-f]{64}", entry["args"]):
                 raise LintError(f"DISPATCHED missing rcpt-sha256: {entry['args']}")

--- a/scripts/test_rcpt_verify.py
+++ b/scripts/test_rcpt_verify.py
@@ -738,5 +738,42 @@ class TestWitnessSpanCapActual(unittest.TestCase):
             self.assertIn("4 KiB", str(cm.exception))
 
 
+class TestEditWroteHashDeliberateNonGate(unittest.TestCase):
+    """#412 (BS1): an undeclared EDIT/WROTE hash is provenance, NOT a verified claim.
+    A receipt whose TRACE WROTEs a file that is neither a declared ARTIFACT key nor a
+    declared ARTIFACT hash lints PASS — the deliberate trust-model decision
+    (return-convention.md "for each EDIT / WROTE in TRACE"), not a hole. This locks it:
+    a future "fix" that hard-FAILs undeclared EDIT/WROTE would flip these AND the
+    committed clean-pass fixtures + canonical example, so it must be a conscious
+    trust-model change, never an accidental one. Both shapes are covered — the
+    bare-basename PoC and the path-shaped variant (is_path_shaped True), the case an
+    audit is most likely to re-flag as 'but this one looks resolvable.'"""
+
+    BOGUS = "beadfeed" * 8  # 64 hex; matches no declared artifact hash
+
+    def _inject(self, verb, path):
+        # Insert an effect-bearing verb whose hash is undeclared and whose path is
+        # not an ARTIFACTS key, into the known-good corpus receipt[0]. (Fails LOUD,
+        # not silent, if receipt[0]'s shape ever drops its CLAIMS header.)
+        base = _load("sample-corpus/receipts.jsonl")[0]["receipt"]
+        lines = base.splitlines()
+        lines.insert(lines.index("CLAIMS"), f"  4  {verb}  {path}  sha256:{self.BOGUS}")
+        return "\n".join(lines)
+
+    def test_bare_basename_poc_still_passes(self):
+        rv = _import_rv()
+        self.assertEqual(rv.lint_receipt(self._inject("WROTE", "secrets.env")), "PASS")
+
+    def test_path_shaped_poc_still_passes(self):
+        rv = _import_rv()
+        self.assertEqual(rv.lint_receipt(self._inject("WROTE", "src/secrets.env")), "PASS")
+
+    def test_edit_verb_also_passes(self):
+        # The dead branch serves BOTH EDIT and WROTE (rcpt_verify.py:243) — lock both.
+        rv = _import_rv()
+        self.assertEqual(rv.lint_receipt(self._inject("EDIT", "secrets.env")), "PASS")
+        self.assertEqual(rv.lint_receipt(self._inject("EDIT", "src/secrets.env")), "PASS")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/shared/return-convention.md
+++ b/skills/shared/return-convention.md
@@ -150,7 +150,7 @@ for each EXEC in TRACE:
   fail if out= byte-range exceeds 4 KiB
 
 for each EDIT / WROTE in TRACE:
-  fail if sha256:<hex64> missing OR the hash is not declared in ARTIFACTS
+  fail if sha256:<hex64> is missing   # the hash is provenance, NOT verified vs ARTIFACTS (0000… placeholders are normal); effects are verified via declared ARTIFACTS + WITNESS + ledger, never this hash. Deliberate — see #412.
 
 for each DISPATCHED in TRACE:
   fail if rcpt-sha256:<hex64> is missing


### PR DESCRIPTION
## What & why

`scripts/rcpt_verify.py:243` accepts an `EDIT`/`WROTE` TRACE entry whose `sha256` is undeclared **and** whose path is not an ARTIFACTS key. A 2026-06-10 audit kept re-flagging this as a hole (**BS1**, split out of #397) because the dead branch was commented *"a tightening is left as future work."*

Investigation (gated design doc, local-only) established it is **deliberate, not a TODO**:

- EDIT/WROTE hashes are **decorative provenance**, never disk-verified. The dominant *legitimate* receipt pattern (`EDIT src/foo.ts` while only `patch.diff` is declared) is structurally identical to the "attack" PoC, and two committed clean-pass fixtures + the canonical example (`return-convention.md:242-246`) depend on these hashes never being checked.
- The anti-fabrication guarantee lives in **declared ARTIFACTS** (disk-verified under `--strict`) + **WITNESS** + **receipt-ledger**. Orchestrators act on **exit-code FAIL**, never on the `WROTE` line — so the PoC (`WROTE secrets.env sha256:<bogus>`) lints PASS but is **inert at the linter layer**.
- The one genuine residual (manifest-layer `wrote(glob)` tripwire) is a **different layer**, path-based, and untouched by single-receipt linting. Recorded as a known residual (possible future defense-in-depth follow-up).

**Option C** (spec-truth + documented non-gate) was chosen over **B** (hard-gate — breaks the committed trust model + every fixture) and **D** (partial Tier-2 check — trivially evaded by the `0000…0` placeholder or a non-resolvable path, and muddies the "decorative provenance" contract). **No linter verdict changes.**

## Changes
- **`return-convention.md:153`** — drop the false *"OR the hash is not declared in ARTIFACTS"* clause; add an inline deliberate-decision note. Done as a 1-line→1-line replacement to avoid shifting downstream `:NNN` anchors.
- **`rcpt_verify.py:248-256`** — replace the misleading "future work" comment with a deliberate-#412-decision comment. Control flow and the `pass` are **unchanged** (behavior identical).
- **`test_rcpt_verify.py`** — new `TestEditWroteHashDeliberateNonGate` locks the decision: undeclared EDIT/WROTE (bare-basename + path-shaped, **both** verbs) still lint PASS, so a future accidental "fix" must be a conscious trust-model change.

## Verification
- `/quality-gate` run on the **design doc**: PASS clean, independent look-harder confirmation (0F/0S).
- `/quality-gate` run on the **code diff**: PASS clean, independent look-harder confirmation (0F/0S).
- `bash scripts/run_tests.sh` → **50/50** suite invocations pass; `test_rcpt_verify.py` 61 → 64; `rcpt_verify.py --selftest` OK.

## Scope notes
- Closes BS1, the last open sub-defect of #397 (the other three shipped in #413). Closing both.
- Pre-existing, out-of-scope: `lint_receipt` raises a raw `ValueError` (not a clean `LintError`) on a WITNESS with misordered fields — noted, not fixed here (scope discipline).

Closes #412
Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)