### PR TITLE
fix(scripts): #442 — calibrate crash-guard + trust/calibration dedup (G5/G6a/G6b/G6c)

### DIFF
--- a/scripts/calibrate_tolerance.py
+++ b/scripts/calibrate_tolerance.py
@@ -73,9 +73,11 @@ def _per_fixture_pass_rate(fixture_result: dict) -> float:
     expectations = fixture_result.get("expectations", [])
     if not expectations:
         return 0.0
-    # All expectations share trial count; pull from first.
-    per_trial_lists = [er["per_trial_verdicts"] for er in expectations]
-    n_trials = len(per_trial_lists[0]) if per_trial_lists else 0
+    # #442 G5: tolerate malformed input — a missing per_trial_verdicts key and
+    # ragged per-trial lists must degrade gracefully, not traceback. Evaluate
+    # only the common trial prefix (min length across expectations).
+    per_trial_lists = [er.get("per_trial_verdicts", []) for er in expectations]
+    n_trials = min((len(lst) for lst in per_trial_lists), default=0)
     if n_trials == 0:
         return 0.0
     passes = 0

--- a/scripts/rcpt_verify.py
+++ b/scripts/rcpt_verify.py
@@ -14,7 +14,7 @@ entry on (dispatch_id, rcpt_sha256, verdict); mismatch = FAIL. Without it, a rec
 has DISPATCHED lines reports `UNVERIFIABLE: ledger binding (no --ledger)` (advisory).
 """
 from __future__ import annotations
-import json, re, sys, hashlib, pathlib
+import json, re, sys, hashlib, pathlib, typing
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 CORPUS_DIR = ROOT / "eval/ledger-return-protocol"
@@ -132,12 +132,38 @@ def parse_trace(body):
     return out
 
 
+class OutRange(typing.NamedTuple):
+    artifact: str
+    kind: str   # "L" (line) | "B" (byte)
+    start: int
+    end: int
+
+
+# #442 G6b: the ONE canonical out=<artifact>#<KIND><a>-<KIND><b> parser, accepting
+# EXACTLY one well-formed range as a complete token. [^#\s]+ rejects '#' in the
+# artifact; \2 back-ref rejects mixed kind (#L1-B5); (?!#[LB]\d) negative-lookahead
+# rejects a trailing second #<range> (double-#range) WITHOUT over-rejecting other
+# trailing chars (out=a#L1-L5 mode=x / out=a#L1-L5,x still parse). A None parse
+# makes check_exec_range_bound LINT-FAIL at Tier-1 before any Tier-2 site, so all 5
+# (formerly divergent: old greedy/last vs the non-greedy first-range readers) now
+# agree. Replaces 5 divergent regexes.
+_OUT_RANGE_RE = re.compile(r"out=([^#\s]+)#([LB])(\d+)-\2(\d+)(?!#[LB]\d)")
+
+
+def parse_out_range(args_str):
+    """Parse out=<artifact>#<KIND><a>-<KIND><b>. Returns OutRange or None."""
+    m = _OUT_RANGE_RE.search(args_str)
+    if not m:
+        return None
+    return OutRange(m.group(1), m.group(2), int(m.group(3)), int(m.group(4)))
+
+
 def check_exec_range_bound(args_str):
     """out=<artifact>#<range> — check range ≤ 4 KiB."""
-    m = re.search(r"out=\S+#([LB])(\d+)-\1(\d+)", args_str)
-    if not m:
+    r = parse_out_range(args_str)
+    if not r:
         raise LintError(f"EXEC missing out= or bad range: {args_str}")
-    kind, a, b = m.group(1), int(m.group(2)), int(m.group(3))
+    kind, a, b = r.kind, r.start, r.end
     if b < a:
         raise LintError(f"EXEC range negative: {args_str}")
     # Tier-1 is disk-free, so a line range can only be ESTIMATED (80 bytes/line). This
@@ -253,9 +279,9 @@ def lint_receipt(text):
     for entry in trace:
         if entry["verb"] == "EXEC":
             check_exec_range_bound(entry["args"])
-            m = re.search(r"out=(\S+?)#", entry["args"])
-            if m and m.group(1) not in artifacts:
-                raise LintError(f"EXEC out= artifact not in ARTIFACTS: {m.group(1)}")
+            r = parse_out_range(entry["args"])
+            if r and r.artifact not in artifacts:
+                raise LintError(f"EXEC out= artifact not in ARTIFACTS: {r.artifact}")
         elif entry["verb"] in {"EDIT", "WROTE"}:
             m = re.search(r"sha256:([0-9a-f]{64})", entry["args"])
             if not m:
