### PR TITLE
fix(reconcile_ledger): #439 restore falsification discovery (merge --first-parent + squash commits)

### DIFF
--- a/docs/research/2026-06-10-audit-scripts-milestone16.md
+++ b/docs/research/2026-06-10-audit-scripts-milestone16.md
@@ -147,6 +147,17 @@ The `/audit scripts/` run read these in full and grounded findings in them: `led
 > #394–#406 issue. It is tracked by dedicated follow-up issue **#408** (milestone 16) so a later
 > Opus-session pass can complete coverage of the un-audited trust-critical modules.
 
+### #408 update (2026-06-22, focused Opus pass)
+
+Read **in full** and grounded findings: `rcpt_verify.py`, `test_rcpt_verify.py`, `reconcile_ledger.py`, `calibrate_tolerance.py` (+ `test_ledger_core.py`, `test_brier_advise.py` for test-health). Findings filed:
+
+- **#439 (Fatal)** — `reconcile_ledger` falsification/Brier is a no-op in practice: `git show --name-only` without `-m` suppresses merge diffs + squash-merged `fix(...)` commits aren't `--merges` → `falsified += 0` always; `fix_branch_sizes` p90=0 sample-collapse at ≥30 merges.
+- **#440 (Significant)** — `rcpt_verify` unguarded `int(TRACE#…)` at 5 sites → `ValueError` not `LintError`; `--eval` batch catches only `LintError` so one poisoned row aborts the batch.
+- **#441 (Significant)** — untested trust-critical surface: reconcile GIT layer `:835-1067` (where #439 lives, zero coverage), `calibrate_tolerance` body, `parse_witness` grammar.
+- **#442 (Significant + minors)** — `calibrate_tolerance` crash-on-malformed; drifted duplicated logic (forked ISO parsers reconcile/render; 5× `out=#range` regexes; 3× expect-fail); minor sweep. (`_glob_match` drift → already **#401**.)
+
+**Still DEFERRED (remaining #408 boxes):** `render_ledger.py` (WHS honest-count + 3×-rolling-median inflation detector), `test_catalog.py`, `grudge_query.py` full read, `compass.py:180-1182` field caps + `MUTEX_PAIRS`. #408 stays open for these.
+
 ## Provenance
 
 - Lens reports (source): `~/.claude/projects/-home-user-crucible/memory/audit/scratch/2026-06-10T19-29-36/{architecture,blindspots,consistency-a,consistency-b,robustness,testhealth}-findings.md`, `coverage-map.md`, `manifest.md` — machine-local, reclaimable.

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -847,6 +847,10 @@ def _git(args: List[str], cwd: Optional[str] = None) -> Optional[str]:
 
 
 _FIX_MERGE_RE = re.compile(r"(?:^|[\s/'\"])(?:hot)?fix/", re.I)
+# Conventional-commit subject of a SQUASH-merged fix landing: `fix:`,
+# `fix(scope):`, `fix(scope)!:`, `hotfix:`. Anchored at start so `prefix:`,
+# `fixture:`, `affix:` do NOT match (#439 — squash workflow has no fix/* merge).
+_FIX_COMMIT_RE = re.compile(r"^(?:hot)?fix(?:\([^)]*\))?!?:", re.I)
 
 
 def _is_fix_merge_subject(subject: str) -> bool:
@@ -860,6 +864,17 @@ def _is_fix_merge_subject(subject: str) -> bool:
     return _FIX_MERGE_RE.search(subject) is not None
 
 
+def _is_fix_commit_subject(subject: str) -> bool:
+    """True iff a non-merge commit subject is a conventional-commit fix landing
+    (`fix:` / `fix(scope):` / `fix(scope)!:` / `hotfix:`). This is the squash-
+    merge analog of `_is_fix_merge_subject`: repos that squash-merge (the
+    default here) land a fix as a single non-merge commit, never a fix/* merge,
+    so the merge-only discovery missed every one of them (#439)."""
+    if not subject:
+        return False
+    return _FIX_COMMIT_RE.match(subject) is not None
+
+
 def discover_candidates(lookback_days: int = 30) -> List[dict]:
     """Discover fix/* hotfix/* merges within lookback_days, plus regression
     issues with a referenced commit (best-effort).
@@ -871,25 +886,33 @@ def discover_candidates(lookback_days: int = 30) -> List[dict]:
         _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=lookback_days)
     ).strftime("%Y-%m-%d")
 
-    # Merge commits whose merged branch matches fix/* or hotfix/*. We look at
-    # merge commits in the lookback window and inspect the merge subject for a
-    # fix/hotfix branch name.
-    log = _git([
-        "log", "--merges", f"--since={since}",
-        "--pretty=format:%H%x1f%cI%x1f%s",
-    ])
-    if log:
+    # A fix lands one of two ways, depending on the repo's merge policy. We
+    # discover both on the mainline first-parent chain (so feature-branch internal
+    # commits are never double-counted against their own merge):
+    #   (1) MERGE workflow — a merge commit whose subject names a fix/* branch.
+    #   (2) SQUASH workflow (the default here) — a single non-merge commit with a
+    #       conventional-commit `fix(...)` subject. Missing this class was the #439
+    #       Fatal: merge-only discovery found zero squash-merged fixes.
+    for fp_args, is_fix in (
+        (["--merges"], _is_fix_merge_subject),
+        (["--no-merges"], _is_fix_commit_subject),
+    ):
+        log = _git([
+            "log", "--first-parent", *fp_args, f"--since={since}",
+            "--pretty=format:%H%x1f%cI%x1f%s",
+        ])
+        if not log:
+            continue
         for line in log.splitlines():
             parts = line.split("\x1f")
             if len(parts) < 3:
                 continue
             sha, when, subject = parts[0], parts[1], parts[2]
-            if not _is_fix_merge_subject(subject):
+            if not is_fix(subject):
                 continue
-            touched = _touched_files(sha)
             candidates.append({
                 "commit": sha,
-                "touched_files": touched,
+                "touched_files": _touched_files(sha),
                 "merge_time": when,
             })
 
@@ -908,7 +931,11 @@ def discover_candidates(lookback_days: int = 30) -> List[dict]:
 
 
 def _touched_files(sha: str) -> List[str]:
-    out = _git(["show", "--name-only", "--pretty=format:", sha])
+    # `--first-parent` is load-bearing (#439): plain `git show` emits NO diff for
+    # a merge commit, so every fix/* merge candidate got empty touched_files and
+    # walkback falsification silently never fired. `--first-parent` shows the
+    # merge's net change vs mainline; on a non-merge (squash) commit it is a no-op.
+    out = _git(["show", "--first-parent", "--name-only", "--pretty=format:", sha])
     if not out:
         return []
     return [ln.strip() for ln in out.splitlines() if ln.strip()]
@@ -1034,26 +1061,33 @@ def discover_reference_commits(tokens: List[str], lookback_days: int = 30) -> Li
 
 
 def fix_branch_sizes(days: int = 90) -> List[int]:
-    """Touched-file counts of fix/hotfix merges over the prior `days` (a
-    DISTINCT 90-day window from the 30-day candidate lookback)."""
+    """Touched-file counts of fix/hotfix landings over the prior `days` (a
+    DISTINCT 90-day window from the 30-day candidate lookback). Counts BOTH
+    fix/* merges and squash-merged `fix(...)` commits (#439) — counting only
+    merges left every size at 0 on a squash-merge repo, collapsing the p90
+    cross-cut threshold."""
     since = (
         _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=days)
     ).strftime("%Y-%m-%d")
-    log = _git([
-        "log", "--merges", f"--since={since}",
-        "--pretty=format:%H%x1f%s",
-    ])
     sizes: List[int] = []
-    if not log:
-        return sizes
-    for line in log.splitlines():
-        parts = line.split("\x1f")
-        if len(parts) < 2:
+    for fp_args, is_fix in (
+        (["--merges"], _is_fix_merge_subject),
+        (["--no-merges"], _is_fix_commit_subject),
+    ):
+        log = _git([
+            "log", "--first-parent", *fp_args, f"--since={since}",
+            "--pretty=format:%H%x1f%s",
+        ])
+        if not log:
             continue
-        sha, subject = parts[0], parts[1]
-        if not _is_fix_merge_subject(subject):
-            continue
-        sizes.append(len(_touched_files(sha)))
+        for line in log.splitlines():
+            parts = line.split("\x1f")
+            if len(parts) < 2:
+                continue
+            sha, subject = parts[0], parts[1]
+            if not is_fix(subject):
+                continue
+            sizes.append(len(_touched_files(sha)))
     return sizes
 
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -54,6 +54,9 @@ run python3 scripts/test_brier_advise.py
 # --- Ledger pipeline pure core (#398 Phase 1) ---
 run python3 scripts/test_ledger_core.py
 
+# --- Ledger GIT layer: falsification discovery (#439 / #441) ---
+run python3 scripts/test_reconcile_git.py
+
 # --- Lock state machines + crash recovery (#398 Phase 2) ---
 run python3 scripts/test_locks.py
 

--- a/scripts/test_reconcile_git.py
+++ b/scripts/test_reconcile_git.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""GIT-layer integration tests for reconcile_ledger.py (#439 / #441).
+
+The GIT layer (`discover_candidates`, `_touched_files`, `fix_branch_sizes`) is
+the SOLE producer of the falsification input the well-tested pure core consumes
+to flip a Brier `actual`. Before this file it had ZERO coverage (#441), and that
+gap hid a Fatal (#439): walkback falsification was a no-op in practice because
+(a) `git show --name-only` without `--first-parent` suppresses merge diffs, and
+(b) squash-merged `fix(...)` commits are not `--merges` so were never discovered.
+
+These tests build a real on-disk git repo (a merge of a `fix/*` branch AND a
+squash-style `fix(...)` commit) and run the GIT layer with cwd inside it — the
+same integration style as test_brier_advise.py. Pure stdlib unittest; no central
+store is touched.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from scripts import reconcile_ledger as rl  # noqa: E402
+
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", repo, *args], check=True,
+                   capture_output=True, text=True)
+
+
+def _write(repo, name, content="x\n"):
+    with open(os.path.join(repo, name), "w") as f:
+        f.write(content)
+
+
+class GitLayerFalsificationTest(unittest.TestCase):
+    """Builds: base commit → fix/foo branch (2 files) merged --no-ff →
+    a squash-style `fix(parser): … (#NN)` commit (1 file) → a non-fix commit
+    and a `prefix(...)` decoy. Both real fix landings must be discovered with
+    non-empty touched_files."""
+
+    def _build_repo(self, repo):
+        _git(repo, "init", "-q", "-b", "main")
+        _git(repo, "config", "user.email", "t@t")
+        _git(repo, "config", "user.name", "t")
+        _write(repo, "a.txt", "1\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "base")
+        # real merge of a fix/* branch (2 files)
+        _git(repo, "checkout", "-qb", "fix/foo")
+        _write(repo, "b.txt")
+        _write(repo, "c.txt")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "work on fix")
+        _git(repo, "checkout", "-q", "main")
+        _git(repo, "merge", "--no-ff", "-q", "fix/foo", "-m", "Merge branch 'fix/foo'")
+        # squash-style fix landing (single non-merge commit, conventional subject, 1 file)
+        _write(repo, "d.txt")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "fix(parser): handle empty input (#123)")
+        # decoys that must NOT be discovered
+        _write(repo, "e.txt")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "feat(core): unrelated feature")
+        _write(repo, "f.txt")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "prefix(x): not a fix")
+
+    def test_discover_candidates_finds_merge_and_squash_with_files(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self._build_repo(repo)
+            old = os.getcwd()
+            os.chdir(repo)
+            try:
+                cands = rl.discover_candidates(30)
+            finally:
+                os.chdir(old)
+        touched = sorted(sorted(c["touched_files"]) for c in cands)
+        # Exactly the two real fix landings, each with its real files.
+        self.assertEqual(len(cands), 2, f"expected merge+squash, got {cands}")
+        self.assertIn(["b.txt", "c.txt"], touched)   # merge diff (was [] pre-fix)
+        self.assertIn(["d.txt"], touched)            # squash commit (was undiscovered)
+        for c in cands:
+            self.assertTrue(c["touched_files"], f"empty touched_files: {c}")
+            self.assertTrue(c["merge_time"])
+
+    def test_fix_branch_sizes_counts_merge_and_squash(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self._build_repo(repo)
+            old = os.getcwd()
+            os.chdir(repo)
+            try:
+                sizes = rl.fix_branch_sizes(90)
+            finally:
+                os.chdir(old)
+        # merge brought 2 files, squash brought 1; decoys contribute nothing.
+        self.assertEqual(sorted(sizes), [1, 2], f"got {sizes}")
+
+
+class FixCommitSubjectTest(unittest.TestCase):
+    """Pure matcher for squash-merged conventional-commit fix subjects (#441)."""
+
+    def test_matches_conventional_fix_subjects(self):
+        for s in ("fix: x", "fix(scope): x", "fix(rcpt_verify): #412 (#438)",
+                  "fix(core)!: breaking", "hotfix: urgent", "HotFix(x): y"):
+            self.assertTrue(rl._is_fix_commit_subject(s), s)
+
+    def test_rejects_non_fix_subjects(self):
+        for s in ("feat(x): y", "prefix(x): y", "affix: y", "fixture: y",
+                  "chore: fix typo", "refactor: fix naming", "", "fix"):
+            self.assertFalse(rl._is_fix_commit_subject(s), s)
+
+
+class CrossCutThresholdBoundaryTest(unittest.TestCase):
+    """cross_cut_threshold_from p90-vs-bootstrap boundary at N=30 (#441)."""
+
+    def test_below_min_samples_uses_bootstrap(self):
+        self.assertEqual(rl.cross_cut_threshold_from([5] * 29),
+                         rl.BOOTSTRAP_CROSS_CUT)
+
+    def test_at_min_samples_uses_p90(self):
+        # 30 samples: nearest-rank p90 = ceil(0.9*30)=27th of sorted 1..30 → 27.
+        self.assertEqual(rl.cross_cut_threshold_from(list(range(1, 31))), 27)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

The calibration **falsification core was a no-op in practice** (Fatal, surfaced by the #408 audit and reproduced). Walkback never falsified any verdict because:

1. `_touched_files` ran `git show --name-only` **without `--first-parent`** → merge commits emit no diff → every `fix/*` merge candidate had empty `touched_files` → walkback skipped it.
2. `discover_candidates` / `fix_branch_sizes` only scanned `git log --merges` → **squash-merged `fix(...)` commits** (this repo's default merge policy — e.g. PRs #437/#438) were never discovered.

Net: `falsified += 0` always — Brier scores never got corrected by reality, and `fix_branch_sizes` returned all-zero (collapsing the p90 cross-cut threshold once ≥30 fix-merges exist). This is the repo's "epistemic backbone" (CLAUDE.md).

## Fix
- **`_touched_files`** adds `--first-parent` (net change vs mainline on merges; no-op on squash/non-merge commits).
- New **`_is_fix_commit_subject`** matches conventional-commit fix landings (`fix:` / `fix(scope):` / `fix(scope)!:` / `hotfix:`), start-anchored so `prefix:`/`fixture:`/`affix:` don't match.
- **`discover_candidates` + `fix_branch_sizes`** now run two `--first-parent` passes on the mainline chain — `--merges` (fix/* branch) and `--no-merges` (conventional `fix(...)`) — **disjoint** (feature-branch internals stay off the first-parent path), so no double-counting.

## Tests
New **`scripts/test_reconcile_git.py`**: builds a real git repo (a `fix/*` merge + a squash `fix(...)` commit + `feat`/`prefix` decoys) and asserts both fix landings are discovered with correct `touched_files`; plus pure matcher + `cross_cut_threshold_from` p90-boundary tests — **closing the #441 GIT-layer coverage gap** (was zero coverage). Wired into `run_tests.sh` (50→51 suite invocations).

## Verification
- `bash scripts/run_tests.sh` → **51/51** pass (with `CRUCIBLE_CALIBRATION_DISABLED=1`, ledger-touching).
- `/quality-gate` PASS clean — round 1 + **independent look-harder** (0F/0S each); look-harder verified the new test **fails against pre-fix HEAD** (non-vacuous) and that the two passes are disjoint with the FAIL-side Brier flip (`via=="predicate"`) untouched.

## Scope notes
- Surgical fix to the discovery path. `discover_revert_candidates` (unchanged) benefits from the `_touched_files` `--first-parent` fix automatically; revert-squash discovery is out of scope.
- Accepted residuals (audit Minors, non-gating): `fix #NN:`-style non-conventional subjects undiscovered (policy-shaped); octopus-merge over-inclusion (pre-existing); gh-regression SHA / candidate overlap (harmless — deduped downstream by `seen_hashes`).
- Bundles the #408 coverage-map doc update (records the audit + filed #439–442).

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)