### PR TITLE
test(scripts): #441 — cover trust-critical surface (merge-subject, calibrate, parse_witness)

### DIFF
--- a/scripts/test_calibrate_tolerance.py
+++ b/scripts/test_calibrate_tolerance.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-"""Unit tests for scripts/calibrate_tolerance.py (#442 G5)."""
+"""Unit tests for scripts/calibrate_tolerance.py (#442 G5, #441 calibrate() body)."""
+import json
 import os
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from scripts.calibrate_tolerance import _per_fixture_pass_rate
+from scripts.calibrate_tolerance import _per_fixture_pass_rate, calibrate
 
 
 class TestPerFixturePassRate(unittest.TestCase):
@@ -42,6 +45,116 @@ class TestPerFixturePassRate(unittest.TestCase):
         ]}
         # t0 all PASS, t1 not (FAIL), t2 all PASS -> 2/3
         self.assertAlmostEqual(_per_fixture_pass_rate(fr), 2 / 3)
+
+
+def _fixture(fid, per_trial):
+    """A scored-fixture dict: one expectation carrying per_trial verdicts. The
+    per-fixture rate = k PASS-trials / N trials (via _per_fixture_pass_rate), so
+    ["PASS"]->1.0, ["FAIL"]->0.0, ["PASS","FAIL"]->0.5 — rates are DERIVED, never
+    a settable field."""
+    return {"id": fid, "expectations": [{"per_trial_verdicts": per_trial}]}
+
+
+class TestCalibrate(unittest.TestCase):
+    """#441 gap-2: calibrate() body — clamp, floor/ceiling-binding flags, pstdev
+    degenerate fallback, str-vs-list lens_column routing, empty input, output shape.
+    Builds temp last_run.json + evals.json (rates derive from per_trial_verdicts)."""
+
+    def _run(self, runs, lens_map):
+        """runs: list of run-fixture-lists, each [(fid, per_trial), ...].
+        lens_map: {fid: lens_column}. Returns calibrate() output."""
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            evals_path = tdp / "evals.json"
+            evals_path.write_text(json.dumps(
+                {"evals": [{"id": fid, "lens_column": lc} for fid, lc in lens_map.items()]}
+            ), encoding="utf-8")
+            input_paths = []
+            for i, run in enumerate(runs):
+                p = tdp / f"run-{i}.json"
+                p.write_text(json.dumps(
+                    {"fixtures": [_fixture(fid, pt) for fid, pt in run]}
+                ), encoding="utf-8")
+                input_paths.append(p)
+            return calibrate(input_paths, evals_path)
+
+    def test_empty_input_raises_valueerror(self):
+        with tempfile.TemporaryDirectory() as td:
+            # calibrate() raises on `if not input_paths` BEFORE reading evals,
+            # so the evals file is never opened — pass an unwritten path.
+            evals_path = Path(td) / "evals.json"
+            with self.assertRaises(ValueError):
+                calibrate([], evals_path)
+
+    def test_floor_binding_identical_rates(self):
+        # 2 runs, fixture f1 rate 1.0 both -> sigma 0 -> t_emp 0 < 0.447 -> floor.
+        out = self._run(
+            [[("f1", ["PASS"])], [("f1", ["PASS"])]],
+            {"f1": "Surgical"},
+        )
+        self.assertEqual(out["tolerance"], 0.45)  # round(0.447, 2)
+        self.assertTrue(out["floor_binding"])
+        self.assertFalse(out["ceiling_binding"])
+
+    def test_ceiling_binding_wide_spread(self):
+        # column rates [0.0, 1.0] -> pstdev 0.5 -> t_emp 1.0 -> clamps to 0.7.
+        out = self._run(
+            [[("f1", ["FAIL"])], [("f1", ["PASS"])]],
+            {"f1": "Surgical"},
+        )
+        self.assertEqual(out["t_emp"], 1.0)
+        self.assertEqual(out["tolerance"], 0.7)
+        self.assertTrue(out["ceiling_binding"])
+        self.assertFalse(out["floor_binding"])
+
+    def test_mid_range_neither_binding(self):
+        # column rates [1.0, 1.0, 0.5] -> pstdev ~0.2357 -> t_emp ~0.4714 -> 0.47.
+        out = self._run(
+            [[("f1", ["PASS"])], [("f1", ["PASS"])], [("f1", ["PASS", "FAIL"])]],
+            {"f1": "Surgical"},
+        )
+        self.assertAlmostEqual(out["t_emp"], 0.4714, places=3)
+        self.assertEqual(out["tolerance"], 0.47)
+        self.assertFalse(out["floor_binding"])
+        self.assertFalse(out["ceiling_binding"])
+
+    def test_single_rate_degenerate_no_statisticserror(self):
+        # one run, one rate -> len(rates) < 2 -> sigma 0.0 fallback, no StatisticsError.
+        out = self._run([[("f1", ["PASS"])]], {"f1": "Surgical"})
+        self.assertEqual(out["per_lens_sigma_empirical"]["Surgical"], 0.0)
+        self.assertEqual(out["sigma_worst"], 0.0)
+        self.assertEqual(out["tolerance"], 0.45)
+
+    def test_lens_column_list_routes_into_both(self):
+        # f1 lens=list ["Surgical","DRY"] feeds rate into BOTH columns; "SRP" (str)
+        # feeds one; "Nonsense" (unknown) feeds none.
+        out = self._run(
+            [
+                [("f1", ["FAIL"]), ("f2", ["FAIL"]), ("f3", ["FAIL"])],
+                [("f1", ["PASS"]), ("f2", ["PASS"]), ("f3", ["PASS"])],
+            ],
+            {"f1": ["Surgical", "DRY"], "f2": "SRP", "f3": "Nonsense"},
+        )
+        sig = out["per_lens_sigma_empirical"]
+        # Routing signal: Surgical & DRY both == 0.5 proves the list fed BOTH columns;
+        # SRP == 0.5 proves the str fed exactly one. OCP == 0.0 only confirms no fixture
+        # reached OCP (degenerate <2 rates) — it is NOT the unknown-"Nonsense" proof.
+        self.assertEqual(sig["Surgical"], 0.5)  # list routed here
+        self.assertEqual(sig["DRY"], 0.5)        # ...and here
+        self.assertEqual(sig["SRP"], 0.5)        # str routed here
+        self.assertEqual(sig["OCP"], 0.0)        # no fixture reached OCP
+
+    def test_output_shape_invariants(self):
+        out = self._run([[("f1", ["PASS"])], [("f1", ["FAIL"])]], {"f1": "Surgical"})
+        for k in ("tolerance", "sigma_worst", "t_emp", "per_lens_sigma_empirical",
+                  "floor_binding", "ceiling_binding", "analytic_floor", "design_ceiling"):
+            self.assertIn(k, out)
+        self.assertEqual(set(out["per_lens_sigma_empirical"]),
+                         {"Surgical", "DRY", "SRP", "OCP"})
+        self.assertEqual(out["analytic_floor"], 0.447)
+        self.assertEqual(out["design_ceiling"], 0.7)
+        self.assertGreaterEqual(out["tolerance"], 0.45)
+        self.assertLessEqual(out["tolerance"], 0.7)
 
 
 if __name__ == "__main__":

