### PR TITLE
test(evals): #404 — gate the temper/evals pytest suite (162 unrun tests)

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -102,10 +102,18 @@ run python3 scripts/check_inquisitor_phase1b_invariants.py --selftest
 run python3 scripts/check_inquisitor_phase1b_invariants.py
 
 # --- Minimalism-ladder eval harness (#425) ---
-# REQUIRES pytest (uses parametrize/fixtures); CI provisions pytest==9.0.3. This
-# is the only -m pytest line in the suite — bare `python3 file.py` would silently
-# skip the pytest-collected tests.
+# REQUIRES pytest (uses parametrize/fixtures); CI provisions pytest==9.0.3. The
+# suite has two -m pytest lines (this and skills/temper/evals/ below) — bare
+# `python3 file.py` would silently skip the pytest-collected tests.
 run python3 -m pytest skills/build/evals/minimalism-ladder/ -q
+
+# --- Temper eval harness (#290/#297/#424) — pytest-collected ---
+# Gated here (#404): previously UNRUN. The temper/evals tests are pytest-collected
+# (bare `python3 file.py` silently skips them), and no -m pytest line covered them,
+# so CI never exercised temper/evals at all — the 162 tests behind temper's
+# run_evals stage/score, convergence_runner, _dispatch_paths, _runid, legacy modes,
+# global expectations, and the #297 inquisitor-dimension suites.
+run python3 -m pytest skills/temper/evals/ -q
 
 # --- Catalog unit suite ---
 run python3 scripts/test_catalog.py


### PR DESCRIPTION
Reframed slice of **#404**. Investigation found the headline (extract a shared `evals_lib`, port temper+build) is lower-value than filed — but it surfaced a real, clean gap.

## The real gap
`skills/temper/evals/`'s 13 test files are **pytest-collected (162 tests)** but were **never run** by `run_tests.sh`: the suite runs other tests as bare `python3 file.py` (which silently skips pytest-collected tests), and no `-m pytest` line covered temper/evals. So CI never exercised temper's eval harness at all — `run_evals` stage/score, `convergence_runner`, `_dispatch_paths`, `_runid`, legacy modes, global expectations, and the #297 inquisitor-dimension suites.

## Change
One `run python3 -m pytest skills/temper/evals/ -q` line (mirrors the existing `minimalism-ladder` pytest line) + a fix to the now-stale "only -m pytest line" comment. All 162 pass; suite **52→53**.

## Why the headline is deferred (not done here)
- The inquisitor↔temper shared helpers (`_dispatch_paths.py`, `_runid.py`) are already **deliberate drift-guarded copies** (#424, `check_inquisitor_helper_drift.py`) — not accidental fork tax.
- The "misfiled inquisitor tests" are temper's **inquisitor-dimension** tests (#297), correctly placed with temper (they assert on `temper-eval-calibrate/SKILL.md`).
- The lib-extraction can be reassessed if/when #373 actually needs it — and now builds on a **gated** base.

## Verification
- `bash scripts/run_tests.sh` → **53/53** (the new line = 162 temper tests).
- `/quality-gate`: 1 round clean (0F/0S/0M) + look-harder confirm. The red-team chased and refuted the conftest/`sys.path` portability risk (pytest prepends cwd; the suite runs from repo root, same pattern the existing minimalism-ladder line proves works in CI). Self-gate → not ledger-emitted.

Refs #404 (kept open as a reduced-scope tracker for the deferred lib-extraction — see issue comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)