@@ -566,18 +592,29 @@ def derive_art_name(cited, verdict):
     tier2_verify_fail (FAIL: EXEC out= only) do. Returns None when no body lookup
     applies (→ clean). Shared by verify_witness (message/control) and the --eval
     caller (body fetch) so the two Tier-2 paths cannot diverge on art_name."""
-    m = re.search(r"out=(\S+?)#([LB]\d+-[LB]\d+)", cited["args"]) if cited["verb"] == "EXEC" else None
+    r = parse_out_range(cited["args"]) if cited["verb"] == "EXEC" else None
     if verdict == "FAIL":
         # tier2_verify_fail — EXEC-only (lint.py:370-373)
-        if not m:
+        if not r:
             return None
-        return m.group(1)
+        return r.artifact
     # verdict == PASS — tier2_verify (lint.py:315-326)
-    if not m and cited["verb"] in {"READ", "WROTE"}:
+    if not r and cited["verb"] in {"READ", "WROTE"}:
         path_m = re.match(r"^(\S+)", cited["args"])
         return path_m.group(1) if path_m else None
-    if m:
-        return m.group(1)
+    if r:
+        return r.artifact
+    return None
+
+
+def _expect_fail_pattern(expect_fail):
+    """Regex source for a WITNESS expect-fail sig: /regex/ verbatim, "literal"
+    escaped, else None (e.g. an exit= clause). #442 G6c — one source for the
+    two byte-identical derivation blocks in verify_witness."""
+    if expect_fail.startswith("/") and expect_fail.endswith("/"):
+        return expect_fail[1:-1]
+    if expect_fail.startswith('"') and expect_fail.endswith('"'):
+        return re.escape(expect_fail[1:-1])
     return None
 
 
@@ -609,11 +646,7 @@ def verify_witness(body_text, witness, verdict, cited) -> bool:
         # tier2_verify_fail (lint.py:377-390)
         exit_m = re.search(r"exit=(-?\d+)", cited["args"])
         exit_success = exit_m and int(exit_m.group(1)) == 0
-        pattern = None
-        if expect_fail.startswith("/") and expect_fail.endswith("/"):
-            pattern = expect_fail[1:-1]
-        elif expect_fail.startswith('"') and expect_fail.endswith('"'):
-            pattern = re.escape(expect_fail[1:-1])
+        pattern = _expect_fail_pattern(expect_fail)
         content_match = bool(pattern and re.search(pattern, body))
         if exit_success and not content_match:
             raise LintError(
@@ -637,11 +670,7 @@ def verify_witness(body_text, witness, verdict, cited) -> bool:
                     )
             return True
     # regex / literal expect-fail
-    pattern = None
-    if expect_fail.startswith("/") and expect_fail.endswith("/"):
-        pattern = expect_fail[1:-1]
-    elif expect_fail.startswith('"') and expect_fail.endswith('"'):
-        pattern = re.escape(expect_fail[1:-1])
+    pattern = _expect_fail_pattern(expect_fail)
     if pattern and re.search(pattern, body):
         raise LintError(
             f"Tier-2: WITNESS expect-fail regex /{pattern}/ matches body of {art_name} "
@@ -655,10 +684,10 @@ def _read_cited_range(path: pathlib.Path, cited):
     Deliberate (M2): lint.py's inline tier2_verify reads the WHOLE body, but the disk
     reader reads only the cited range (fixture-4(g)-guarded). READ/WROTE entries carry
     no #range → read whole file (the grep-on-READ/WROTE path; not in natural corpus)."""
-    m = re.search(r"out=\S+?#([LB])(\d+)-[LB](\d+)", cited["args"])
-    if not m:
+    r = parse_out_range(cited["args"])
+    if not r:
         return path.read_text()
-    kind, a, b = m.group(1), int(m.group(2)), int(m.group(3))
+    kind, a, b = r.kind, r.start, r.end
     # Ranges are 1-based; a<1 is malformed, clamp to 1 so `[a-1:b]` never slices from
     # the END (a=0 → [-1:b], an empty/wrong body that silently bypasses the witness).
     if a < 1:
@@ -703,9 +732,9 @@ def tier2_witness(witness, trace, root, strict, verdict):
     #    false-FAIL.
     # Scoped to ranged out= citations (the EXEC#L/#B read budget per return-convention.md:224);
     # rangeless READ/WROTE grep reads carry no #range and keep their whole-file behavior.
-    m = re.search(r"out=\S+?#([LB])(\d+)-\1(\d+)", cited["args"])
-    if m:
-        kind, a, b = m.group(1), int(m.group(2)), int(m.group(3))
+    r = parse_out_range(cited["args"])
+    if r:
+        kind, a, b = r.kind, r.start, r.end
         if a < 1:  # 1-based; clamp matches _read_cited_range
             a = 1
         if kind == "L":

--- a/scripts/render_ledger.py
+++ b/scripts/render_ledger.py
@@ -36,6 +36,7 @@ from scripts.reconcile_ledger import (  # noqa: E402
     ledger_entry_hash,
     PREDICATE_SENTINEL,
     GRACE_DAYS,
+    _parse_iso,
 )
 
 # Defaults point at the central machine-local store (#270): the live ledger
@@ -343,21 +344,6 @@ def _breakdown_from_reduced(reduced: dict) -> dict:
 # Predicate calibration (predicted_falsifier — design §3a, Phase 7)           #
 # --------------------------------------------------------------------------- #
 
-def _parse_ts(ts):
-    """Tolerant ISO-8601 parse -> aware UTC datetime, or None. (Mirrors the
-    reconciler's parser without importing a private helper.)"""
-    if not ts or not isinstance(ts, str):
-        return None
-    s = ts.strip().replace("Z", "+00:00")
-    try:
-        dt = _dt.datetime.fromisoformat(s)
-    except ValueError:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=_dt.timezone.utc)
-    return dt.astimezone(_dt.timezone.utc)
-
-
 def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
     """Per-skill predicate hit-rate + unparseable-rate (design §3a).
 
@@ -375,7 +361,7 @@ def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
     Returns {skill: {total_non_null, parseable, unparseable, hit_count,
     hit_rate, unparseable_rate}}.
     """
-    now_dt = _parse_ts(now)
+    now_dt = _parse_iso(now)
     grace_cutoff = (now_dt - _dt.timedelta(days=GRACE_DAYS)) if now_dt else None
 
     per_skill = {}
@@ -414,7 +400,7 @@ def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
             continue
         # Parseable + auto-checkable: counts toward the hit-rate denominator once
         # it is outside the grace window (it has had a full chance to fire).
-        ts = _parse_ts(e.get("timestamp"))
+        ts = _parse_iso(e.get("timestamp"))
         outside_grace = grace_cutoff is None or (ts is not None and ts < grace_cutoff)
         if not outside_grace:
             continue

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -50,6 +50,7 @@ run bash hooks/tests/test-rcpt-verify-hook.sh
 run python3 scripts/check_calibration_dispatch.py --selftest
 run python3 scripts/check_calibration_dispatch.py
 run python3 scripts/test_brier_advise.py
+run python3 scripts/test_calibrate_tolerance.py
 
 # --- Ledger pipeline pure core (#398 Phase 1) ---
 run python3 scripts/test_ledger_core.py

