### PR TITLE
docs(skills): #406 doc-hygiene slice — ledger paths, desc scalars, recon dedup

### DIFF
--- a/skills/grudge/SKILL.md
+++ b/skills/grudge/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: grudge
-description: >
-  The Book of Grudges — cross-session bug graveyard. Every fixed bug is recorded
-  as a structured "grudge"; before touching code, skills query the grudgebook for
-  the files in scope and surface past regressions as forced "DO NOT REPEAT"
-  context. Read mode (pre-flight) and write mode (on bug resolution / fix(*) PR).
-  Machine-local, per-repo, never committed. Triggers on /grudge, "check grudges",
-  "record a grudge", "any past bugs here", "regression oracle", "bug graveyard".
+description: The Book of Grudges — cross-session bug graveyard. Every fixed bug is recorded as a structured "grudge"; before touching code, skills query the grudgebook for the files in scope and surface past regressions as forced "DO NOT REPEAT" context. Read mode (pre-flight) and write mode (on bug resolution / fix(*) PR). Machine-local, per-repo, never committed. Triggers on /grudge, "check grudges", "record a grudge", "any past bugs here", "regression oracle", "bug graveyard".
 ---
 
 # Grudge — the Book of Grudges (#271)

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -638,68 +638,20 @@ not dispatch the recorder twice.
 
 Return the Investigation Brief as the agent output (inline return to parent skill).
 