--- a/scripts/test_rcpt_verify.py
+++ b/scripts/test_rcpt_verify.py
@@ -59,10 +59,25 @@ class TestV1CorpusEquivalence(unittest.TestCase):
     Tier-2-only rows (102-inject/105-inject — the ONLY artifact_bodies carriers)
     return cleanly from lint_receipt (their catch fires via the Tier-2 path)."""
 
-    def test_samples_lint_pass(self):
+    def test_samples_lint_exact_verdict(self):
+        # #441 gap-5: tightened from a vacuous assertIn({PASS,FAIL,BLOCKED}) — that
+        # only pinned "didn't raise". lint_receipt returns each receipt's DECLARED
+        # VERDICT when it lints clean, and the sample corpus is MIXED-verdict, so the
+        # exact per-receipt map is the real check. (The no-raise sibling is kept
+        # separately at test_v1_receipt_not_v11_linted — complementary, not redundant.)
+        # Map keyed on dispatch-id (rows carry dispatch-id/skill/receipt, no id).
+        EXPECTED = {
+            "7-implementer": "PASS",
+            "12-judge": "PASS",
+            "8-implementer": "FAIL",
+            "3-attacker": "BLOCKED",
+            "15-reviewer": "FAIL",
+        }
         rv = _import_rv()
         for rec in _load("sample-corpus/receipts.jsonl"):
-            self.assertIn(rv.lint_receipt(rec["receipt"]), {"PASS", "FAIL", "BLOCKED"})
+            self.assertIn(rec["dispatch-id"], EXPECTED,
+                          f"corpus row {rec['dispatch-id']!r} not in EXPECTED map — add it")
+            self.assertEqual(rv.lint_receipt(rec["receipt"]), EXPECTED[rec["dispatch-id"]])
 
     def test_injections_partition_by_artifact_bodies(self):
         rv = _import_rv()
@@ -890,6 +905,98 @@ class TestExpectFailPattern(unittest.TestCase):
 
     def test_exit_clause_returns_none(self):
         self.assertIsNone(self.rv._expect_fail_pattern("exit!=0"))
+
+
+class TestParseWitness(unittest.TestCase):
+    """#441 gap-3: direct coverage of parse_witness's WITNESS grammar — ~11 LintError
+    legs on the security-load-bearing witness line + the happy-path dict shape. None
+    was asserted before. parse_witness takes a body = list of lines; line 0 is parsed.
+    Several legs share one message (raise 9's /.*/, /.+/, /abc/ all emit the shared
+    'wildcard/too-short'), so plain assertRaises(LintError) per leg — not
+    assertRaisesRegex on per-leg messages (matches test_each_inject_shape_raises)."""
+
+    def setUp(self):
+        self.rv = _import_rv()
+
+    # --- raise legs ---
+    def test_empty_body_missing(self):
+        # `[]` is falsy -> the `if not body` leg.
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness([])
+
+    def test_empty_string_line_routes_to_missing_ran(self):
+        # `[""]` is truthy, so it falls through to line-0 "" -> the missing-ran= leg,
+        # NOT the `if not body` "WITNESS missing" leg.
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness([""])
+
+    def test_na_not_permitted(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["(n/a)"])
+
+    def test_missing_ran(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["exec:cmd  expect-fail=exit!=0"])
+
+    def test_missing_expect_fail(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["exec:cmd  ran=2026-06-24"])
+
+    def test_kind_payload_no_colon(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["execcmd  expect-fail=exit!=0  ran=2026-06-24"])
+
+    def test_unknown_kind(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["foo:bar  expect-fail=exit!=0  ran=2026-06-24"])
+
+    def test_lint_rule_unknown(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["lint:bogus-rule  expect-fail=exit!=0  ran=2026-06-24"])
+
+    def test_expect_fail_empty(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["exec:cmd  expect-fail=  ran=2026-06-24"])
+
+    def test_wildcard_or_too_short_regex(self):
+        # All three hit the shared "wildcard/too-short" leg. The wildcard-set arm
+        # ({".*", ".+"}) is observationally unreachable: both members are 2 chars, so
+        # `len(pattern) < 4` short-circuits first. Assert the raise, not which arm.
+        for ef in ("/.*/", "/.+/", "/abc/"):
+            with self.assertRaises(self.rv.LintError, msg=f"expect-fail={ef}"):
+                self.rv.parse_witness([f"exec:cmd  expect-fail={ef}  ran=2026-06-24"])
+
+    def test_literal_too_short(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(['exec:cmd  expect-fail="ab"  ran=2026-06-24'])
+
+    def test_invalid_signature_form(self):
+        with self.assertRaises(self.rv.LintError):
+            self.rv.parse_witness(["exec:cmd  expect-fail=bogus  ran=2026-06-24"])
+
+    # --- happy paths (assert returned dict fields) ---
+    def test_happy_exec_exit_signature(self):
+        out = self.rv.parse_witness(["exec:cmd  expect-fail=exit!=0  ran=2026-06-24"])
+        self.assertEqual(out["kind"], "exec")
+        self.assertEqual(out["payload"], "cmd")
+        self.assertEqual(out["expect_fail"], "exit!=0")
+        self.assertEqual(out["ran"], "2026-06-24")
+
+    def test_happy_grep_literal(self):
+        out = self.rv.parse_witness(['grep:pattern  expect-fail="literal text"  ran=2026-06-24'])
+        self.assertEqual(out["kind"], "grep")
+        self.assertEqual(out["payload"], "pattern")  # only happy path whose expect-fail has a space — locks space-handling
+        self.assertEqual(out["expect_fail"], '"literal text"')
+
+    def test_happy_lint_regex(self):
+        out = self.rv.parse_witness(["lint:all-claims-cited  expect-fail=/regexp4/  ran=2026-06-24"])
+        self.assertEqual(out["kind"], "lint")
+        self.assertEqual(out["payload"], "all-claims-cited")
+
+    def test_happy_signature_forms(self):
+        for ef in ("exit=-1", "match"):
+            out = self.rv.parse_witness([f"exec:cmd  expect-fail={ef}  ran=2026-06-24"])
+            self.assertEqual(out["expect_fail"], ef)
 
 
 if __name__ == "__main__":

--- a/scripts/test_reconcile_git.py
+++ b/scripts/test_reconcile_git.py
@@ -127,5 +127,24 @@ class CrossCutThresholdBoundaryTest(unittest.TestCase):
         self.assertEqual(rl.cross_cut_threshold_from(list(range(1, 31))), 27)
 
 
+class FixMergeSubjectTest(unittest.TestCase):
+    """#441 gap-1 residual: pure matcher for MERGE-commit subjects naming a fix/* or
+    hotfix/* branch. The squash analog `_is_fix_commit_subject` has a pure test; the
+    merge matcher's anchor invariant (matches `fix/`/`hotfix/` at a branch boundary but
+    NOT mid-word `prefix/`/`affix/`/`suffix/`, S-4) was only exercised via the
+    integration repo build, never asserted directly — a regex edit could regress the
+    anchor undetectably."""
+
+    def test_matches_fix_and_hotfix_branch_merges(self):
+        for s in ("Merge branch 'fix/foo'", "merge hotfix/x", "fix/bar at start",
+                  "Merge remote-tracking branch \"fix/baz\"", "x /fix/y", "HotFix/Y"):
+            self.assertTrue(rl._is_fix_merge_subject(s), s)
+
+    def test_rejects_midword_and_non_fix_subjects(self):
+        for s in ("prefix/x", "affix/x", "suffix/y", "feat/x",
+                  "Merge branch 'feature'", "", "fix:"):
+            self.assertFalse(rl._is_fix_merge_subject(s), s)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Test-only coverage hardening for the least-verified trust modules — the residual of the #408 → #439/#440/#442 audit-remediation thread. **No production code touched.** The #408 audit named this code least-verified; the #439 Fatal and #440 ValueError class both lived here.

## Items (issue priority order)

- **A — `FixMergeSubjectTest`** (`test_reconcile_git.py`): direct pure test of `reconcile_ledger._is_fix_merge_subject`'s anchor invariant — matches `fix/`/`hotfix/` at a branch boundary, rejects mid-word `prefix/`/`affix/`/`suffix/` (S-4). Previously exercised only via the integration repo build, so a regex edit could regress the anchor undetectably. (`_is_fix_commit_subject` already had a pure test from #439; this covers the distinct *merge* matcher.)
- **B — `TestCalibrate`** (`test_calibrate_tolerance.py`): `calibrate_tolerance.calibrate()` body — floor/ceiling/mid-range tolerance + binding flags, `pstdev` <2 degenerate fallback, str-vs-list `lens_column` routing, empty-input `ValueError`, output-shape invariants. Rates derive from `per_trial_verdicts` via temp `last_run.json` + `evals.json`. (#442 G5 covered only `_per_fixture_pass_rate`.)
- **C — `TestParseWitness`** (`test_rcpt_verify.py`): 11 `LintError` legs + happy-path dict shape of `rcpt_verify.parse_witness`, the security-load-bearing WITNESS grammar (previously zero direct coverage).
- **D — `test_samples_lint_pass` → `test_samples_lint_exact_verdict`** (`test_rcpt_verify.py`): replaced a vacuous `assertIn({PASS,FAIL,BLOCKED})` with an exact per-receipt verdict map (corpus is mixed-verdict; keyed on `dispatch-id`). The no-raise sibling `test_v1_receipt_not_v11_linted` is retained — complementary, not redundant.

## Verification

- Every pinned value verified against real source behavior (the gate's red-team + look-harder ran the functions directly).
- **Plan gate** (real `/quality-gate`): 3 rounds, score 2→1→0, + look-harder under tightened rubric — clean.
- **Code gate** (real `/quality-gate`): 1 round + look-harder — clean. Caught + fixed a wrong-key/over-claim set across both gates.
- `bash scripts/run_tests.sh` → **52/52**. rcpt tests 79→95, calibrate 5→12, reconcile-git 6→8.

## Scope

`#441` stays **OPEN** — it is a coverage tracker. Gap 4 (`parse_artifacts`/`parse_trace`/`parse_claims`/`check_exec_range_bound` raises, `tier2_witness` FAIL leg) and the gap-5 remainder are carried forward. This PR uses `Refs #441`, not `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)