### PR TITLE
fix(rcpt_verify): #440 guard int(TRACE#N) — clean LintError, not ValueError; isolate --eval batch

### DIFF
--- a/scripts/rcpt_verify.py
+++ b/scripts/rcpt_verify.py
@@ -217,6 +217,22 @@ def parse_witness(body):
     return {"kind": kind, "payload": payload.strip(), "expect_fail": expect_fail, "ran": ran.strip()}
 
 
+_TRACE_REF_RE = re.compile(r"^TRACE#([0-9]+)$")
+
+
+def _trace_idx(ref: str) -> int:
+    """Parse N from a `TRACE#N` reference. Raises LintError (NOT a raw ValueError
+    traceback) on a non-numeric / empty / trailing-junk suffix. Receipt text is
+    attacker-influenced, so a malformed citation must lint-FAIL cleanly — and an
+    uncaught ValueError here used to abort the whole `--eval` batch (#440).
+    Anchored on ASCII digits only (`str.isdigit()` would admit e.g. superscripts
+    that `int()` then rejects)."""
+    m = _TRACE_REF_RE.match(ref)
+    if not m:
+        raise LintError(f"malformed TRACE# reference: {ref!r}")
+    return int(m.group(1))
+
+
 def lint_receipt(text):
     sections = parse_receipt(text)
     # VERDICT
@@ -264,7 +280,7 @@ def lint_receipt(text):
     for c in claims:
         cit = c["citation"]
         if cit.startswith("TRACE#"):
-            idx = int(cit[len("TRACE#"):])
+            idx = _trace_idx(cit)
             if not 1 <= idx <= len(trace):
                 raise LintError(f"CLAIM citation TRACE#{idx} does not resolve")
         else:
@@ -282,7 +298,7 @@ def lint_receipt(text):
         if ran.startswith("UNRUNNABLE"):
             raise LintError("WITNESS ran=UNRUNNABLE not permitted on PASS")
     if ran.startswith("TRACE#"):
-        idx = int(ran[len("TRACE#"):])
+        idx = _trace_idx(ran)
         if not 1 <= idx <= len(trace):
             raise LintError(f"WITNESS ran=TRACE#{idx} does not resolve")
         verb = trace[idx - 1]["verb"]
@@ -314,7 +330,7 @@ def lint_receipt(text):
         if not has_skipped:
             for c in claims:
                 if c["key"] in {"tests-ran", "tests-pass"} and c["citation"].startswith("TRACE#"):
-                    idx = int(c["citation"][len("TRACE#"):])
+                    idx = _trace_idx(c["citation"])
                     cited = trace[idx - 1]
                     if cited["verb"] != "EXEC":
                         raise LintError(f"CLAIM {c['key']} cites TRACE#{idx} which is {cited['verb']}, not EXEC")