-The brief follows the exact template from the design, including the metadata block:
+The brief follows the exact core template assembled in
+[Phase 3 — Assemble the Investigation Brief](#assemble-the-investigation-brief)
+(metadata block + core sections through the Verification Ledger). Do not re-echo
+that template here — it is the single source so the two copies cannot drift.
 
-```markdown
-# Investigation Brief
-**Brief version:** 1
-**Task:** [task description or "Full repository scan"]
-**Scope:** [constrained path or "Full repo"]
-**Depth modules:** [list or "Core only"]
-**Cartographer state:** [consulted / cold start / N/A]
-**Commit:** [HEAD SHA at investigation time]
+When depth modules ran, append their sections after a `---` separator, in this
+order (only the requested modules' sections appear):
 
-## Project Structure
-...
-
-## Existing Patterns
-...
-
-## Scope Boundaries
-### In Scope
-...
-### Out of Scope
-...
-### Contested
-...
-
-## Prior Art
-...
-
-## Conflicts
-...
-
-## Open Questions
-...
-
-## Verification Ledger
-<!-- Records causal claims made by this brief (populated this run). Falsifications flow via handoff-doc entries under docs/handoffs/ per the convention in skills/recon/SKILL.md. -->
-...
-
----
-<!-- Depth modules below, only present if requested -->
-
-## Impact Analysis
-...
-
-## Consumer Registry
-...
-
-## Friction Scan
-...
-
-## Subsystem Manifest
-...
-
-## Diagnostic Context
-...
-
-## Execution Readiness
-**Test command:** ...
-**Lint command:** ...
-**CI checks:** ...
-**Manual verification:** ...
-```
+1. `## Impact Analysis`
+2. `## Consumer Registry`
+3. `## Friction Scan`
+4. `## Subsystem Manifest`
+5. `## Diagnostic Context`
+6. `## Execution Readiness` — **Test command** / **Lint command** / **CI checks** / **Manual verification**
 
 **When invoked as sub-skill:** Include `## Recon Progress` section at the top with all narration lines from the run.
 

--- a/skills/shared/ledger-append.md
+++ b/skills/shared/ledger-append.md
@@ -5,7 +5,7 @@ version: 1
 # Ledger Append Protocol (canonical)
 
 > Canonical write-protocol prompt for the Crucible calibration ledger
-> (`.crucible/ledger/runs.jsonl`). Referenced by every gating skill that emits a
+> (`~/.claude/crucible/ledger/runs.jsonl`). Referenced by every gating skill that emits a
 > calibration entry via `<!-- CANONICAL: shared/ledger-append.md -->`.
 >
 > This file is the **protocol-as-spec**. The importable single source of truth
@@ -255,7 +255,7 @@ backfill script produce the same backfill IDs and skip on re-encounter.
 Hard caps enforced inside `scripts/ledger_append.py`:
 
 - `gated_files`: maximum 500 entries in the ledger line. Overflow goes to a
-  sidecar at `.crucible/ledger/overflow/<run_id>.<skill>.txt` (one path per
+  sidecar at `~/.claude/crucible/ledger/overflow/<run_id>.<skill>.txt` (one path per
   line, complete list including the overflow). The ledger entry sets
   `gated_files_truncated` to the count of dropped paths.
 - `highest_finding`: maximum 256 characters in the ledger line. Truncated
@@ -280,12 +280,12 @@ unreliable on network mounts, and FS-pathway-dependent on macOS. We use a
 portable scheme that does not rely on advisory locking. `mkdir` is atomic
 across all supported filesystems and IS the mutex.
 
-1. **Acquire:** `mkdir .crucible/ledger/.lock-runs-jsonl`
+1. **Acquire:** `mkdir ~/.claude/crucible/ledger/.lock-runs-jsonl`
    - On success: continue to step 2.
    - On EEXIST: spin with 50 ms backoff up to 5 s.
    - If stale recovery applies (step 5), invoke before spinning further.
 
-2. **Write identity:** open `.crucible/ledger/.lock-runs-jsonl/holder`,
+2. **Write identity:** open `~/.claude/crucible/ledger/.lock-runs-jsonl/holder`,
    write `<run_id>:<skill>:<pid>:<acquired_ts_iso>`, close.
 
 3. **Append:** open `runs.jsonl` with `O_APPEND | O_CREAT`; write one JSONL

--- a/skills/temper-eval-calibrate/SKILL.md
+++ b/skills/temper-eval-calibrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temper-eval-calibrate
-description: Wrapper skill that runs k iterations of (stage → collect-behavior → score) for #290 calibration sweeps. Replaces bash for-loops that cannot invoke session skills. Default k=3. Inlines collect-dispatch behavior per iteration. Idempotent resume via per-iteration sentinels under skills/temper/evals/.calibrate-state/.
+description: Internal temper-eval harness — not auto-routed; invoke explicitly via /temper-eval-calibrate. Wrapper skill that runs k iterations of (stage → collect-behavior → score) for #290 calibration sweeps. Replaces bash for-loops that cannot invoke session skills. Default k=3. Inlines collect-dispatch behavior per iteration. Idempotent resume via per-iteration sentinels under skills/temper/evals/.calibrate-state/.
 model: opus
 ---
 

--- a/skills/temper-eval-collect/SKILL.md
+++ b/skills/temper-eval-collect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temper-eval-collect
-description: Live-dispatch phase of temper eval harness. Reads stage-manifest.json from a pre-staged dispatch dir; fans Task-tool reviewer dispatches in parallel (max 6); writes per-seq result files; exits. Single bounded session. Pairs with `python -m skills.temper.evals.run_evals stage` and `score`.
+description: Internal temper-eval harness — not auto-routed; invoke explicitly via /temper-eval-collect. Live-dispatch phase of temper eval harness. Reads stage-manifest.json from a pre-staged dispatch dir; fans Task-tool reviewer dispatches in parallel (max 6); writes per-seq result files; exits. Single bounded session. Pairs with `python -m skills.temper.evals.run_evals stage` and `score`.
 model: opus
 ---
 


### PR DESCRIPTION
Resolves the genuinely-mechanical doc-hygiene tail of the 2026-06-10 audit sweep (**#406**). Trust-critical code (the 4 instance bugs, lock semantics) and meatier rewrites are deferred to focused follow-ups — kept this PR tight and low-risk.

## Changes (5 files, +21/−75, doc-only)

- **`skills/shared/ledger-append.md`** — 4 stale `.crucible/ledger` prose paths → `~/.claude/crucible/ledger` (the live machine-local central store, override `CRUCIBLE_LEDGER_DIR`; per #270). Aligns with the doc's own line 27 + the inlined `default_ledger_dir()`. The in-repo `.crucible/ledger/runs.jsonl` is the deliberate test fixture, not the live store.
- **`skills/grudge/SKILL.md`** — folded `description: >` block → single-line plain scalar (text verbatim). Removes the lone parser-divergence canary.
- **`skills/temper-eval-{calibrate,collect}/SKILL.md`** — description guard reworded to `Internal temper-eval harness — not auto-routed; invoke explicitly via /temper-eval-…`. Tightens NL auto-routing **without** contradicting each skill's own `**Invocation:**` line. (The original `Not invoked directly` phrasing was caught as a self-contradiction by the gate's round-1 red-team.)
- **`skills/recon/SKILL.md`** — the Output section re-echoed the full Investigation Brief template (~58 lines duplicating the Phase 3 copy → independent drift). Replaced with a back-reference to Phase 3 + an explicit depth-module composition list (order + `---` separator + Execution Readiness sub-fields). No information lost.

## Out of scope (deferred, still open on #406)
- `skill-creator/references/schemas.md:228` stale model id — **gitignored, non-shipping** local file (the whole `skills/skill-creator/` dir is ignored); not a public-repo hygiene item. Surfaced by the gate's round-2 red-team.
- `CONTRIBUTING-CALIBRATION.md` committed-ledger framing (the higher-priority remaining `.crucible/ledger` staleness — asserts the live store is committed); the 4 trust-critical instance bugs; `check_model_pins` minors; hook smoke tests.

## Verification
- `bash scripts/run_tests.sh` → **52/52**; `python3 scripts/catalog.py check` → OK.
- Gated with `/quality-gate` (full loop): R1 FAIL (1 Significant, the temper-eval contradiction) → fix → R2 fresh red-team 0F/0S → look-harder (tightened rubric) confirm 0F/0S. Crucible self-gate → **not** emitted to the central calibration ledger (local marker only).

Refs #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)