### PR TITLE
feat(evals): #373 — delve eval harness (deterministic matcher)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ skills/stocktake/results.json
 skills/temper/evals/last_run.json
 skills/inquisitor/evals/last_run.json
 skills/inquisitor/evals/results.md
+skills/delve/evals/last_run.json
+skills/delve/evals/results.md
 src/
 tests/
 

--- a/scripts/check_delve_gt_provenance.py
+++ b/scripts/check_delve_gt_provenance.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Provenance + GT-integrity check for the delve eval ground-truth fixtures (#373).
+
+Invocation (from repo root):
+    python3 scripts/check_delve_gt_provenance.py            # check the tree
+    python3 scripts/check_delve_gt_provenance.py --selftest # built-in logic tests
+
+Two machine-verifiable checks per fixture under `skills/delve/evals/fixtures/<repo>/`:
+
+1. Blind boundary. Each fixture's primary oracle is `ground-truth-bugs.json`, whose
+   `signature` tokens + per-bug `desc` strings ARE the answer key. The design requires
+   that key be withheld from the blind author who wrote `ground-truth-bugs.provenance.md`
+   (authoring from the answer key would bias the recorded run's grading). This check
+   asserts the provenance file contains NONE of that fixture's GT `signature` tokens or
+   `desc` strings — if any appears, the blind boundary leaked.
+
+2. GT integrity. A malformed committed fixture corrupts recall silently (CI stays
+   green while a bug can never match) or crashes `match()`/the scorer at score time.
+   This check is a COMPLETE GT-schema validator — it asserts the full invariant set the
+   matcher + scorer depend on, and is itself total (it returns a violations list for ANY
+   input shape and never raises):
+     - structure: `gt["bugs"]` is present and a `list`, and every element is a `dict`
+       (a non-list `bugs` or a non-dict element would crash the per-bug loop / matcher);
+     - per bug, every required field is present AND correctly typed: `bug_id` and `file`
+       are non-empty `str`, `line_lo` and `line_hi` are `int` (and not `bool`, since
+       `isinstance(True, int)` is True) — the matcher does `file.startswith(...)` and
+       arithmetic/comparison on the lines, so a wrong type crashes `match()` (a str/None
+       line → TypeError, an int file → AttributeError) and a float line silently matches;
+     - relational: `line_lo <= line_hi` — an inverted/transposed range inverts the match
+       window, so the bug can NEVER match and its recall is silently 0;
+     - non-empty `signature` per bug — a `list` with ≥1 non-empty `str` token; the
+       matcher gates every edge on `_signature_hits(bug, finding) > 0`, so a bug with no
+       usable signature token can NEVER match (recall silently 0), while a `[""]`-only
+       signature substring-matches EVERYTHING (recall silently inflated);
+     - `off_axis`, when present, is a JSON bool — the scorer uses `b.get("off_axis")`
+       truthiness, so a JSON string like `"false"` would (mis)count as off-axis;
+     - unique `bug_id`s within `ground-truth-bugs.json` (the matcher keys everything by
+       `bug_id`, so two rows sharing one collapse into a single matchable slot);
+     - if a `manifest.json` exists, `manifest["n"] == len(bugs)` AND
+       `set(manifest["bug_ids"])` equals the GT bug_id set (the manifest duplicates the
+       answer key, so an undetected mismatch would mask a corrupt fixture).
+
+"Trust the process" is what this repo's calibration ethos rejects, so both are gated.
+Stdlib only. Exit 0 clean / 1 on any detected leak or integrity violation.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+FIXTURES_DIR = ROOT / "skills/delve/evals/fixtures"
+
+
+def withheld_strings(gt: dict) -> list:
+    """Every signature token + desc string the provenance must NOT contain.
+
+    Signature tokens are matched case-insensitively (the matcher lowercases them);
+    desc strings are matched verbatim. Returned as (needle, kind, comparison_text)
+    so the scan can be case-correct per kind.
+
+    Robust by construction: a non-string `desc` or signature token is skipped (the
+    `isinstance(..., str)` guards), so the comparison_text fed to `leaks()` is always a
+    `str` and `cmp in haystack` can never raise — even if a malformed fixture bypassed
+    `gt_integrity_violations()`. The validator names the violation; this guarantees no
+    bare TypeError regardless."""
+    out = []
+    if not isinstance(gt, dict):
+        return out
+    bugs = gt.get("bugs")
+    if not isinstance(bugs, list):
+        return out
+    for bug in bugs:
+        if not isinstance(bug, dict):
+            continue
+        sig = bug.get("signature")
+        for tok in sig if isinstance(sig, list) else []:
+            if isinstance(tok, str) and tok:
+                out.append((tok, "signature", tok.lower()))
+        desc = bug.get("desc")
+        if isinstance(desc, str) and desc:
+            out.append((desc, "desc", desc))
+    return out
+
+
+def leaks(provenance_text: str, strings) -> list:
+    """Return the (needle, kind) entries that leaked into the provenance text.
+    Signature tokens compare case-insensitively; desc strings compare verbatim."""
+    lower_text = provenance_text.lower()
+    found = []
+    for needle, kind, cmp in strings:
+        haystack = lower_text if kind == "signature" else provenance_text
+        if cmp in haystack:
+            found.append((needle, kind))
+    return found
+
+
+# Required fields and the exact type each must carry. `line_lo`/`line_hi` use `int`
+# but bool is excluded explicitly below (isinstance(True, int) is True in Python).
+_REQUIRED_FIELDS = ("bug_id", "file", "line_lo", "line_hi")
+_STR_FIELDS = ("bug_id", "file")
+_INT_FIELDS = ("line_lo", "line_hi")
+
+
+def _is_int(v) -> bool:
+    """True iff v is a real int — bool excluded (isinstance(True, int) is True)."""
+    return isinstance(v, int) and not isinstance(v, bool)
+
+
+def gt_integrity_violations(gt, manifest) -> list:
+    """Return human-readable integrity violations for one fixture's GT (+manifest).
+
+    COMPLETE GT-schema validator, and TOTAL: it returns a violations list for ANY input
+    shape and never raises. Guards the container/elements FIRST, so a malformed
+    `bugs` value or a non-dict element produces a violation instead of an exception.
+
+    Per fixture, flags a violation for any of:
+      - structure: `gt` is not a dict, or `gt["bugs"]` is missing / not a list, or any
+        element of `bugs` is not a dict;
+      - per bug: a required field (`bug_id`, `file`, `line_lo`, `line_hi`) missing or of
+        the wrong type — `bug_id`/`file` must be non-empty `str`, `line_lo`/`line_hi`
+        must be `int` (not `bool`);
+      - relational: when both line bounds are valid ints, `line_lo <= line_hi`;
+      - `signature` present, a `list`, with EVERY token a non-empty `str` (a missing
+        key, non-list, empty list, or any non-str / empty / blank token → violation;
+        the matcher does `str(tok).lower()`, so a non-str token would latently
+        overmatch);
+      - `desc`, when present, is a `str` (the blind-boundary leak scan uses it as a
+        withheld needle in `cmp in haystack`, so a non-str would crash the scan);
+      - `off_axis`, when present, is a Python `bool`;
+      - bug_id uniqueness within `ground-truth-bugs.json`;
+      - if `manifest` is not None, `manifest["n"] == len(bugs)` and
+        `set(manifest["bug_ids"])` equals the GT bug_id set.
+    Empty list ⇒ clean. Pure (no filesystem)."""
+    violations = []
+    # --- Structure guards (run FIRST so the per-bug loop never raises). ---
+    if not isinstance(gt, dict):
+        return [f"ground-truth-bugs.json is {type(gt).__name__}, not a dict (object)"]
+    if "bugs" not in gt:
+        violations.append("ground-truth-bugs.json is missing required key 'bugs'")
+        bugs = []
+    elif not isinstance(gt["bugs"], list):
+        violations.append(
+            f"ground-truth-bugs.json 'bugs' is {type(gt['bugs']).__name__}, not a list")
+        bugs = []
+    else:
+        bugs = gt["bugs"]
+
+    # bug_id set is computed only from dict elements (others are reported below).
+    bug_ids = [b.get("bug_id") for b in bugs if isinstance(b, dict)]
+    dups = sorted({bid for bid in bug_ids
+                   if isinstance(bid, str) and bug_ids.count(bid) > 1})
+    if dups:
+        violations.append(f"duplicate bug_id(s) in ground-truth-bugs.json: {dups}")
+
+    for i, b in enumerate(bugs):
+        if not isinstance(b, dict):
+            violations.append(
+                f"bug at index {i} is {type(b).__name__}, not a dict (object)")
+            continue
+        # Name the bug by bug_id when it is a usable string, else by index.
+        bid = b.get("bug_id")
+        who = repr(bid) if isinstance(bid, str) and bid else f"index {i}"
+        for field in _REQUIRED_FIELDS:
+            if field not in b:
+                violations.append(f"bug {who} is missing required field {field!r}")
+        for field in _STR_FIELDS:
+            if field in b:
+                v = b[field]
+                if not isinstance(v, str) or not v:
+                    violations.append(
+                        f"bug {who} field {field!r} is "
+                        f"{type(v).__name__ if not isinstance(v, str) else 'empty'}, "
+                        f"not a non-empty str")
+        for field in _INT_FIELDS:
+            if field in b and not _is_int(b[field]):
+                violations.append(
+                    f"bug {who} field {field!r} is {type(b[field]).__name__}, "
+                    f"not an int")
+        # Relational: only when both bounds are valid ints (else type errors above).
+        if (_is_int(b.get("line_lo")) and _is_int(b.get("line_hi"))
+                and b["line_lo"] > b["line_hi"]):
+            violations.append(
+                f"bug {who} has inverted range line_lo={b['line_lo']} > "
+                f"line_hi={b['line_hi']} (bug could never match)")
+        sig = b.get("signature")
+        if not isinstance(sig, list):
+            if "signature" not in b:
+                shape = "absent (key missing)"
+            elif sig is None:
+                shape = "null"
+            else:
+                shape = type(sig).__name__
+            violations.append(f"bug {who} signature is {shape}, not a list")
+        elif not any(isinstance(tok, str) and tok.strip() for tok in sig):
+            violations.append(
+                f"bug {who} signature has no usable non-empty str token")
+        else:
+            # Every token must be a non-empty str: the matcher does str(tok).lower(),
+            # so 123 -> "123" / None -> "none" is a latent substring overmatch even
+            # when one good token satisfies the "≥1 usable" rule above.
+            for j, tok in enumerate(sig):
+                if not isinstance(tok, str):
+                    violations.append(
+                        f"bug {who} signature token at index {j} is "
+                        f"{type(tok).__name__}, not a str")
+                elif not tok.strip():
+                    violations.append(
+                        f"bug {who} signature token at index {j} is empty/blank")
+        if "desc" in b and not isinstance(b["desc"], str):
+            violations.append(
+                f"bug {who} field 'desc' is {type(b['desc']).__name__}, not a str")
+        if "off_axis" in b and not isinstance(b["off_axis"], bool):
+            violations.append(
+                f"bug {who} off_axis is {type(b['off_axis']).__name__}, not a bool")
+
+    if manifest is not None:
+        gt_set = set(bug_ids)
+        man_n = manifest.get("n") if isinstance(manifest, dict) else None
+        if man_n != len(bugs):
+            violations.append(f"manifest n={man_n} != len(bugs)={len(bugs)}")
+        man_ids = manifest.get("bug_ids", []) if isinstance(manifest, dict) else []
+        man_set = set(man_ids) if isinstance(man_ids, list) else set()
+        if man_set != gt_set:
+            violations.append(
+                f"manifest bug_ids {sorted(man_set, key=str)} != "
+                f"GT bug_ids {sorted(gt_set, key=str)}")
+    return violations
+
+
+def _fixture_dirs() -> list:
+    if not FIXTURES_DIR.exists():
+        return []
+    return sorted(d for d in FIXTURES_DIR.iterdir()
+                  if d.is_dir() and (d / "ground-truth-bugs.json").exists())
+
+
+def main() -> int:
+    dirs = _fixture_dirs()
+    if not dirs:
+        print(f"[fatal] no delve eval fixtures with ground-truth-bugs.json under "
+              f"{FIXTURES_DIR.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+    any_leak = False
+    total = 0
+    for d in dirs:
+        gt = json.loads((d / "ground-truth-bugs.json").read_text(encoding="utf-8"))
+
+        manifest_path = d / "manifest.json"
+        manifest = (json.loads(manifest_path.read_text(encoding="utf-8"))
+                    if manifest_path.exists() else None)
+        integrity = gt_integrity_violations(gt, manifest)
+        if integrity:
+            any_leak = True
+            print(f"GROUND-TRUTH INTEGRITY VIOLATION in {d.relative_to(ROOT)}:")
+            for v in integrity:
+                print(f"  {v}")
+
+        prov_path = d / "ground-truth-bugs.provenance.md"
+        if not prov_path.exists():
+            print(f"[fatal] {d.relative_to(ROOT)} has ground-truth-bugs.json but no "
+                  f"ground-truth-bugs.provenance.md (the blind input is unverifiable)",
+                  file=sys.stderr)
+            any_leak = True
+            continue
+        strings = withheld_strings(gt)
+        total += len(strings)
+        text = prov_path.read_text(encoding="utf-8")
+        found = leaks(text, strings)
+        if found:
+            any_leak = True
+            print(f"GROUND-TRUTH BLIND BOUNDARY LEAKED in "
+                  f"{prov_path.relative_to(ROOT)}:")
+            for needle, kind in found:
+                print(f"  withheld {kind} present: {needle[:80]!r}")
+    if any_leak:
+        print("\nThe provenance artifact must contain only the feature description + "
+              "factual codebase context fed to the blind author — none of the "
+              "ground-truth-bugs.json signature tokens or desc strings. And each "
+              "fixture's GT must satisfy the COMPLETE schema: bugs is a list of dicts; "
+              "every bug has its required fields present and correctly typed "
+              "(bug_id/file non-empty str, line_lo/line_hi int with line_lo<=line_hi), a "
+              "non-empty string signature, and a bool off_axis where present; bug_ids "
+              "are unique and consistent with the manifest n/bug_ids. A violation means "
+              "the recorded run may be scored against a biased or corrupt oracle "
+              "(design #373).")
+        return 1
+    print(f"OK — {len(dirs)} fixture(s); provenance contains none of the {total} "
+          "withheld signature/desc strings; the blind boundary held; every GT is a "
+          "list of dict bugs with unique bug_ids consistent with each manifest, every "
+          "required field present and correctly typed (bug_id/file non-empty str, "
+          "line_lo<=line_hi ints), a non-empty string signature, and a bool off_axis "
+          "where present.")
+    return 0
+
+
+def selftest() -> int:
+    """Built-in logic tests (in-memory) for the substring leak scan."""
+    gt = {"bugs": [
+        {"signature": ["off-by-one", "Slice"], "desc": "drops the final element"},
+    ]}
+    strings = withheld_strings(gt)
+    clean = ("## Feature under review\nA helper returning recent items.\n"
+             "## Task\nReview for defects.\n")
+    leaky_sig = clean + "There is an off-by-one here.\n"
+    leaky_sig_case = clean + "A SLICE bug lurks.\n"   # case-insensitive signature
+    leaky_desc = clean + "It drops the final element.\n"
+    cases = [
+        (clean, False, "feature/context only → no leak"),
+        (leaky_sig, True, "a signature token in the provenance is caught"),
+        (leaky_sig_case, True, "signature match is case-insensitive"),
+        (leaky_desc, True, "a desc string in the provenance is caught"),
+    ]
+    failures = []
+    for text, expect_fail, reason in cases:
+        got = bool(leaks(text, strings))
+        if got != expect_fail:
+            failures.append(f"  expected leak={expect_fail} ({reason}), got={got}")
+    # GT-integrity legs (in-memory; no real broken fixture added to the tree).
+    # A fully clean bug carries every required field, a non-empty signature, and a
+    # bool off_axis — the broadened check must pass it untouched.
+    def _bug(**over):
+        base = {"bug_id": "x1", "file": "a.py", "line_lo": 5, "line_hi": 5,
+                "signature": ["a"], "desc": "d1", "off_axis": False}
+        base.update(over)
+        return base
+    clean_gt = {"bugs": [_bug(), _bug(bug_id="x2", signature=["b"], desc="d2")]}
+    clean_manifest = {"n": 2, "bug_ids": ["x1", "x2"]}
+    dup_gt = {"bugs": [_bug(), _bug(signature=["b"], desc="d2")]}
+    mismatch_manifest_n = {"n": 3, "bug_ids": ["x1", "x2"]}
+    mismatch_manifest_ids = {"n": 2, "bug_ids": ["x1", "x9"]}
+    # Each seeds exactly one malformation the complete-schema check must name.
+    empty_sig_gt = {"bugs": [_bug(signature=[])]}
+    missing_sig_gt = {"bugs": [{k: v for k, v in _bug().items() if k != "signature"}]}
+    blank_sig_gt = {"bugs": [_bug(signature=[""])]}        # [""] substring-matches all
+    missing_field_gt = {"bugs": [{k: v for k, v in _bug().items() if k != "line_lo"}]}
+    str_off_axis_gt = {"bugs": [_bug(off_axis="false")]}
+    inverted_range_gt = {"bugs": [_bug(line_lo=60, line_hi=40)]}
+    str_line_gt = {"bugs": [_bug(line_lo="10")]}           # matcher would TypeError
+    none_line_gt = {"bugs": [_bug(line_lo=None)]}          # matcher would TypeError
+    float_line_gt = {"bugs": [_bug(line_lo=10.0)]}         # latent: passed AND matched
+    int_file_gt = {"bugs": [_bug(file=123)]}               # matcher would AttributeError
+    empty_file_gt = {"bugs": [_bug(file="")]}
+    nonlist_bugs_gt = {"bugs": "not-a-list"}               # would crash the per-bug loop
+    nondict_bug_gt = {"bugs": ["not-a-dict", _bug()]}      # would crash .get on element
+    missing_bugs_gt = {}                                   # no 'bugs' key
+    # R5-S1: non-string desc — validator names it AND the leak scan must not raise.
+    list_desc_gt = {"bugs": [_bug(desc=["a", "b"])]}       # leaks() crashed on this
+    num_desc_gt = {"bugs": [_bug(desc=123)]}
+    # R5-M3: a non-str signature token passes the "≥1 usable" rule yet overmatches.
+    nonstr_sig_tok_gt = {"bugs": [_bug(signature=["ok", 123])]}
+    integrity_cases = [
+        # (gt, manifest, expect_violation, anchor_substr, reason)
+        (clean_gt, clean_manifest, False, None,
+         "fully clean bug (typed fields, line_lo<=line_hi, str sig, bool off_axis) → clean"),
+        (clean_gt, None, False, None,
+         "no manifest → per-bug + uniqueness checks still pass"),
+        (dup_gt, clean_manifest, True, "duplicate bug_id",
+         "a duplicate bug_id is caught"),
+        (clean_gt, mismatch_manifest_n, True, "!= len(bugs)",
+         "a manifest n mismatch is caught"),
+        (clean_gt, mismatch_manifest_ids, True, "!= GT bug_ids",
+         "a manifest bug_ids mismatch is caught"),
+        (empty_sig_gt, None, True, "signature",
+         "an empty signature is caught (bug could never match)"),
+        (missing_sig_gt, None, True, "signature",
+         "a missing signature key is caught"),
+        (blank_sig_gt, None, True, "signature",
+         "a [''] blank-only signature is caught (would substring-match everything)"),
+        (missing_field_gt, None, True, "line_lo",
+         "a missing required field (line_lo) is caught"),
+        (str_off_axis_gt, None, True, "off_axis",
+         "a string off_axis (not bool) is caught"),
+        # R4-S1: inverted/transposed range — the Significant.
+        (inverted_range_gt, None, True, "inverted range",
+         "an inverted range line_lo>line_hi is caught (R4-S1)"),
+        # R4-M1: wrong-type fields the presence-only check missed.
+        (str_line_gt, None, True, "line_lo",
+         "a str line_lo (matcher TypeError) is caught as a type violation"),
+        (none_line_gt, None, True, "line_lo",
+         "a None line_lo (matcher TypeError) is caught as a type violation"),
+        (float_line_gt, None, True, "line_lo",
+         "a float line_lo (latent laxness — passed AND matched) is caught"),
+        (int_file_gt, None, True, "file",
+         "an int file (matcher AttributeError) is caught as a type violation"),
+        (empty_file_gt, None, True, "file",
+         "an empty-string file is caught"),
+        # R4-M1: the validator itself must be total — never raise on a bad container.
+        (nonlist_bugs_gt, None, True, "not a list",
+         "a non-list 'bugs' is caught (validator does not raise)"),
+        (nondict_bug_gt, None, True, "not a dict",
+         "a non-dict bug element is caught (validator does not raise)"),
+        (missing_bugs_gt, None, True, "missing required key 'bugs'",
+         "a GT with no 'bugs' key is caught"),
+        # R5-S1: a non-string desc — validator names it (totality guard + the leak-scan
+        # no-raise assertion below cover the runtime path).
+        (list_desc_gt, None, True, "desc",
+         "a list desc is caught (R5-S1; leaks() would otherwise TypeError)"),
+        (num_desc_gt, None, True, "desc",
+         "a numeric desc is caught (R5-S1)"),
+        # R5-M3: a non-str signature token (latent str()-coerce overmatch).
+        (nonstr_sig_tok_gt, None, True, "signature token",
+         "a non-str signature token is caught (R5-M3; latent str()-coerce overmatch)"),
+    ]
+    for gt_c, man_c, expect_violation, anchor, reason in integrity_cases:
+        try:
+            viols = gt_integrity_violations(gt_c, man_c)
+        except Exception as e:  # the validator must be total — a raise is a failure.
+            failures.append(
+                f"  gt_integrity_violations RAISED {type(e).__name__}: {e} ({reason})")
+            continue
+        if bool(viols) != expect_violation:
+            failures.append(
+                f"  expected violation={expect_violation} ({reason}), got={viols}")
+        elif anchor is not None and not any(anchor in v for v in viols):
+            # Non-vacuous: the mutation we seeded must produce a violation naming it.
+            failures.append(
+                f"  violation present but anchor {anchor!r} missing ({reason}): {viols}")
+
+    # R5-S1 runtime path: even bypassing the validator, withheld_strings()/leaks() on a
+    # non-string desc must NOT raise (belt-and-suspenders for the provenance scan).
+    for gt_c, reason in [(list_desc_gt, "list desc"), (num_desc_gt, "numeric desc"),
+                         (nonstr_sig_tok_gt, "non-str signature token")]:
+        try:
+            leaks("some provenance text", withheld_strings(gt_c))
+        except Exception as e:
+            failures.append(
+                f"  withheld_strings/leaks RAISED {type(e).__name__}: {e} "
+                f"({reason} — R5-S1 robustness)")
+    # And a clean bug with a valid string desc + all-string signature actually leaks
+    # those very strings when the provenance contains them (the scan still works).
+    valid_desc_gt = {"bugs": [_bug(desc="a unique sentinel desc",
+                                   signature=["uniquesig"])]}
+    try:
+        hit = leaks("text mentions uniquesig and a unique sentinel desc here",
+                    withheld_strings(valid_desc_gt))
+        kinds = {k for _, k in hit}
+        if kinds != {"signature", "desc"}:
+            failures.append(
+                f"  valid string desc/sig leak scan caught {kinds}, expected "
+                f"{{'signature', 'desc'}}")
+    except Exception as e:
+        failures.append(
+            f"  valid-desc leak scan RAISED {type(e).__name__}: {e}")
+
+    if failures:
+        print("SELFTEST FAILED:")
+        print("\n".join(failures))
+        return 1
+    print("SELFTEST OK — the leak scan fires on a seeded signature token "
+          "(case-insensitively) and a desc string, passes a "
+          "feature-plus-context-only provenance, and the GT-integrity check is a total, "
+          "complete-schema validator: it catches a duplicate bug_id, manifest n/bug_ids "
+          "mismatch, missing/empty/blank/non-list signature, missing required field, "
+          "wrong-typed fields (str/None/float line, int/empty file), an inverted range "
+          "(R4-S1), a non-string desc (R5-S1) and a non-str signature token (R5-M3), a "
+          "string off_axis, and a non-list 'bugs' / non-dict element / missing 'bugs' "
+          "key — all WITHOUT raising — while the provenance leak scan itself never "
+          "raises on a non-string desc/sig token yet still leaks valid string "
+          "desc/sig needles; a fully clean fixture passes untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/check_delve_helper_drift.py
+++ b/scripts/check_delve_helper_drift.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Function-scoped drift check for the delve eval-harness helpers (#373).
+
+Invocation (from repo root):
+    python3 scripts/check_delve_helper_drift.py            # check the tree
+    python3 scripts/check_delve_helper_drift.py --selftest # built-in logic tests
+
+The delve eval harness copies temper's `_dispatch_paths.py` / `_runid.py` helpers
+(the design's "link/derive, never copy" rule is relaxed for these tiny
+path/hash/validation utilities — copying with a machine-checked no-drift invariant
+is cheaper than a shared-package refactor; #424 precedent). This check tolerates the
+copy's *legitimate* edits (docstring/comment rewrites) yet still catches a logic fork.
+
+It is **function-scoped**: it diffs ONLY the bodies of the functions delve actually
+imports —
+  - `resolve_dispatch_dir`, `fixture_sha`, `template_sha` from `_dispatch_paths.py`
+  - `validate_run_id` from `_runid.py`
+— against temper's, parsing each side with `ast` and comparing those named function
+nodes by `ast.dump` (whitespace/comment/line-number insensitive). It does NOT compare
+the whole file, so the delve copy may freely omit temper-only helpers
+(`validate_prefix`, `sanitize_summary`) and delve CI never reddens when temper edits a
+function delve never calls.
+
+**Referenced module-level constants are in scope too:** a compared function's real
+logic can live in a module constant it references by name — `validate_run_id`'s run-id
+cap is the regex constant `_RUN_ID_RE`, not code in the body. So in addition to each
+function body, this check diffs the module-level single-target `Assign` nodes
+(`NAME = …`) that a compared function *loads* (e.g. `_RUN_ID_RE`). A forked constant
+(widening `{0,31}`→`{0,99}`, dropping the leading-`-` guard) therefore registers as
+drift even though the function body is byte-identical. Scoping stays surgical — only
+constants a compared function references, not every module global.
+
+**Docstring handling is by structural/AST position, NOT a blanket triple-quote
+regex:** a function's docstring is stripped before comparison ONLY for the sites the
+delve copy legitimately rewrites — the module docstring (never in the compared set: we
+compare function nodes only) and `template_sha` (whose docstring names the hashed
+artifact). Every OTHER compared function (`resolve_dispatch_dir`, `fixture_sha`,
+`validate_run_id`) keeps its docstring in the comparison, so a logic-altering rewrite
+of a non-{module,template_sha} docstring still FAILS the check.
+
+Exits 0 if the copies are faithful, 1 with a per-drift list otherwise. Stdlib only.
+"""
+from __future__ import annotations
+import ast
+import copy
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# (reference helper, delve copy, the function names delve imports)
+PAIRS = [
+    ("skills/temper/evals/_dispatch_paths.py",
+     "skills/delve/evals/_dispatch_paths.py",
+     ("resolve_dispatch_dir", "fixture_sha", "template_sha")),
+    ("skills/temper/evals/_runid.py",
+     "skills/delve/evals/_runid.py",
+     ("validate_run_id",)),
+]
+
+# Compared functions whose docstring the delve copy legitimately rewrites; their
+# docstring is stripped (by AST position) before comparison. The module-level docstring
+# is likewise rewritten in the copy but is never in the compared set (we compare only
+# the named FunctionDef nodes), so it needs no entry here.
+DOCSTRING_REWRITTEN = {"template_sha"}
+
+
+def _functions(src: str) -> dict:
+    """Map function name -> FunctionDef node for the top-level defs in `src`."""
+    return {n.name: n for n in ast.parse(src).body
+            if isinstance(n, ast.FunctionDef)}
+
+
+def _module_assigns(src: str) -> dict:
+    """Map single-target module-level constant name -> its `Assign` node. Covers
+    only `NAME = …` top-level assignments (the `_RUN_ID_RE = re.compile(...)` shape);
+    tuple/attribute/annotated targets are out of scope (none of the compared
+    helpers reference such)."""
+    out: dict = {}
+    for n in ast.parse(src).body:
+        if isinstance(n, ast.Assign) and len(n.targets) == 1 \
+                and isinstance(n.targets[0], ast.Name):
+            out[n.targets[0].id] = n
+    return out
+
+
+def _referenced_names(node: ast.FunctionDef) -> set:
+    """The set of bare Name ids loaded inside a function body (e.g. `_RUN_ID_RE`).
+    Used to scope the module-constant drift diff to ONLY constants a compared
+    function actually references — not every module global."""
+    return {sub.id for sub in ast.walk(node)
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load)}
+
+
+def _strip_docstring(node: ast.FunctionDef) -> ast.FunctionDef:
+    """Return a copy of `node` with a leading docstring statement removed by AST
+    position (the first stmt iff it is a bare string Constant Expr) — NOT by a
+    triple-quote regex over the source."""
+    node = copy.deepcopy(node)
+    body = node.body
+    if (body and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)):
+        node.body = body[1:]
+    return node
+
+
+def _dump(node: ast.FunctionDef, strip: bool) -> str:
+    if strip:
+        node = _strip_docstring(node)
+    return ast.dump(node)
+
+
+def compare_sources(ref_src: str, copy_src: str, names) -> list:
+    """Return a list of drift descriptions for the named functions (empty == faithful).
+
+    Besides each function's body, this also diffs the module-level constant
+    `Assign` nodes that the function *references by name* (e.g. `validate_run_id`'s
+    `_RUN_ID_RE`). A compared function's real logic can live in such a constant
+    (the run-id cap regex), so a forked constant referenced by a faithful-looking
+    body must still register as drift. Scoping is surgical: only constants a
+    compared function loads, not every module global."""
+    ref = _functions(ref_src)
+    cp = _functions(copy_src)
+    ref_assigns = _module_assigns(ref_src)
+    cp_assigns = _module_assigns(copy_src)
+    drift = []
+    for name in names:
+        if name not in ref:
+            drift.append(f"{name}: missing from reference (temper) helper")
+            continue
+        if name not in cp:
+            drift.append(f"{name}: missing from delve copy")
+            continue
+        strip = name in DOCSTRING_REWRITTEN
+        if _dump(ref[name], strip) != _dump(cp[name], strip):
+            note = " (docstring-stripped)" if strip else ""
+            drift.append(f"{name}: body diverged from temper{note}")
+        # Diff module-level constants this function references (catch a logic fork
+        # that lives in a referenced constant, not the function body).
+        refd = _referenced_names(ref[name]) | _referenced_names(cp[name])
+        for const in sorted(refd & (set(ref_assigns) | set(cp_assigns))):
+            in_ref, in_cp = const in ref_assigns, const in cp_assigns
+            if in_ref and in_cp:
+                if ast.dump(ref_assigns[const]) != ast.dump(cp_assigns[const]):
+                    drift.append(
+                        f"{name}: referenced module constant {const} diverged "
+                        f"from temper")
+            elif in_ref != in_cp:
+                where = "delve copy" if in_ref else "reference (temper) helper"
+                drift.append(
+                    f"{name}: referenced module constant {const} missing from "
+                    f"{where}")
+    return drift
+
+
+def main() -> int:
+    all_drift = []
+    for ref_rel, copy_rel, names in PAIRS:
+        ref_src = (ROOT / ref_rel).read_text(encoding="utf-8")
+        copy_src = (ROOT / copy_rel).read_text(encoding="utf-8")
+        for d in compare_sources(ref_src, copy_src, names):
+            all_drift.append(f"{copy_rel}: {d}")
+    if all_drift:
+        print("DELVE HELPER DRIFT — the copied helpers diverged from temper:")
+        for d in all_drift:
+            print(f"  {d}")
+        print("\nRe-sync the copied function bodies with "
+              "skills/temper/evals/, or update this check if the divergence is "
+              "intentional. See scripts/check_delve_helper_drift.py docstring.")
+        return 1
+    print("OK — delve's copied helpers match temper for every imported "
+          "function and each module constant they reference (e.g. _RUN_ID_RE); "
+          "module + template_sha docstrings excepted.")
+    return 0
+
+
+def selftest() -> int:
+    """Built-in logic tests, in-memory, against the real temper reference.
+
+    Two negative legs pin the structural docstring strip:
+      case-A — a non-docstring body-line fork in resolve_dispatch_dir must be caught;
+      case-B — a reworded NON-{module,template_sha} docstring (fixture_sha's) must be
+               caught (an "all-docstrings" stripper would false-PASS this).
+    A third negative leg pins the referenced-constant teeth:
+      case-D — a forked module constant `_RUN_ID_RE` (cap {0,31}->{0,99}) referenced
+               by an otherwise byte-identical validate_run_id must be caught.
+    Plus a positive leg (the real clean copy is faithful) and a tolerance leg (a
+    template_sha docstring reword is tolerated)."""
+    ref_rel, copy_rel, names = PAIRS[0]  # _dispatch_paths pair
+    ref_src = (ROOT / ref_rel).read_text(encoding="utf-8")
+    clean_copy = (ROOT / copy_rel).read_text(encoding="utf-8")
+
+    failures = []
+
+    # positive leg — the committed copy is faithful
+    drift = compare_sources(ref_src, clean_copy, names)
+    if drift:
+        failures.append(f"positive: clean copy unexpectedly drifted: {drift}")
+
+    # case-A — fork a non-docstring body line in resolve_dispatch_dir → must FAIL
+    case_a = clean_copy.replace(
+        'f"{user}-crucible-dispatch-{run_id}"',
+        'f"{user}-MUTATED-dispatch-{run_id}"')
+    if case_a == clean_copy:
+        failures.append("case-A: mutation anchor not found (test is vacuous)")
+    drift = compare_sources(ref_src, case_a, names)
+    if not any("resolve_dispatch_dir" in d for d in drift):
+        failures.append(f"case-A: body fork in resolve_dispatch_dir NOT caught: {drift}")
+
+    # case-B — reword fixture_sha's (non-stripped) docstring → must FAIL
+    case_b = clean_copy.replace(
+        '"""S-A: sha256 of canonical JSON of the evals.json fixture record."""',
+        '"""Reworded: hash the canonical fixture record."""')
+    if case_b == clean_copy:
+        failures.append("case-B: docstring anchor not found (test is vacuous)")
+    drift = compare_sources(ref_src, case_b, names)
+    if not any("fixture_sha" in d for d in drift):
+        failures.append(f"case-B: fixture_sha docstring reword NOT caught "
+                        f"(over-strip): {drift}")
+
+    # tolerance leg — rewording template_sha's docstring is tolerated (no drift)
+    case_c = clean_copy.replace(
+        "sha256 of a committed delve fixture/prompt artifact",
+        "sha256 of a delve eval artifact")
+    if case_c == clean_copy:
+        failures.append("tolerance: template_sha docstring anchor not found")
+    drift = compare_sources(ref_src, case_c, names)
+    if drift:
+        failures.append(f"tolerance: template_sha docstring reword should be "
+                        f"tolerated, got drift: {drift}")
+
+    # case-D — fork the referenced module constant _RUN_ID_RE (widen the cap
+    # {0,31}->{0,99}, a real behavior fork) with a byte-identical validate_run_id
+    # body → must FAIL on the constant, not the body. Uses the _runid pair (PAIRS[1]).
+    runid_ref_rel, runid_copy_rel, runid_names = PAIRS[1]
+    runid_ref_src = (ROOT / runid_ref_rel).read_text(encoding="utf-8")
+    runid_clean_copy = (ROOT / runid_copy_rel).read_text(encoding="utf-8")
+    # sanity: the clean copy is faithful (constant included)
+    drift = compare_sources(runid_ref_src, runid_clean_copy, runid_names)
+    if drift:
+        failures.append(f"case-D positive: clean _runid copy unexpectedly "
+                        f"drifted: {drift}")
+    case_d = runid_clean_copy.replace(
+        r"[A-Za-z0-9_-]{0,31}$", r"[A-Za-z0-9_-]{0,99}$")
+    if case_d == runid_clean_copy:
+        failures.append("case-D: _RUN_ID_RE cap anchor not found (test is vacuous)")
+    drift = compare_sources(runid_ref_src, case_d, runid_names)
+    if not any("_RUN_ID_RE" in d for d in drift):
+        failures.append(f"case-D: forked _RUN_ID_RE constant NOT caught "
+                        f"(referenced-constant blindness): {drift}")
+
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("SELFTEST OK — function-scoped comparison catches body forks (case-A), "
+          "non-{module,template_sha} docstring rewrites (case-B), and a forked "
+          "referenced module constant _RUN_ID_RE (case-D); tolerates the "
+          "template_sha docstring reword.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -115,6 +115,13 @@ run python3 -m pytest skills/build/evals/minimalism-ladder/ -q
 # global expectations, and the #297 inquisitor-dimension suites.
 run python3 -m pytest skills/temper/evals/ -q
 
+# --- Delve eval harness (#373) ---
+run python3 -m pytest skills/delve/evals/ -q
+run python3 scripts/check_delve_helper_drift.py --selftest
+run python3 scripts/check_delve_helper_drift.py
+run python3 scripts/check_delve_gt_provenance.py --selftest
+run python3 scripts/check_delve_gt_provenance.py
+
 # --- Catalog unit suite ---
 run python3 scripts/test_catalog.py
 

--- a/skills/delve/evals/README.md
+++ b/skills/delve/evals/README.md
@@ -1,0 +1,104 @@
+# Delve eval harness (#373)
+
+A regression harness for `delve` (the instance-bug finder). The oracle is a
+**deterministic matcher** (`_matcher.py`) — NOT an LLM judge — so scoring is LLM-free
+and the scorer + fixtures + harness tests are **CI-gated** (real regression
+protection). The live `/delve` run between `stage` and `score` is **manual/periodic**:
+it produces a recorded findings JSON that the deterministic scorer consumes. This
+mirrors inquisitor's split (deterministic harness-tests in CI; the live decision-run
+out of CI).
+
+## Invocation (module form)
+
+Run from the repo root (the package uses relative imports, so `-m` is required):
+
+```
+python3 -m skills.delve.evals.run_evals stage <run-id> [--fixture ID] [--force]
+python3 -m skills.delve.evals.run_evals score <run-id> [--allow-incomplete]
+```
+
+`stage` prints the dispatch dir path.
+
+## The matcher (oracle)
+
+A recorded finding `F` **matches** a planted bug `B` iff ALL hold:
+
+1. **same file** (repo-relative POSIX, normalized — backslashes → `/`, leading `./`
+   stripped).
+2. **line overlap**: `F`'s line (an `int`, `"12"`, or `"12-15"` range) intersects
+   `[B.line_lo − slop, B.line_hi + slop]`, with `slop = 2` (tolerate off-by-a-line
+   drift).
+3. **signature gate**: ≥1 of `B.signature` (lowercased substring tokens) appears in
+   `F.summary` (falling back to `F.failure_scenario`). This cuts positional
+   false-positives — a finding at the right line about the **wrong** defect does not
+   score.
+
+Matching is **bipartite, one-to-one, maximum-cardinality** (Kuhn augmenting-path):
+candidate edges are *visited* in ranked order — by overlap size, then signature-hit
+count, with a deterministic tie-break by `bug_id` then finding index — so among all
+maximum matchings the result is deterministic and high-weight. Each planted bug is
+credited at most once, each finding consumed at most once. Metrics:
+
+- **recall** = matched planted bugs / total planted bugs.
+- **false-positive rate** = unmatched kept findings / total kept findings.
+- **off-axis recall** (advisory) = recall restricted to `off_axis: true` bugs.
+
+A recorded finding whose `line` is unparseable (e.g. `null`, `""`, `"abc"`, `"12-"`)
+is counted as an **unmatched false positive** (and `score` warns to stderr + reports a
+per-cell `malformed_findings` count) — it is neither silently dropped nor allowed to
+crash the run.
+
+## Workflow (stage → manual collect → score)
+
+1. **`stage <run-id>`** writes `stage-manifest.json` to the dispatch dir, enumerating
+   one cell per fixture: `{fixture_id, scope, result_file, dispatch_note}`. It prints
+   the dispatch dir.
+
+2. **collect** (manual — there is no `collect` subcommand). For each cell, follow its
+   `dispatch_note`:
+   - Run `/delve <scope>` (the engine's normal invocation).
+   - Save the engine's ranked **8-field** findings JSON array (`file`, `line`,
+     `summary`, `failure_scenario`, `severity`, `verdict`, `scope`, `effort`) to the
+     cell's `result_file` in the dispatch dir.
+   - Prepend `DISPATCH_STATUS: OK` then a blank line before the JSON (use
+     `DISPATCH_STATUS: ERROR` if the dispatch failed — that cell scores 0).
+   - **Path form:** save each finding's `file` **verbatim** — the harness reconciles
+     the cell's `scope` prefix at score time, so a `file` recorded bare
+     (`inventory.py`) OR scope-prefixed (`<scope>/inventory.py`) both join to the
+     ground-truth (fixture-relative) form. No manual path rewriting is needed.
+   - When every cell is recorded, write an empty `.collect-status` file in the
+     dispatch dir.
+
+3. **`score <run-id>`** reads `stage-manifest.json` + the recorded findings, runs the
+   matcher against each fixture's `ground-truth-bugs.json`, and writes
+   `skills/delve/evals/last_run.json` + `results.md` (both git-ignored). It **refuses**
+   without `.collect-status` unless `--allow-incomplete` (which stamps
+   `complete: false` — smoke/debug only).
+
+## Fixtures
+
+`fixtures/<repo>/`:
+- a tiny hermetic module with deliberately **planted defects** at known file:line;
+- `ground-truth-bugs.json` — the planted bugs:
+  `{bug_id, file, line_lo, line_hi, signature[], desc, off_axis, severity}`;
+- `ground-truth-bugs.provenance.md` — the **verbatim blind-author input**, with the
+  `signature` tokens + `desc` strings WITHHELD (so the recorded run is scored against
+  an unbiased oracle);
+- `manifest.json` — `{repo_id, scope, bug_ids, n}`.
+
+`scripts/check_delve_gt_provenance.py` proves the blind boundary held (the provenance
+file contains none of the withheld signature/desc strings).
+
+## Files
+
+- `run_evals.py` — `stage` + `score` (no `collect`).
+- `_matcher.py` — the deterministic matcher (delve-original).
+- `_dispatch_paths.py`, `_runid.py` — copied from temper. The drift check
+  `scripts/check_delve_helper_drift.py` is **function-scoped** to the functions delve
+  imports, so the copies may omit temper's unused helpers without reddening CI.
+- `test_matcher.py`, `test_run_evals_stage.py`, `test_run_evals_score.py`,
+  `test_runid.py` — the gating unit tests (run by `scripts/run_tests.sh`).
+
+**Deferred (post-merge, not in CI):** the live `/delve` decision run that produces the
+actual recall/FP numbers, recorded in `docs/evals.md`. The **siege** slice is a
+separate follow-up on #373 (same pattern under `skills/siege/evals/`).

--- a/skills/delve/evals/_dispatch_paths.py
+++ b/skills/delve/evals/_dispatch_paths.py
@@ -1,0 +1,29 @@
+# Copied from skills/temper/evals/_dispatch_paths.py (#424). Mirrors temper's helper; kept AST-identical by scripts/check_delve_helper_drift.py.
+"""Dispatch-dir path resolution + fixture hashing for the delve eval harness (#373).
+Mirrors temper's helper of the same name."""
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+def resolve_dispatch_dir(run_id: str) -> Path:
+    """Resolve XDG_RUNTIME_DIR or /tmp + USER or UID namespacing.
+
+    M-α: USER may be unset in container environments.
+    """
+    base = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+    user = os.environ.get("USER") or str(os.getuid())
+    return Path(base) / f"{user}-crucible-dispatch-{run_id}"
+
+
+def fixture_sha(fixture_record: dict) -> str:
+    """S-A: sha256 of canonical JSON of the evals.json fixture record."""
+    canonical = json.dumps(fixture_record, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def template_sha(template_path: Path) -> str:
+    """sha256 of a committed delve fixture/prompt artifact at stage time, recorded in
+    the manifest so byte-identity invariants are checkable."""
+    return hashlib.sha256(template_path.read_bytes()).hexdigest()

--- a/skills/delve/evals/_matcher.py
+++ b/skills/delve/evals/_matcher.py
@@ -1,0 +1,168 @@
+"""The deterministic matcher/oracle for the delve eval harness (#373).
+
+LLM-free, pure, stdlib-only — this is the CI-gated half of the harness (the scorer),
+so its arithmetic is pinned by test_matcher.py. It takes a recorded delve findings
+list + a ground-truth planted-bug list and computes recall + false-positive rate.
+
+A finding F matches a planted bug B iff ALL hold (design §"The deterministic matcher"):
+  1. same file (repo-relative POSIX, normalized).
+  2. line overlap: F's line (int or "lo-hi") ∩ [B.line_lo - slop, B.line_hi + slop].
+  3. signature gate: ≥1 of B.signature (lowercased substring tokens) appears in F's
+     summary (falling back to failure_scenario). This cuts positional false-positives
+     — a finding at the right line about the WRONG defect does not score.
+
+Matching is bipartite, one-to-one: each planted bug is credited at most once and each
+finding consumed at most once, so two findings on one bug don't inflate recall and one
+finding spanning two bugs doesn't double-count. Resolution is MAXIMUM-CARDINALITY
+(augmenting-path / Kuhn's algorithm) so recall is never understated by a greedy choice
+consuming a finding/bug that a unique edge needed. Determinism: candidate edges are
+visited in the existing ranked order ((line-overlap size, signature-hit count)
+descending, tie-broken by bug_id then finding index), so among all maximum matchings a
+stable, high-weight, reproducible one is returned.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+
+_DEFAULT_LINE_SLOP = 2
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    matched: list            # list[(bug_id, finding_idx)]
+    recall: float
+    false_positive_rate: float
+    unmatched_bugs: list     # list[bug_id]
+    unmatched_findings: list  # list[int]
+
+
+def normalize_file(path: str) -> str:
+    """Normalize a file path to repo-relative POSIX form for comparison: backslashes
+    → forward slashes, a leading `./` stripped. Pure string transform (no filesystem)."""
+    p = (path or "").replace("\\", "/")
+    while p.startswith("./"):
+        p = p[2:]
+    return p
+
+
+def parse_line(v) -> tuple:
+    """Parse a finding/bug line spec into an inclusive (lo, hi) int tuple. Accepts an
+    int (12), a numeric string ("12"), or a range string ("12-15", whitespace ok)."""
+    if isinstance(v, int):
+        return (v, v)
+    s = str(v).strip()
+    if "-" in s:
+        lo, _, hi = s.partition("-")
+        return (int(lo.strip()), int(hi.strip()))
+    n = int(s)
+    return (n, n)
+
+
+def _overlap(a_lo: int, a_hi: int, b_lo: int, b_hi: int) -> int:
+    """Size of the inclusive integer overlap of [a_lo,a_hi] and [b_lo,b_hi]; 0 if
+    disjoint. A single-line touch (a_lo==a_hi inside the range) counts as 1."""
+    lo = max(a_lo, b_lo)
+    hi = min(a_hi, b_hi)
+    return (hi - lo + 1) if hi >= lo else 0
+
+
+def _signature_hits(bug: dict, finding: dict) -> int:
+    """Count how many of bug['signature'] tokens (lowercased substring) appear in the
+    finding's summary OR its failure_scenario fallback. The two fields are searched as
+    one lowercased haystack so a signature recorded only in failure_scenario still
+    scores (design §"signature gate": present in summary and/or failure_scenario)."""
+    text = ((finding.get("summary") or "") + "\n"
+            + (finding.get("failure_scenario") or "")).lower()
+    return sum(1 for tok in bug.get("signature", []) if str(tok).lower() in text)
+
+
+def match(findings: list, ground_truth: list,
+          line_slop: int = _DEFAULT_LINE_SLOP) -> MatchResult:
+    """Bipartite one-to-one match of recorded findings against planted bugs.
+
+    Returns a MatchResult with the matched (bug_id, finding_idx) pairs, recall,
+    false-positive rate, and the unmatched bug ids + finding indices."""
+    # Build every candidate edge (bug, finding) that satisfies all three gates,
+    # carrying the overlap size + signature hit count for ranking.
+    candidates = []  # (overlap, sig_hits, bug_id, finding_idx)
+    for bug in ground_truth:
+        b_lo = bug["line_lo"] - line_slop
+        b_hi = bug["line_hi"] + line_slop
+        b_file = normalize_file(bug["file"])
+        for fi, finding in enumerate(findings):
+            if normalize_file(finding.get("file", "")) != b_file:
+                continue
+            try:
+                f_lo, f_hi = parse_line(finding.get("line"))
+            except (ValueError, TypeError):
+                # A recorded finding with an unparseable `line` (None, "", "abc",
+                # "12-", "3.7", …) yields NO candidate edge here, so it is never
+                # matched to any bug — the n_findings/used_findings arithmetic below
+                # then counts it as a kept-but-unmatched finding (a false positive),
+                # rather than crashing the whole score. `parse_line` stays fail-loud
+                # for direct callers; only this candidate build degrades gracefully.
+                continue
+            ov = _overlap(f_lo, f_hi, b_lo, b_hi)
+            if ov <= 0:
+                continue
+            hits = _signature_hits(bug, finding)
+            if hits <= 0:
+                continue
+            candidates.append((ov, hits, bug["bug_id"], fi))
+
+    # Maximum-cardinality bipartite matching by augmenting paths (Kuhn's algorithm).
+    # Candidate edges are ranked best-first (largest overlap, then most signature
+    # hits), deterministic tie-break by bug_id then finding index. Processing bugs in
+    # that ranked order makes the result deterministic and high-weight among all
+    # maximum matchings; the augmenting search guarantees the cardinality is maximal,
+    # so a high-weight edge never starves a unique low-weight edge.
+    candidates.sort(key=lambda c: (-c[0], -c[1], c[2], c[3]))
+
+    # Adjacency in ranked order: for each bug, its candidate finding indices, and the
+    # bug visitation order — both first-seen order over the sorted candidate list.
+    adj: dict = {}
+    bug_order = []
+    for _ov, _hits, bug_id, fi in candidates:
+        if bug_id not in adj:
+            adj[bug_id] = []
+            bug_order.append(bug_id)
+        adj[bug_id].append(fi)
+
+    finding_to_bug: dict = {}  # finding_idx -> bug_id currently matched to it
+
+    def _augment(bug_id, visited) -> bool:
+        for fi in adj[bug_id]:
+            if fi in visited:
+                continue
+            visited.add(fi)
+            holder = finding_to_bug.get(fi)
+            if holder is None or _augment(holder, visited):
+                finding_to_bug[fi] = bug_id
+                return True
+        return False
+
+    for bug_id in bug_order:
+        _augment(bug_id, set())
+
+    # Reconstruct matched pairs in the deterministic bug visitation order.
+    bug_to_finding = {b: f for f, b in finding_to_bug.items()}
+    matched = [(bug_id, bug_to_finding[bug_id])
+               for bug_id in bug_order if bug_id in bug_to_finding]
+    used_bugs = set(bug_to_finding)
+    used_findings = set(finding_to_bug)
+
+    n_bugs = len(ground_truth)
+    n_findings = len(findings)
+    recall = (len(matched) / n_bugs) if n_bugs else 1.0
+    n_unmatched_findings = n_findings - len(used_findings)
+    fp_rate = (n_unmatched_findings / n_findings) if n_findings else 0.0
+    unmatched_bugs = [b["bug_id"] for b in ground_truth
+                      if b["bug_id"] not in used_bugs]
+    unmatched_findings = [i for i in range(n_findings) if i not in used_findings]
+
+    return MatchResult(
+        matched=matched,
+        recall=recall,
+        false_positive_rate=fp_rate,
+        unmatched_bugs=unmatched_bugs,
+        unmatched_findings=unmatched_findings,
+    )

--- a/skills/delve/evals/_runid.py
+++ b/skills/delve/evals/_runid.py
@@ -1,0 +1,19 @@
+# Copied from skills/temper/evals/_runid.py (#424). Mirrors temper's helper; kept AST-identical by scripts/check_delve_helper_drift.py.
+"""Run-id validation utility for the delve eval harness (#373). I-9 enforcement;
+mirrors temper's helper of the same name. Temper's calibrate-only helpers
+(sanitize_summary, validate_prefix) are intentionally omitted — the drift check is
+function-scoped to validate_run_id, so dropping the unused helpers does not redden CI."""
+import re
+
+# 2P-4: first char must NOT be `-` (else run-id parses as a CLI flag downstream).
+# Subsequent chars may include `-`.
+# M-R7-1: leading underscore is technically legal; treated equivalent to alphanumeric for path-traversal safety (`_foo` resolves identically to `foo` w.r.t. directory escape).
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$")
+
+
+def validate_run_id(run_id: str) -> None:
+    """Raise ValueError if run-id violates I-9."""
+    if not _RUN_ID_RE.fullmatch(run_id):
+        raise ValueError(
+            f"invalid run-id {run_id!r}: must match {_RUN_ID_RE.pattern}"
+        )

--- a/skills/delve/evals/fixtures/sample/ground-truth-bugs.json
+++ b/skills/delve/evals/fixtures/sample/ground-truth-bugs.json
@@ -1,0 +1,29 @@
+{
+  "_provenance": "Bugs were planted by the fixture author, then ground-truth-bugs.provenance.md was written BLIND (the signature tokens + desc strings below are WITHHELD from that provenance input, so the recorded delve run is scored against an unbiased oracle). scripts/check_delve_gt_provenance.py proves the blind boundary held.",
+  "bugs": [
+    {"bug_id": "sm-b1", "file": "inventory.py", "line_lo": 11, "line_hi": 11,
+     "signature": ["off-by-one", "slice", "last element"],
+     "desc": "last_n drops the final element via items[-n:-1]",
+     "off_axis": false, "severity": "Important"},
+    {"bug_id": "sm-b2", "file": "inventory.py", "line_lo": 15, "line_hi": 17,
+     "signature": ["mutable default", "default argument", "discounts=[]"],
+     "desc": "total_price uses a mutable default discounts=[] persisted across calls",
+     "off_axis": false, "severity": "Important"},
+    {"bug_id": "sm-b3", "file": "inventory.py", "line_lo": 24, "line_hi": 24,
+     "signature": ["comparison operator", "wrong operator", ">= 0", "boundary"],
+     "desc": "is_in_stock uses >= 0 so a zero quantity is wrongly in stock",
+     "off_axis": false, "severity": "Important"},
+    {"bug_id": "sm-b4", "file": "inventory.py", "line_lo": 30, "line_hi": 30,
+     "signature": ["keyerror", "missing key", "unknown sku", "not initialized"],
+     "desc": "restock raises KeyError on an unknown sku instead of initializing it",
+     "off_axis": false, "severity": "Important"},
+    {"bug_id": "sm-b5", "file": "report.py", "line_lo": 10, "line_hi": 10,
+     "signature": ["resource leak", "not closed", "file handle", "context manager"],
+     "desc": "write_report never closes the file handle",
+     "off_axis": true, "severity": "Minor"},
+    {"bug_id": "sm-b6", "file": "report.py", "line_lo": 19, "line_hi": 19,
+     "signature": ["division by zero", "zerodivisionerror", "empty", "unguarded division"],
+     "desc": "average divides by len(values) without guarding an empty list",
+     "off_axis": false, "severity": "Important"}
+  ]
+}

--- a/skills/delve/evals/fixtures/sample/ground-truth-bugs.provenance.md
+++ b/skills/delve/evals/fixtures/sample/ground-truth-bugs.provenance.md
@@ -1,0 +1,33 @@
+# Blind-author input for the `sample` delve fixture (#373)
+
+This is the VERBATIM context handed to the blind ground-truth author. It describes
+the feature under review and the codebase facts only. The planted bugs' signature
+tokens and their `desc` strings in `ground-truth-bugs.json` are deliberately
+WITHHELD here, so the author cannot reverse-engineer the answer key from this file.
+`scripts/check_delve_gt_provenance.py` machine-verifies that none of those withheld
+strings appear below.
+
+## Feature under review
+
+A two-module inventory toolkit:
+
+- `inventory.py` — helpers for a small store: returning the most recent items, a
+  cart total with an optional adjustments list, an availability check, and a stock
+  top-up routine.
+- `report.py` — writes a per-row text report to a path and computes an arithmetic
+  mean over a list of numbers.
+
+## Codebase facts
+
+- Pure Python, standard library only; no external packages.
+- Each public function is a few lines; there is no shared mutable state across
+  modules.
+- The store callers pass ordinary Python lists and dicts; SKUs are dict keys.
+- The report writer is expected to persist every row it is given and hand back the
+  path it wrote to.
+
+## Task for the reviewer
+
+Review these two modules for defects a careful engineer would flag in code review.
+Report each issue you find with the file, the line, a one-line summary, and the
+failure scenario it produces.

--- a/skills/delve/evals/fixtures/sample/inventory.py
+++ b/skills/delve/evals/fixtures/sample/inventory.py
@@ -1,0 +1,31 @@
+"""Tiny inventory module for the delve eval fixture (#373). Hermetic, stdlib-only.
+
+Contains deliberately PLANTED defects at known lines — see ground-truth-bugs.json.
+Do not "fix" these in place; they are the eval substrate.
+"""
+
+
+def last_n(items, n):
+    # PLANTED b1 (line 11): off-by-one slice — drops the final element. Should be
+    # items[-n:]; items[-n:-1] omits the last item entirely.
+    return items[-n:-1]
+
+
+def total_price(cart, discounts=[]):
+    # PLANTED b2 (lines 15-17): mutable default argument — `discounts` is shared across
+    # calls, so an append in one call leaks into the next.
+    discounts.append(0)
+    return sum(cart) - sum(discounts)
+
+
+def is_in_stock(quantity):
+    # PLANTED b3 (line 24): wrong comparison operator — treats a quantity of exactly
+    # 0 as in stock (should be `> 0`, not `>= 0`).
+    return quantity >= 0
+
+
+def restock(levels, sku, amount):
+    # PLANTED b4 (line 30): missing key guard — a KeyError is raised for an
+    # unknown sku instead of initializing it.
+    levels[sku] = levels[sku] + amount
+    return levels

--- a/skills/delve/evals/fixtures/sample/manifest.json
+++ b/skills/delve/evals/fixtures/sample/manifest.json
@@ -1,0 +1,6 @@
+{
+  "repo_id": "sample",
+  "scope": "skills/delve/evals/fixtures/sample",
+  "bug_ids": ["sm-b1", "sm-b2", "sm-b3", "sm-b4", "sm-b5", "sm-b6"],
+  "n": 6
+}

--- a/skills/delve/evals/fixtures/sample/report.py
+++ b/skills/delve/evals/fixtures/sample/report.py
@@ -1,0 +1,19 @@
+"""Tiny reporting module for the delve eval fixture (#373). Hermetic, stdlib-only.
+
+Contains deliberately PLANTED defects at known lines — see ground-truth-bugs.json.
+"""
+
+
+def write_report(path, rows):
+    # PLANTED b5 (line 10): resource leak — the file handle is never closed (no
+    # context manager, no .close()).
+    f = open(path, "w")
+    for row in rows:
+        f.write(str(row) + "\n")
+    return path
+
+
+def average(values):
+    # PLANTED b6 (line 19): unguarded division — an empty `values` raises
+    # ZeroDivisionError instead of returning 0.
+    return sum(values) / len(values)

--- a/skills/delve/evals/run_evals.py
+++ b/skills/delve/evals/run_evals.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Delve eval harness — `stage` + `score` (#373).
+
+Mirrors temper's/inquisitor's module layout: package-relative helper imports,
+`if __name__ == "__main__": sys.exit(main())`. Invoked as a module from repo root
+(relative imports require `-m`):
+
+    python3 -m skills.delve.evals.run_evals stage <run-id> [--fixture ID]
+    python3 -m skills.delve.evals.run_evals score <run-id> [--allow-incomplete]
+
+This is the LEAN single-engine variant — NOT inquisitor's multi-arm A/B harness.
+The oracle is the deterministic matcher (`_matcher.py`), not an LLM judge, so `score`
+is fully deterministic and CI-gated; the live `/delve` run between stage and score is
+manual (a human operator records the 8-field findings JSON per the README contract).
+
+`stage` writes a `stage-manifest.json` enumerating one cell per fixture and a rendered
+dispatch note. `score` reads the recorded findings per cell, runs the matcher against
+each fixture's `ground-truth-bugs.json`, and writes `last_run.json` + `results.md`.
+"""
+from __future__ import annotations
+import argparse
+import datetime as _dt
+import json
+import sys
+from pathlib import Path
+
+from ._dispatch_paths import resolve_dispatch_dir
+from ._runid import validate_run_id
+from ._matcher import match, parse_line
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EVALS_DIR = Path(__file__).resolve().parent
+_FIXTURES_DIR = _EVALS_DIR / "fixtures"
+
+# The dispatch-health sentinel the operator prepends to each recorded result file
+# (mirrors inquisitor's `DISPATCH_STATUS: OK\n\n<body>` handshake). An `OK` sentinel
+# is consumed; an `ERROR` sentinel scores that cell as 0 findings (a recorded
+# dispatch failure, not a clean "found nothing").
+_STATUS_PREFIX = "DISPATCH_STATUS:"
+
+
+def _fixture_dirs() -> list:
+    """Every fixture dir under fixtures/ that carries a ground-truth-bugs.json."""
+    if not _FIXTURES_DIR.exists():
+        return []
+    return sorted(d for d in _FIXTURES_DIR.iterdir()
+                  if d.is_dir() and (d / "ground-truth-bugs.json").exists())
+
+
+def _dispatch_note(fixture_id: str, scope: str, result_file: str) -> str:
+    """The human-operator instruction rendered into the manifest for one cell."""
+    return (
+        f"# Delve eval — collect step for fixture {fixture_id!r}\n\n"
+        f"1. Run `/delve {scope}` (the engine's normal invocation).\n"
+        f"2. Save the engine's ranked 8-field findings JSON array to `{result_file}` "
+        f"in this dispatch dir.\n"
+        f"3. Prepend the line `{_STATUS_PREFIX} OK` then a blank line before the JSON "
+        f"(use `{_STATUS_PREFIX} ERROR` if the dispatch failed — that cell scores 0).\n"
+        f"4. When every cell is recorded, write an empty `.collect-status` file in "
+        f"this dispatch dir.\n"
+    )
+
+
+def stage(run_id: str, *, fixture: str | None = None, force: bool = False) -> Path:
+    """Render a stage-manifest.json enumerating one cell per fixture + the operator
+    dispatch note. Returns the dispatch dir path."""
+    validate_run_id(run_id)
+    fixtures = _fixture_dirs()
+    if fixture is not None:
+        fixtures = [d for d in fixtures if d.name == fixture]
+        if not fixtures:
+            raise ValueError(f"--fixture {fixture!r} not found under {_FIXTURES_DIR}")
+    if not fixtures:
+        raise ValueError(f"no fixtures with ground-truth-bugs.json under {_FIXTURES_DIR}")
+
+    dispatch_dir = resolve_dispatch_dir(run_id)
+    if dispatch_dir.exists():
+        if not force:
+            raise FileExistsError(
+                f"dispatch dir {dispatch_dir} already exists; pass force=True")
+        import shutil
+        shutil.rmtree(dispatch_dir)
+    dispatch_dir.mkdir(parents=True)
+
+    ts = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    cells = []
+    for d in fixtures:
+        manifest = json.loads((d / "manifest.json").read_text(encoding="utf-8"))
+        scope = manifest.get("scope", str(d.relative_to(_REPO_ROOT)))
+        result_file = f"{d.name}-findings.json"
+        cells.append({
+            "fixture_id": d.name,
+            "scope": scope,
+            "result_file": result_file,
+            "dispatch_note": _dispatch_note(d.name, scope, result_file),
+        })
+
+    out = {
+        "run_id": run_id,
+        "stage_timestamp": ts,
+        "engine": "delve",
+        "fixtures": len(fixtures),
+        "cells": cells,
+    }
+    (dispatch_dir / "stage-manifest.json").write_text(
+        json.dumps(out, indent=2), encoding="utf-8")
+    return dispatch_dir
+
+
+def _parse_findings(path: Path) -> tuple:
+    """Parse a recorded findings file → (findings_list, dispatch_failed).
+
+    Strips an optional leading `DISPATCH_STATUS:` sentinel (inquisitor's pattern):
+    an `OK` sentinel is consumed and the rest parses as a JSON findings array; an
+    `ERROR` (or any non-OK) sentinel → ([], True) so the cell scores 0/empty. A file
+    with no sentinel parses as a bare JSON array (backward-compatible, as the unit
+    tests write). A missing file → ([], True)."""
+    if not path.exists():
+        return [], True
+    text = path.read_text(encoding="utf-8")
+    stripped = text.lstrip()
+    if stripped.startswith(_STATUS_PREFIX):
+        first, _, rest = stripped.partition("\n")
+        sentinel = first.strip()
+        if sentinel.startswith(f"{_STATUS_PREFIX} ERROR"):
+            return [], True
+        if not sentinel.startswith(f"{_STATUS_PREFIX} OK"):
+            return [], True  # malformed sentinel → dispatch failure
+        text = rest
+    text = text.strip()
+    if not text:
+        return [], True
+    data = json.loads(text)
+    if not isinstance(data, list):
+        raise ValueError(f"recorded findings in {path} is not a JSON array")
+    return data, False
+
+
+def _reconcile_scope(findings: list, scope: str) -> list:
+    """Anchor each recorded finding's `file` to fixture-root-relative form.
+
+    Ground-truth `file`s are BARE fixture-relative names (`inventory.py`). The live
+    `/delve <scope>` engine may emit a scope-relative or repo-relative path
+    (`<scope>/inventory.py`) and the README contract says save it verbatim. Strip the
+    fixture's known `scope` prefix (and a trailing slash) so a finding emitted as
+    `<scope>/inventory.py` OR bare `inventory.py` both normalize to the GT form before
+    the (deliberately generic) matcher's file gate runs. Generic — no hard-coded
+    fixture names; `scope` comes from the manifest cell. Returns a new list (the
+    recorded findings are not mutated)."""
+    if not scope:
+        return findings
+    from ._matcher import normalize_file
+    prefix = normalize_file(scope).rstrip("/") + "/"
+    out = []
+    for f in findings:
+        nf = normalize_file(f.get("file", ""))
+        if nf.startswith(prefix):
+            f = {**f, "file": nf[len(prefix):]}
+        out.append(f)
+    return out
+
+
+def score(run_id: str, *, allow_incomplete: bool = False) -> int:
+    """Read stage-manifest.json + recorded findings; run the matcher per fixture;
+    write last_run.json + results.md. Returns an exit code."""
+    validate_run_id(run_id)
+    dispatch_dir = resolve_dispatch_dir(run_id)
+    manifest_path = dispatch_dir / "stage-manifest.json"
+    if not manifest_path.exists():
+        print(f"[fatal] no stage-manifest.json at {manifest_path}", file=sys.stderr)
+        return 1
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    if not (dispatch_dir / ".collect-status").exists() and not allow_incomplete:
+        print(f"[fatal] no .collect-status in {dispatch_dir}; collect is incomplete "
+              f"(pass --allow-incomplete for a smoke/debug score)", file=sys.stderr)
+        return 1
+    complete = not allow_incomplete
+
+    total_bugs = 0
+    total_matched = 0
+    total_findings = 0
+    total_fp = 0
+    off_total = 0
+    off_matched = 0
+    per_fixture = []
+    for cell in manifest["cells"]:
+        fixture_dir = _FIXTURES_DIR / cell["fixture_id"]
+        gt = json.loads(
+            (fixture_dir / "ground-truth-bugs.json").read_text(encoding="utf-8"))
+        bugs = gt["bugs"]
+        bug_ids = [b["bug_id"] for b in bugs]
+        if len(bug_ids) != len(set(bug_ids)):
+            dup = sorted({bid for bid in bug_ids if bug_ids.count(bid) > 1})
+            raise ValueError(
+                f"ground-truth-bugs.json for fixture {cell['fixture_id']!r} has "
+                f"duplicate bug_id(s) {dup}; the matcher keys by bug_id so duplicates "
+                f"collapse into one slot and silently corrupt recall")
+        findings, dispatch_failed = _parse_findings(
+            dispatch_dir / cell["result_file"])
+        findings = _reconcile_scope(findings, cell.get("scope", ""))
+
+        # Detect recorded findings whose `line` is unparseable. The matcher already
+        # degrades them gracefully (no candidate edge → counted as kept-unmatched
+        # false positives), so here we only WARN (naming the fixture + finding
+        # indices) and report a per-cell `malformed_findings` count. Do not filter —
+        # let `match` count them so they still land in findings/false_positives.
+        malformed_idxs = []
+        for i, f in enumerate(findings):
+            try:
+                parse_line(f.get("line"))
+            except (ValueError, TypeError):
+                malformed_idxs.append(i)
+        if malformed_idxs:
+            print(f"[warn] fixture {cell['fixture_id']!r}: {len(malformed_idxs)} "
+                  f"recorded finding(s) with an unparseable `line` at index "
+                  f"{malformed_idxs} — counted as unmatched false positive(s)",
+                  file=sys.stderr)
+
+        result = match(findings, bugs)
+
+        matched_bug_ids = {b for (b, _f) in result.matched}
+        off_ids = {b["bug_id"] for b in bugs if b.get("off_axis")}
+        f_off_total = len(off_ids)
+        f_off_matched = len(matched_bug_ids & off_ids)
+
+        n_bugs = len(bugs)
+        n_matched = len(result.matched)
+        n_findings = len(findings)
+        n_fp = len(result.unmatched_findings)
+
+        total_bugs += n_bugs
+        total_matched += n_matched
+        total_findings += n_findings
+        total_fp += n_fp
+        off_total += f_off_total
+        off_matched += f_off_matched
+
+        per_fixture.append({
+            "fixture_id": cell["fixture_id"],
+            "bugs": n_bugs,
+            "matched": n_matched,
+            "recall": result.recall,
+            "findings": n_findings,
+            "false_positives": n_fp,
+            "false_positive_rate": result.false_positive_rate,
+            "unmatched_bugs": result.unmatched_bugs,
+            "off_axis_recall": (f_off_matched / f_off_total) if f_off_total else None,
+            "dispatch_failed": dispatch_failed,
+            "malformed_findings": len(malformed_idxs),
+        })
+
+    last_run = {
+        "run_id": run_id,
+        "engine": "delve",
+        "complete": complete,
+        "fixtures": len(manifest["cells"]),
+        "aggregate": {
+            "bugs": total_bugs,
+            "matched": total_matched,
+            "recall": (total_matched / total_bugs) if total_bugs else 1.0,
+            "findings": total_findings,
+            "false_positives": total_fp,
+            "false_positive_rate": (total_fp / total_findings) if total_findings else 0.0,
+            "off_axis_recall": (off_matched / off_total) if off_total else None,
+        },
+        "per_fixture": per_fixture,
+    }
+
+    (_EVALS_DIR / "last_run.json").write_text(
+        json.dumps(last_run, indent=2), encoding="utf-8")
+    (_EVALS_DIR / "results.md").write_text(
+        _render_results(last_run), encoding="utf-8")
+    return 0
+
+
+def _render_results(lr: dict) -> str:
+    agg = lr["aggregate"]
+    off = agg["off_axis_recall"]
+    lines = [
+        f"# Delve eval — run {lr['run_id']}",
+        "",
+        f"- engine: {lr['engine']} · fixtures: {lr['fixtures']} · "
+        f"complete: {lr['complete']}",
+        "",
+        "## Aggregate",
+        f"- recall: {agg['recall']:.3f} ({agg['matched']}/{agg['bugs']} planted bugs)",
+        f"- false-positive rate: {agg['false_positive_rate']:.3f} "
+        f"({agg['false_positives']}/{agg['findings']} findings)",
+        f"- off-axis recall: {'n/a' if off is None else f'{off:.3f}'}",
+        "",
+        "## Per fixture",
+    ]
+    for pf in lr["per_fixture"]:
+        off_pf = pf["off_axis_recall"]
+        lines.append(
+            f"- {pf['fixture_id']}: recall {pf['recall']:.3f} "
+            f"({pf['matched']}/{pf['bugs']}) · FP {pf['false_positive_rate']:.3f} "
+            f"({pf['false_positives']}/{pf['findings']}) · off-axis "
+            f"{'n/a' if off_pf is None else f'{off_pf:.3f}'}"
+            + (" · DISPATCH FAILED" if pf["dispatch_failed"] else ""))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="run_evals", description="Delve eval harness")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    ps = sub.add_parser("stage", help="render the dispatch manifest")
+    ps.add_argument("run_id")
+    ps.add_argument("--fixture", default=None, help="stage only this fixture dir name")
+    ps.add_argument("--force", action="store_true",
+                    help="overwrite an existing dispatch dir")
+
+    pc = sub.add_parser("score", help="score recorded findings")
+    pc.add_argument("run_id")
+    pc.add_argument("--allow-incomplete", action="store_true",
+                    help="score without .collect-status (stamps complete:false)")
+
+    args = p.parse_args(argv)
+    if args.cmd == "stage":
+        dispatch_dir = stage(args.run_id, fixture=args.fixture, force=args.force)
+        print(dispatch_dir)
+        return 0
+    if args.cmd == "score":
+        return score(args.run_id, allow_incomplete=args.allow_incomplete)
+    return 2  # pragma: no cover (argparse requires a subcommand)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/delve/evals/test_matcher.py
+++ b/skills/delve/evals/test_matcher.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Deterministic matcher tests for the delve eval harness (#373) — the design's
+acceptance criterion #1 (the worked recall + FP example).
+
+stdlib unittest. The matcher is LLM-free, pure, stdlib-only; these tests pin its
+arithmetic exactly so a regression in the scorer (the CI-gated half of the harness)
+is caught. No live dispatch.
+"""
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.delve.evals._matcher import match, parse_line  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# The worked example (acceptance #1). Four planted bugs; a recorded-findings set
+# mixing true hits, a positional false-positive, a miss, a double-finding on one
+# bug, and a ±LINE_SLOP boundary hit.
+# ---------------------------------------------------------------------------
+
+GROUND_TRUTH = [
+    # b1: a true hit — a finding lands exactly here with a matching signature.
+    {"bug_id": "sm-b1", "file": "calc.py", "line_lo": 10, "line_hi": 10,
+     "signature": ["off-by-one", "slice"]},
+    # b2: a slop-boundary hit — the finding's line is line_hi + LINE_SLOP (12 + 2 = 14).
+    {"bug_id": "sm-b2", "file": "calc.py", "line_lo": 12, "line_hi": 12,
+     "signature": ["mutable default"]},
+    # b3: TWO findings land on this bug — must be credited exactly once (one-to-one).
+    {"bug_id": "sm-b3", "file": "util.py", "line_lo": 20, "line_hi": 25,
+     "signature": ["comparison operator", "wrong operator"]},
+    # b4: a MISS — no finding covers it (the one finding at its line is the FP, which
+    #     is signature-mismatched, so it does not score for b4 either).
+    {"bug_id": "sm-b4", "file": "util.py", "line_lo": 40, "line_hi": 40,
+     "signature": ["resource leak", "not closed"]},
+]
+
+FINDINGS = [
+    # F0 → b1 (exact line + signature "off-by-one" present in summary).
+    {"file": "calc.py", "line": 10,
+     "summary": "off-by-one error in the slice bound drops the last element"},
+    # F1 → b2 via the ±LINE_SLOP boundary: line 14 = b2.line_hi(12) + slop(2).
+    {"file": "calc.py", "line": 14,
+     "summary": "mutable default argument shared across calls"},
+    # F2 → b3 (line 22 overlaps 20-25; signature "wrong operator" present).
+    {"file": "util.py", "line": 22,
+     "summary": "uses == where >= was intended, a wrong operator"},
+    # F3 → ALSO on b3 (line 24 overlaps; "comparison operator" present). Must NOT
+    # double-count: b3 is already credited by F2 (one-to-one), so F3 is an
+    # unmatched kept finding → a false positive.
+    {"file": "util.py", "line": 24,
+     "summary": "the comparison operator here is also suspicious"},
+    # F4 → positional FP: lands at b4's planted line (40) but the summary contains
+    # NONE of b4's signatures ("resource leak"/"not closed") → must NOT match b4.
+    {"file": "util.py", "line": 40,
+     "summary": "this loop could be rewritten more clearly for readability"},
+]
+
+
+class TestMatcherWorkedExample(unittest.TestCase):
+    def setUp(self):
+        self.result = match(FINDINGS, GROUND_TRUTH, line_slop=2)
+
+    def test_recall(self):
+        # 3 of 4 planted bugs matched (b1, b2, b3); b4 missed.
+        self.assertEqual(self.result.recall, 3 / 4)
+
+    def test_false_positive_rate(self):
+        # 5 kept findings, 2 unmatched (F3 the double, F4 the positional FP) → 2/5.
+        self.assertEqual(self.result.false_positive_rate, 2 / 5)
+
+    def test_one_to_one_bipartite(self):
+        # Each bug at most once, each finding at most once.
+        bug_ids = [b for (b, _f) in self.result.matched]
+        finding_idxs = [f for (_b, f) in self.result.matched]
+        self.assertEqual(len(bug_ids), len(set(bug_ids)),
+                         "a bug was credited more than once")
+        self.assertEqual(len(finding_idxs), len(set(finding_idxs)),
+                         "a finding was consumed more than once")
+        self.assertEqual(len(self.result.matched), 3)
+
+    def test_matched_pairs(self):
+        # b3 is credited to F2 (the deterministic tie-break: greedy by overlap then
+        # bug_id then finding index; F2 precedes F3).
+        self.assertEqual(set(self.result.matched),
+                         {("sm-b1", 0), ("sm-b2", 1), ("sm-b3", 2)})
+
+    def test_unmatched(self):
+        self.assertEqual(self.result.unmatched_bugs, ["sm-b4"])
+        self.assertEqual(sorted(self.result.unmatched_findings), [3, 4])
+
+    def test_positional_fp_does_not_match(self):
+        # F4 is at b4's exact line but signature-mismatched → b4 stays unmatched and
+        # F4 is a false positive. (This is the core of the signature gate.)
+        self.assertIn("sm-b4", self.result.unmatched_bugs)
+        self.assertIn(4, self.result.unmatched_findings)
+
+
+class TestSlopBoundary(unittest.TestCase):
+    def test_just_inside_slop_matches(self):
+        gt = [{"bug_id": "b", "file": "a.py", "line_lo": 10, "line_hi": 10,
+               "signature": ["bug"]}]
+        # line 12 = 10 + slop(2) → inside.
+        r = match([{"file": "a.py", "line": 12, "summary": "a bug here"}], gt,
+                  line_slop=2)
+        self.assertEqual(r.recall, 1.0)
+
+    def test_just_outside_slop_misses(self):
+        gt = [{"bug_id": "b", "file": "a.py", "line_lo": 10, "line_hi": 10,
+               "signature": ["bug"]}]
+        # line 13 = 10 + slop(2) + 1 → outside.
+        r = match([{"file": "a.py", "line": 13, "summary": "a bug here"}], gt,
+                  line_slop=2)
+        self.assertEqual(r.recall, 0.0)
+        self.assertEqual(r.false_positive_rate, 1.0)
+
+
+class TestSignatureFallbackAndNormalization(unittest.TestCase):
+    def test_signature_falls_back_to_failure_scenario(self):
+        gt = [{"bug_id": "b", "file": "a.py", "line_lo": 5, "line_hi": 5,
+               "signature": ["deadlock"]}]
+        # summary has no signature token; failure_scenario does → match via fallback.
+        f = [{"file": "a.py", "line": 5, "summary": "something is wrong",
+              "failure_scenario": "two threads deadlock under contention"}]
+        r = match(f, gt, line_slop=2)
+        self.assertEqual(r.recall, 1.0)
+
+    def test_file_normalization_posix(self):
+        gt = [{"bug_id": "b", "file": "src/a.py", "line_lo": 5, "line_hi": 5,
+               "signature": ["bug"]}]
+        # backslash-separated + ./ prefix on the finding must normalize to match.
+        f = [{"file": ".\\src\\a.py", "line": 5, "summary": "a bug"}]
+        r = match(f, gt, line_slop=2)
+        self.assertEqual(r.recall, 1.0)
+
+    def test_signature_case_insensitive(self):
+        gt = [{"bug_id": "b", "file": "a.py", "line_lo": 5, "line_hi": 5,
+               "signature": ["SQL Injection"]}]
+        f = [{"file": "a.py", "line": 5, "summary": "possible sql injection sink"}]
+        r = match(f, gt, line_slop=2)
+        self.assertEqual(r.recall, 1.0)
+
+
+class TestMaximumCardinality(unittest.TestCase):
+    """Regression: greedy-by-weight understated recall (S1). A high-weight edge
+    (a finding spanning two bugs) could consume a bug that a unique low-weight edge
+    needed, dropping recall below the true maximum one-to-one matching."""
+
+    def test_high_weight_edge_does_not_starve_unique_edge(self):
+        # B1 at 20-20, B2 at 24-26 (both signature ["bug"]). At slop=2:
+        #   F0 spans "20-26" → overlaps BOTH B1 (overlap 1) and B2 (overlap 3).
+        #   F1 at line 25 → overlaps ONLY B2 (overlap 1).
+        # Greedy takes F0→B2 first (overlap 3) and leaves B1 with no finding (F1
+        # can't reach B1) → recall 0.5. Maximum matching is F0→B1, F1→B2 → recall 1.0.
+        gt = [
+            {"bug_id": "B1", "file": "inventory.py", "line_lo": 20, "line_hi": 20,
+             "signature": ["bug"]},
+            {"bug_id": "B2", "file": "inventory.py", "line_lo": 24, "line_hi": 26,
+             "signature": ["bug"]},
+        ]
+        findings = [
+            {"file": "inventory.py", "line": "20-26", "summary": "a bug spans here"},
+            {"file": "inventory.py", "line": 25, "summary": "a bug here"},
+        ]
+        r = match(findings, gt, line_slop=2)
+        self.assertEqual(r.recall, 1.0)
+        # Both bugs matched, one-to-one (each bug once, each finding once).
+        matched_bugs = [b for (b, _f) in r.matched]
+        matched_findings = [f for (_b, f) in r.matched]
+        self.assertEqual(sorted(matched_bugs), ["B1", "B2"])
+        self.assertEqual(sorted(matched_findings), [0, 1])
+        self.assertEqual(r.unmatched_bugs, [])
+
+
+class TestMalformedLineIsFalsePositive(unittest.TestCase):
+    """R2-S1 regression: a recorded finding with an unparseable `line` must NOT crash
+    the matcher (parse_line raises ValueError/TypeError for None, "12-", …). The
+    candidate-build loop swallows it so the malformed finding produces no edge and is
+    counted as a kept-but-unmatched finding (a false positive); valid findings on the
+    same run still match."""
+
+    GT = [{"bug_id": "b", "file": "a.py", "line_lo": 5, "line_hi": 5,
+           "signature": ["x"]}]
+
+    def test_none_line_does_not_crash_and_is_fp(self):
+        findings = [
+            {"file": "a.py", "line": 5, "summary": "x here"},   # valid → matches b
+            {"file": "a.py", "line": None, "summary": "x here too"},  # malformed → FP
+        ]
+        r = match(findings, self.GT, line_slop=2)
+        self.assertEqual(r.recall, 1.0)              # the valid finding still matches
+        self.assertEqual(r.matched, [("b", 0)])
+        self.assertIn(1, r.unmatched_findings)       # malformed finding is unmatched
+        self.assertEqual(r.false_positive_rate, 1 / 2)  # 1 of 2 kept findings is FP
+
+    def test_malformed_range_does_not_crash_and_is_fp(self):
+        # "12-" → int("") raises ValueError inside parse_line.
+        findings = [
+            {"file": "a.py", "line": 5, "summary": "x here"},
+            {"file": "a.py", "line": "12-", "summary": "x here too"},
+        ]
+        r = match(findings, self.GT, line_slop=2)
+        self.assertEqual(r.recall, 1.0)
+        self.assertEqual(r.matched, [("b", 0)])
+        self.assertIn(1, r.unmatched_findings)
+
+
+class TestParseLine(unittest.TestCase):
+    def test_int(self):
+        self.assertEqual(parse_line(12), (12, 12))
+
+    def test_numeric_string(self):
+        self.assertEqual(parse_line("12"), (12, 12))
+
+    def test_range_string(self):
+        self.assertEqual(parse_line("12-15"), (12, 15))
+
+    def test_whitespace_range(self):
+        self.assertEqual(parse_line(" 12 - 15 "), (12, 15))
+
+
+class TestEmptyInputs(unittest.TestCase):
+    def test_no_findings(self):
+        gt = [{"bug_id": "b", "file": "a.py", "line_lo": 1, "line_hi": 1,
+               "signature": ["x"]}]
+        r = match([], gt)
+        self.assertEqual(r.recall, 0.0)
+        # No kept findings → FP rate is 0.0 (0/0 guarded).
+        self.assertEqual(r.false_positive_rate, 0.0)
+        self.assertEqual(r.unmatched_bugs, ["b"])
+
+    def test_no_ground_truth(self):
+        f = [{"file": "a.py", "line": 1, "summary": "x"}]
+        r = match(f, [])
+        # No planted bugs → recall is 1.0 (0/0 guarded — vacuously complete); every
+        # finding is a false positive.
+        self.assertEqual(r.recall, 1.0)
+        self.assertEqual(r.false_positive_rate, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/delve/evals/test_run_evals_score.py
+++ b/skills/delve/evals/test_run_evals_score.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""`score` mechanics for the delve eval harness (#373) — fully synthetic, no live
+agents. Stages the committed `sample` fixture, writes a hand-authored recorded
+findings JSON + .collect-status, and asserts last_run.json carries the expected
+matcher metrics.
+"""
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.delve.evals import run_evals  # noqa: E402
+
+_EVALS_DIR = pathlib.Path(__file__).resolve().parent
+
+# A hand-authored recorded findings set over the `sample` fixture (6 planted bugs):
+# hits sm-b1, sm-b3, sm-b5 (one of which, sm-b5, is off_axis), plus one positional
+# false-positive (a non-bug finding). → recall 3/6, FP 1/4, off-axis recall 1/1.
+SAMPLE_FINDINGS = [
+    {"file": "inventory.py", "line": 11,
+     "summary": "off-by-one in last_n drops the final element",
+     "failure_scenario": "the most recent item is silently omitted",
+     "severity": "Important", "verdict": "CONFIRMED"},
+    {"file": "inventory.py", "line": 24,
+     "summary": "is_in_stock uses the wrong operator and returns true at zero",
+     "failure_scenario": "a sold-out SKU is reported available",
+     "severity": "Important", "verdict": "CONFIRMED"},
+    {"file": "report.py", "line": 10,
+     "summary": "write_report leaks a resource — the file handle is not closed",
+     "failure_scenario": "fd exhaustion under repeated calls",
+     "severity": "Minor", "verdict": "PLAUSIBLE"},
+    # A false positive: real line, but about a wholly different (non-planted) concern
+    # with no signature overlap → must NOT match any bug.
+    {"file": "inventory.py", "line": 5,
+     "summary": "the module could use a docstring for clarity",
+     "failure_scenario": "none — readability only",
+     "severity": "Suggestion", "verdict": "PLAUSIBLE"},
+]
+
+
+class _DispatchEnv(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._prev = os.environ.get("XDG_RUNTIME_DIR")
+        os.environ["XDG_RUNTIME_DIR"] = self._tmp.name
+        # Preserve any pre-existing committed/ignored eval outputs.
+        self._lr = _EVALS_DIR / "last_run.json"
+        self._md = _EVALS_DIR / "results.md"
+        self._saved = {p: (p.read_bytes() if p.exists() else None)
+                       for p in (self._lr, self._md)}
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("XDG_RUNTIME_DIR", None)
+        else:
+            os.environ["XDG_RUNTIME_DIR"] = self._prev
+        self._tmp.cleanup()
+        for p, data in self._saved.items():
+            if data is None:
+                if p.exists():
+                    p.unlink()
+            else:
+                p.write_bytes(data)
+
+    def _stage_and_record(self, run_id, findings, *, sentinel="DISPATCH_STATUS: OK",
+                          collect=True):
+        dispatch_dir = run_evals.stage(run_id, fixture="sample")
+        m = json.loads((dispatch_dir / "stage-manifest.json").read_text("utf-8"))
+        cell = m["cells"][0]
+        body = json.dumps(findings)
+        text = f"{sentinel}\n\n{body}" if sentinel else body
+        (dispatch_dir / cell["result_file"]).write_text(text, encoding="utf-8")
+        if collect:
+            (dispatch_dir / ".collect-status").write_text("", encoding="utf-8")
+        return dispatch_dir
+
+
+class TestScore(_DispatchEnv):
+    def test_score_computes_expected_metrics(self):
+        self._stage_and_record("test-score-1", SAMPLE_FINDINGS)
+        rc = run_evals.score("test-score-1")
+        self.assertEqual(rc, 0)
+
+        lr = json.loads((_EVALS_DIR / "last_run.json").read_text("utf-8"))
+        self.assertTrue(lr["complete"])
+        agg = lr["aggregate"]
+        self.assertEqual(agg["bugs"], 6)
+        self.assertEqual(agg["matched"], 3)
+        self.assertEqual(agg["recall"], 3 / 6)
+        self.assertEqual(agg["findings"], 4)
+        self.assertEqual(agg["false_positives"], 1)
+        self.assertEqual(agg["false_positive_rate"], 1 / 4)
+        # Only sm-b5 is off_axis in the fixture, and it was hit.
+        self.assertEqual(agg["off_axis_recall"], 1.0)
+
+        pf = lr["per_fixture"][0]
+        self.assertEqual(pf["fixture_id"], "sample")
+        self.assertEqual(sorted(pf["unmatched_bugs"]),
+                         ["sm-b2", "sm-b4", "sm-b6"])
+        self.assertFalse(pf["dispatch_failed"])
+        self.assertTrue((_EVALS_DIR / "results.md").exists())
+
+    def test_score_refuses_without_collect_status(self):
+        self._stage_and_record("test-score-2", SAMPLE_FINDINGS, collect=False)
+        self.assertEqual(run_evals.score("test-score-2"), 1)
+        # --allow-incomplete scores anyway, stamping complete:false.
+        self.assertEqual(
+            run_evals.score("test-score-2", allow_incomplete=True), 0)
+        lr = json.loads((_EVALS_DIR / "last_run.json").read_text("utf-8"))
+        self.assertFalse(lr["complete"])
+
+    def test_score_error_sentinel_scores_zero(self):
+        self._stage_and_record("test-score-3", SAMPLE_FINDINGS,
+                               sentinel="DISPATCH_STATUS: ERROR")
+        self.assertEqual(run_evals.score("test-score-3"), 0)
+        lr = json.loads((_EVALS_DIR / "last_run.json").read_text("utf-8"))
+        agg = lr["aggregate"]
+        self.assertEqual(agg["matched"], 0)
+        self.assertEqual(agg["findings"], 0)
+        self.assertEqual(agg["recall"], 0.0)
+        self.assertEqual(agg["false_positive_rate"], 0.0)
+        self.assertTrue(lr["per_fixture"][0]["dispatch_failed"])
+
+    def test_score_no_sentinel_parses_bare_array(self):
+        # Backward-compat: a file with no DISPATCH_STATUS sentinel parses as a bare
+        # JSON array (as a minimal operator might write).
+        self._stage_and_record("test-score-4", SAMPLE_FINDINGS, sentinel=None)
+        self.assertEqual(run_evals.score("test-score-4"), 0)
+        lr = json.loads((_EVALS_DIR / "last_run.json").read_text("utf-8"))
+        self.assertEqual(lr["aggregate"]["matched"], 3)
+
+    def test_score_no_manifest_fails(self):
+        self.assertEqual(run_evals.score("test-score-missing"), 1)
+
+    def test_score_malformed_line_counts_as_fp_without_crash(self):
+        # R2-S1 regression: a recorded finding with an unparseable `line` (here None)
+        # must NOT abort the whole score with a raw ValueError. The run completes
+        # (rc 0), the valid findings still match (recall 3/6), and the malformed one is
+        # counted as a kept-unmatched false positive (findings 5, FP 2) and reflected in
+        # the new per-cell `malformed_findings` count.
+        malformed = {"file": "inventory.py", "line": None,
+                     "summary": "the line is unparseable here",
+                     "failure_scenario": "n/a", "severity": "Minor",
+                     "verdict": "PLAUSIBLE"}
+        findings = SAMPLE_FINDINGS + [malformed]
+        self._stage_and_record("test-score-malformed", findings)
+        rc = run_evals.score("test-score-malformed")
+        self.assertEqual(rc, 0)
+
+        lr = json.loads((_EVALS_DIR / "last_run.json").read_text("utf-8"))
+        agg = lr["aggregate"]
+        self.assertEqual(agg["matched"], 3)          # valid findings still match
+        self.assertEqual(agg["recall"], 3 / 6)
+        self.assertEqual(agg["findings"], 5)         # malformed finding still counted
+        self.assertEqual(agg["false_positives"], 2)  # original FP + the malformed one
+        pf = lr["per_fixture"][0]
+        self.assertEqual(pf["malformed_findings"], 1)
+
+    def test_score_reconciles_scope_prefixed_paths(self):
+        # S2 regression: the live engine may emit scope-relative paths
+        # (`<scope>/inventory.py`) rather than bare GT filenames. The harness
+        # reconciles the fixture's known `scope` prefix so verbatim-recorded findings
+        # still join — scoring identically to the bare-path case (recall 3/6 etc.),
+        # NOT silently 0.0.
+        scope = "skills/delve/evals/fixtures/sample"
+        prefixed = [{**f, "file": f"{scope}/{f['file']}"} for f in SAMPLE_FINDINGS]
+        self._stage_and_record("test-score-scope", prefixed)
+        self.assertEqual(run_evals.score("test-score-scope"), 0)
+
+        lr = json.loads((_EVALS_DIR / "last_run.json").read_text("utf-8"))
+        agg = lr["aggregate"]
+        self.assertEqual(agg["bugs"], 6)
+        self.assertEqual(agg["matched"], 3)
+        self.assertEqual(agg["recall"], 3 / 6)
+        self.assertEqual(agg["findings"], 4)
+        self.assertEqual(agg["false_positives"], 1)
+        self.assertEqual(agg["false_positive_rate"], 1 / 4)
+        self.assertEqual(agg["off_axis_recall"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/delve/evals/test_run_evals_stage.py
+++ b/skills/delve/evals/test_run_evals_stage.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""`stage` mechanics for the delve eval harness (#373) — fully synthetic, no live
+agents. Asserts stage writes a well-formed stage-manifest.json enumerating one cell
+per fixture with the dispatch note + result_file.
+"""
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.delve.evals import run_evals  # noqa: E402
+
+
+class TestStage(unittest.TestCase):
+    def setUp(self):
+        # Point resolve_dispatch_dir at an isolated temp root (it honors
+        # XDG_RUNTIME_DIR) so the test never touches a real /tmp dispatch dir.
+        self._tmp = tempfile.TemporaryDirectory()
+        self._prev = os.environ.get("XDG_RUNTIME_DIR")
+        os.environ["XDG_RUNTIME_DIR"] = self._tmp.name
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("XDG_RUNTIME_DIR", None)
+        else:
+            os.environ["XDG_RUNTIME_DIR"] = self._prev
+        self._tmp.cleanup()
+
+    def test_stage_writes_wellformed_manifest(self):
+        dispatch_dir = run_evals.stage("test-stage-1")
+        manifest_path = dispatch_dir / "stage-manifest.json"
+        self.assertTrue(manifest_path.exists())
+        m = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(m["run_id"], "test-stage-1")
+        self.assertEqual(m["engine"], "delve")
+        self.assertGreaterEqual(m["fixtures"], 1)
+        self.assertEqual(len(m["cells"]), m["fixtures"])
+
+        # The committed `sample` fixture must be staged with a usable cell.
+        sample = next(c for c in m["cells"] if c["fixture_id"] == "sample")
+        self.assertEqual(sample["result_file"], "sample-findings.json")
+        self.assertIn("skills/delve/evals/fixtures/sample", sample["scope"])
+        self.assertIn("/delve", sample["dispatch_note"])
+        self.assertIn("DISPATCH_STATUS: OK", sample["dispatch_note"])
+        self.assertIn(".collect-status", sample["dispatch_note"])
+
+    def test_stage_named_fixture(self):
+        dispatch_dir = run_evals.stage("test-stage-named", fixture="sample")
+        m = json.loads((dispatch_dir / "stage-manifest.json").read_text("utf-8"))
+        self.assertEqual([c["fixture_id"] for c in m["cells"]], ["sample"])
+
+    def test_stage_unknown_fixture_raises(self):
+        with self.assertRaises(ValueError):
+            run_evals.stage("test-stage-x", fixture="does-not-exist")
+
+    def test_stage_refuses_existing_dir_without_force(self):
+        run_evals.stage("test-stage-dup")
+        with self.assertRaises(FileExistsError):
+            run_evals.stage("test-stage-dup")
+        # force re-stages cleanly
+        run_evals.stage("test-stage-dup", force=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/delve/evals/test_runid.py
+++ b/skills/delve/evals/test_runid.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""run-id validation re-assertion for the delve eval harness (#373).
+
+stdlib unittest. The validator is the copied _runid.validate_run_id; this re-asserts
+its I-9 behavior in delve's own gating suite (the drift check pins the body; this pins
+the behavior).
+"""
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from skills.delve.evals import run_evals  # noqa: E402
+from skills.delve.evals._runid import validate_run_id  # noqa: E402
+
+
+class TestRunIdValidation(unittest.TestCase):
+    def test_accepts_well_formed_ids(self):
+        for ok in ("run1", "2026-06-26T20-45-00", "abc_DEF-123", "_x"):
+            validate_run_id(ok)  # must not raise
+
+    def test_rejects_flag_like_and_traversal_unsafe(self):
+        for bad in ("-rf", "--force", "../escape", "a/b", "has space",
+                    "x" * 40, "", "a.b"):
+            with self.assertRaises(ValueError):
+                validate_run_id(bad)
+
+    def test_stage_rejects_bad_run_id(self):
+        with self.assertRaises(ValueError):
+            run_evals.stage("../escape")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Vertical slice of #373: a **CI-gated regression harness for `delve`** (the instance-bug finder), mirroring `skills/inquisitor/evals/` (#424 copy+drift-check precedent). The oracle is a **deterministic** file+line+signature matcher — no LLM judge — so the scorer + fixtures + harness tests gate in CI, while the live `/delve` run between `stage` and `score` stays manual/out-of-CI by design.

- **`_matcher.py`** — bipartite one-to-one **maximum-cardinality** (Kuhn augmenting-path) matcher: file + ±slop line overlap + signature gate; recall / FP-rate / off-axis recall. Max-cardinality (not greedy) so recall is never understated; deterministic high-weight result; a malformed finding `line` degrades to a false positive instead of crashing.
- **`run_evals.py`** — lean `stage`/`score` CLI (manifest + `DISPATCH_STATUS` sentinel). `score()` reconciles a scope-prefixed finding path to the bare GT form, warns + counts malformed-line findings, asserts GT `bug_id` uniqueness.
- **`_dispatch_paths.py` / `_runid.py`** — copied from temper, kept AST-identical by `scripts/check_delve_helper_drift.py` (#424).
- **`fixtures/sample/`** — 2-file module, 6 planted defects + blind-authored ground truth + provenance. `scripts/check_delve_gt_provenance.py` proves the blind boundary held **and** is a total, complete GT-schema validator (every documented field type-checked, `line_lo<=line_hi`, unique bug_ids, manifest consistency) — a malformed committed fixture reddens CI rather than silently corrupting recall.
- **`run_tests.sh`** — +5 invocations (suite **53 → 58**, all green).

## Quality gate

Ran the binding implementation `/quality-gate` (artifact: code) — **6 rounds**, score trajectory `2,2,1,1,1→0`, terminal **PASS** (clean round + tail-rubric; look-harder fired round 5 and demoted a premature clean, catching the non-string-`desc` provenance crash). The greedy→max-cardinality matcher, scope-path join, malformed-line crash-guard, and the complete GT-schema/integrity validator all emerged from adversarial review. Self-gate → local verdict marker only (not emitted to the central calibration ledger, per repo policy on gating crucible's own artifacts).

`Refs #373`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