@@ -662,7 +678,7 @@ def tier2_witness(witness, trace, root, strict, verdict):
     notes; raises LintError on FAIL (incl. verify_witness's byte-identical messages)."""
     if not witness["ran"].startswith("TRACE#"):
         return []
-    idx = int(witness["ran"][len("TRACE#"):])
+    idx = _trace_idx(witness["ran"])
     if not 1 <= idx <= len(trace):
         return []
     cited = trace[idx - 1]
@@ -711,7 +727,7 @@ def _eval_tier2(witness, trace, bodies, verdict):
     Raises LintError (byte-identical message) on FAIL; the caller prints it as LINT-FAIL."""
     if not witness["ran"].startswith("TRACE#"):
         return
-    idx = int(witness["ran"][len("TRACE#"):])
+    idx = _trace_idx(witness["ran"])
     if not 1 <= idx <= len(trace):
         return
     cited = trace[idx - 1]
@@ -748,7 +764,15 @@ def _eval_text(path) -> str:
     for line in _read_path_arg(path).splitlines():
         if not line.strip():
             continue
-        rec = json.loads(line)
+        try:
+            rec = json.loads(line)
+        except ValueError:  # json.JSONDecodeError is a ValueError subclass
+            # Per-record fault isolation (#440): a malformed line is surfaced as a
+            # LINT-FAIL row, never an aborted batch. The contract is "classify each
+            # record, always exit 0"; one corrupt line must not suppress the rest.
+            total += 1
+            out.append(f"{'?':30s}  LINT-FAIL  malformed JSON line")
+            continue
         if not rec.get("receipt"):
             continue
         total += 1
@@ -970,7 +994,7 @@ def _selftest_crosscheck(rec, bodies):
     sections = parse_receipt(text)
     trace = parse_trace(sections["TRACE"])
     witness = parse_witness(sections["WITNESS"])
-    idx = int(witness["ran"][len("TRACE#"):])
+    idx = _trace_idx(witness["ran"])
     cited = trace[idx - 1]
     art = derive_art_name(cited, verdict)
     inline_disp = _eval_record(rec)[0]

--- a/scripts/test_rcpt_verify.py
+++ b/scripts/test_rcpt_verify.py
@@ -775,5 +775,71 @@ class TestEditWroteHashDeliberateNonGate(unittest.TestCase):
         self.assertEqual(rv.lint_receipt(self._inject("EDIT", "src/secrets.env")), "PASS")
 
 
+class TestTraceRefGuard(unittest.TestCase):
+    """#440: a malformed `TRACE#<non-digits>` reference (attacker-influenced
+    receipt text) must lint-FAIL cleanly (LintError), NOT raise a raw ValueError
+    traceback. Six sites fed `int()` an unvalidated suffix; this locks them, and
+    the --eval batch isolation that the ValueError used to break."""
+
+    def _base(self):
+        return _load("sample-corpus/receipts.jsonl")[0]["receipt"]
+
+    def _sub(self, text, old, new):
+        self.assertIn(old, text, f"fixture drift: {old!r} not in receipt")
+        return text.replace(old, new, 1)
+
+    def test_claim_citation_non_numeric_is_lint_error(self):
+        rv = _import_rv()
+        bad = self._sub(self._base(), "from=TRACE#2", "from=TRACE#2x")
+        with self.assertRaises(rv.LintError):
+            rv.lint_receipt(bad)
+
+    def test_witness_ran_trailing_junk_is_lint_error(self):
+        rv = _import_rv()
+        # WITNESS ran= captured greedily → trailing junk reaches int() (the bug
+        # hit live during the #412 gate). Must be a clean LintError.
+        bad = self._sub(self._base(), "ran=TRACE#3", "ran=TRACE#3 junk")
+        with self.assertRaises(rv.LintError):
+            rv.lint_receipt(bad)
+
+    def test_cli_malformed_citation_exit1_no_traceback(self):
+        bad = self._sub(self._base(), "from=TRACE#2", "from=TRACE#2x")
+        r = run("--tier1", "-", stdin=bad)
+        self.assertEqual(r.returncode, 1, r.stderr)
+        self.assertNotIn("Traceback", r.stderr)
+        self.assertNotIn("ValueError", r.stderr)
+
+    def test_eval_batch_isolates_poisoned_record(self):
+        # A good record followed by one whose citation used to crash the WHOLE
+        # batch (ValueError escaping _eval_record's LintError-only catch).
+        good = self._base()
+        bad = self._sub(good, "from=TRACE#2", "from=TRACE#2x")
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "corpus.jsonl"
+            p.write_text(
+                json.dumps({"dispatch-id": "good", "receipt": good}) + "\n" +
+                json.dumps({"dispatch-id": "poisoned", "receipt": bad}) + "\n"
+            )
+            r = run("--eval", str(p))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("good", r.stdout)
+        self.assertIn("poisoned", r.stdout)
+        self.assertIn("LINT-FAIL", r.stdout)        # the bad one classified, not crashed
+        self.assertNotIn("Traceback", r.stdout + r.stderr)
+
+    def test_eval_batch_isolates_malformed_json_line(self):
+        good = self._base()
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "corpus.jsonl"
+            p.write_text(
+                json.dumps({"dispatch-id": "good", "receipt": good}) + "\n" +
+                "{not valid json\n"
+            )
+            r = run("--eval", str(p))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("good", r.stdout)
+        self.assertNotIn("Traceback", r.stdout + r.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What & why

`scripts/rcpt_verify.py` (the anti-fabrication trust boundary every gating orchestrator shells out to) fed `int()` an **unvalidated suffix** at six `TRACE#<ref>` sites. Malformed / hostile receipt text raised a raw **`ValueError` traceback** instead of a clean `LintError`:
- a CLAIM `from=TRACE#2x`
- a misordered WITNESS `ran=TRACE#2  pattern=...` (greedy `ran=` capture leaves trailing junk — the bug hit live during the #412 gate this session)

On `--eval`, `_eval_record` caught only `LintError`, so that `ValueError` **aborted the whole batch** — violating the documented "classify each record, always exit 0" contract (and crashing `--selftest`/CI on a corrupt fixture). Found + reproduced by the #408 audit.

## Fix
- New **`_trace_idx(ref)`** — `^TRACE#([0-9]+)$` (ASCII digits; `str.isdigit()` would admit superscripts `int()` rejects) → raises `LintError` on a non-numeric/empty/trailing-junk suffix. Replaces all **six** `int(ref[len("TRACE#"):])` sites (`lint_receipt` CLAIM/WITNESS/tests-pass, `tier2_witness`, `_eval_tier2`, `_selftest_crosscheck`). Tier-2 sites run after Tier-1 validation, so the new raise is unreachable there in normal flow (defense-in-depth + consistency).
- **`_eval_text`** wraps the per-line `json.loads` so a malformed JSON line becomes a `LINT-FAIL` row, not an aborted batch — closing the other `--eval` abort vector the audit named.

## Tests
New **`TestTraceRefGuard`** (5): malformed CLAIM citation + greedy-WITNESS-`ran=` → `LintError` (not `ValueError`); CLI exits 1 with a bullet, no traceback; the `--eval` batch isolates a poisoned record **and** a malformed JSON line (both still exit 0, classified). Verified **non-vacuous** (all 5 fail against pre-fix code). `rcpt_verify` 64→69.

## Verification
- `bash scripts/run_tests.sh` → **51/51**; `rcpt_verify.py --selftest` OK.
- `/quality-gate` PASS clean — round 1 + **independent look-harder** (0F/0S each); look-harder confirmed all 6 sites routed, the regex rejects nothing valid, and the Tier-2 `LintError`-vs-`return` change is unreachable for inputs Tier-1 didn't already catch. 1 Minor (redundant `except` tuple) quick-fixed.

## Scope notes
This closes the rcpt_verify half of the #408 audit's findings. Remaining audit issues: #441 (untested surface — GIT layer covered by #439; `calibrate_tolerance`/`parse_witness` remain), #442 (calibrate crash + drifted logic), #408 deferred boxes.

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)