--- a/scripts/test_calibrate_tolerance.py
+++ b/scripts/test_calibrate_tolerance.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/calibrate_tolerance.py (#442 G5)."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.calibrate_tolerance import _per_fixture_pass_rate
+
+
+class TestPerFixturePassRate(unittest.TestCase):
+    def test_missing_per_trial_verdicts_key_does_not_crash(self):
+        # G5: an expectation lacking 'per_trial_verdicts' must not KeyError.
+        fr = {"expectations": [{"id": "e1"}]}  # no per_trial_verdicts
+        self.assertEqual(_per_fixture_pass_rate(fr), 0.0)
+
+    def test_ragged_per_trial_lists_do_not_crash(self):
+        # G5: n_trials was read from [0]; a shorter later list must not IndexError.
+        fr = {"expectations": [
+            {"per_trial_verdicts": ["PASS", "PASS", "PASS"]},
+            {"per_trial_verdicts": ["PASS"]},  # ragged (shorter)
+        ]}
+        # common prefix = 1 trial; both PASS at t=0 -> rate 1.0
+        self.assertEqual(_per_fixture_pass_rate(fr), 1.0)
+
+    def test_ragged_with_fail_in_common_prefix(self):
+        fr = {"expectations": [
+            {"per_trial_verdicts": ["PASS", "FAIL"]},
+            {"per_trial_verdicts": ["FAIL"]},  # common prefix = 1; t=0 -> not all PASS
+        ]}
+        self.assertEqual(_per_fixture_pass_rate(fr), 0.0)
+
+    def test_no_expectations_returns_zero(self):
+        self.assertEqual(_per_fixture_pass_rate({"expectations": []}), 0.0)
+        self.assertEqual(_per_fixture_pass_rate({}), 0.0)
+
+    def test_happy_path_unchanged(self):
+        fr = {"expectations": [
+            {"per_trial_verdicts": ["PASS", "FAIL", "PASS"]},
+            {"per_trial_verdicts": ["PASS", "PASS", "PASS"]},
+        ]}
+        # t0 all PASS, t1 not (FAIL), t2 all PASS -> 2/3
+        self.assertAlmostEqual(_per_fixture_pass_rate(fr), 2 / 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_rcpt_verify.py
+++ b/scripts/test_rcpt_verify.py
@@ -12,6 +12,7 @@ import importlib.util
 import json
 import pathlib
 import hashlib
+import re
 import shutil
 import subprocess
 import sys
@@ -839,6 +840,56 @@ class TestTraceRefGuard(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertIn("good", r.stdout)
         self.assertNotIn("Traceback", r.stdout + r.stderr)
+
+
+class TestParseOutRange(unittest.TestCase):
+    def setUp(self):
+        self.rv = _import_rv()
+
+    def test_basic_line_range(self):
+        r = self.rv.parse_out_range("out=foo.py#L1-L5 mode=x")
+        self.assertEqual((r.artifact, r.kind, r.start, r.end), ("foo.py", "L", 1, 5))
+
+    def test_byte_range(self):
+        r = self.rv.parse_out_range("out=a.bin#B10-B20")
+        self.assertEqual((r.artifact, r.kind, r.start, r.end), ("a.bin", "B", 10, 20))
+
+    def test_mixed_kind_rejected(self):
+        self.assertIsNone(self.rv.parse_out_range("out=foo#L1-B5"))
+
+    def test_no_out_returns_none(self):
+        self.assertIsNone(self.rv.parse_out_range("pattern=foo ran=TRACE#1"))
+
+    def test_double_range_rejected(self):
+        # #442 G6b / F1: the 5 out=#range sites diverge on a double-#range (old L137
+        # greedy/last vs the non-greedy first-range readers), so the grammar rejects
+        # multi-#range outright — None makes check_exec_range_bound LINT-FAIL at Tier-1,
+        # before any Tier-2 site, so all 5 agree.
+        self.assertIsNone(self.rv.parse_out_range("out=a#L1-L5#L9-L1"))  # neg second range
+        self.assertIsNone(self.rv.parse_out_range("out=a#L1-L5#L9-L9"))  # both valid -> still rejected (tightening)
+
+    def test_hash_in_artifact_rejected(self):
+        self.assertIsNone(self.rv.parse_out_range("out=a#b#L1-L5"))
+
+    def test_trailing_nonrange_arg_not_over_rejected(self):
+        # the (?!#[LB]\d) lookahead must reject only a trailing second #<range>, not
+        # ordinary trailing chars after a well-formed range.
+        self.assertEqual(self.rv.parse_out_range("out=a#L1-L5 mode=x")[:4], ("a", "L", 1, 5))
+        self.assertEqual(self.rv.parse_out_range("out=a#L1-L5,x")[:4], ("a", "L", 1, 5))
+
+
+class TestExpectFailPattern(unittest.TestCase):
+    def setUp(self):
+        self.rv = _import_rv()
+
+    def test_regex_form_returned_verbatim(self):
+        self.assertEqual(self.rv._expect_fail_pattern("/err.*/"), "err.*")
+
+    def test_literal_form_is_escaped(self):
+        self.assertEqual(self.rv._expect_fail_pattern('"a.b"'), re.escape("a.b"))
+
+    def test_exit_clause_returns_none(self):
+        self.assertIsNone(self.rv._expect_fail_pattern("exit!=0"))
 
 
 if __name__ == "__main__":

--- a/scripts/test_stores.py
+++ b/scripts/test_stores.py
@@ -892,5 +892,15 @@ class LedgerDoctorScanTest(unittest.TestCase):
             self.assertEqual(rc, 1)
 
 
+class TestIsoParserUnified(unittest.TestCase):
+    def test_render_ledger_uses_reconcile_iso_parser(self):
+        # #442 G6a: render_ledger must NOT carry a forked ISO parser.
+        import scripts.render_ledger as rl
+        import scripts.reconcile_ledger as rc
+        self.assertFalse(hasattr(rl, "_parse_ts"),
+                         "render_ledger._parse_ts must be deleted (forked parser)")
+        self.assertIs(rl._parse_iso, rc._parse_iso)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What & why

Closes the **Significant tier** of #442 (4 defects found by the 2026-06-10 `/audit scripts/` coverage pass; Minor sweep deferred — overlaps #406/#401/#342/#343). All four are "drifted duplicated logic / crash-on-malformed" hazards in the trust/calibration scripts.

- **G5 — `calibrate_tolerance._per_fixture_pass_rate` crash.** A missing `per_trial_verdicts` key (`KeyError`) and ragged per-trial lists (`IndexError`, `n_trials` read from `[0]` but indexed for all) raised tracebacks instead of degrading. Fix: `.get("per_trial_verdicts", [])` + `n_trials = min(len(lst)…, default=0)` (evaluate only the common trial prefix). First test file for this module.
- **G6a — forked ISO-8601 parsers.** `render_ledger._parse_ts` (global `.replace("Z",…)`) duplicated `reconcile_ledger._parse_iso` (trailing-`Z` trim); both drive the same 30-day grace cutoff. Deleted the fork, imported `_parse_iso` (render already imports 5 reconcile internals). Identical on every real timestamp; `_parse_iso` is strictly more correct on pathological input.
- **G6b — five divergent `out=<artifact>#<range>` regexes** in `rcpt_verify.py` (the anti-fabrication linter). They disagreed on greediness, kind back-reference, and grouping; a grammar change had to touch all five and one miss silently diverged the budget-cap path from the body-read path. Replaced with one canonical `parse_out_range()` (`r"out=([^#\s]+)#([LB])(\d+)-\2(\d+)(?!#[LB]\d)"`) routed through all 5 sites. It accepts exactly one well-formed range as a complete token and **rejects multi-`#range` / `#`-in-artifact / mixed-kind uniformly** (`None` → `check_exec_range_bound` LINT-FAILs at Tier-1, before any Tier-2 site, so all 5 agree).
- **G6c — `_expect_fail_pattern()`** extracted; two byte-identical expect-fail derivation blocks in `verify_witness` routed through it.

## Trust-boundary preservation (G6b)

`rcpt_verify` is the linter every gating orchestrator shells out to, so the canonical grammar must not loosen accept/reject behavior:
- **Two-branch verdict diff (main vs branch) = 0** over all 43 receipt records / 31 files the `_eval_record` classifier reads.
- `--selftest` (green) covers the disk-reader sites (658/706) via the `tier2-fixtures` manifest.
- old-vs-new matrix: every divergence is a **tightening** (an OLD-reject stays rejected, or a malformed double-`#range` that OLD's greedy regex happened to accept is now rejected) — **no OLD-reject ever becomes a NEW-accept.** The one delta is a non-corpus PASS→FAIL tightening on a both-valid double-`#range`, the safe direction.

## Tests / verification

- New `TestParseOutRange` (7) + `TestExpectFailPattern` (3) in `test_rcpt_verify.py` (69→79); `TestPerFixturePassRate` (5) in new `test_calibrate_tolerance.py`; `TestIsoParserUnified` (1) in `test_stores.py`. All new crash/grammar tests verified non-vacuous (fail against pre-fix code).
- `bash scripts/run_tests.sh` → **52/52** (was 51; +1 for `test_calibrate_tolerance.py`).
- `rcpt_verify.py --selftest` OK; LintError message strings byte-identical to `main`.

## Gates

Both gated with the real `/quality-gate` loop:
- **Design/plan gate** — 4 rounds (score 2→5→1→0). Round 2 caught a Fatal in an earlier grammar attempt (the 5 sites can't be unified into a single first-or-last reading); resolved by rejecting malformed multi-range uniformly. Look-harder demotion handled; clean independent confirm.
- **Code gate** — round 1 (0F/0S) + look-harder (0F/0S, 1 no-action Minor) on the committed diff.

Refs #408 (audit coverage). Remaining audit issue #441 (untested surface) stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)