### PR TITLE
fix(calibration): #408 — validate git-layer candidates at reconciler boundary (F1+F2+F3+F16c)

### DIFF
--- a/docs/research/2026-06-10-audit-scripts-milestone16.md
+++ b/docs/research/2026-06-10-audit-scripts-milestone16.md
@@ -158,6 +158,19 @@ Read **in full** and grounded findings: `rcpt_verify.py`, `test_rcpt_verify.py`,
 
 **Still DEFERRED (remaining #408 boxes):** `render_ledger.py` (WHS honest-count + 3×-rolling-median inflation detector), `test_catalog.py`, `grudge_query.py` full read, `compass.py:180-1182` field caps + `MUTEX_PAIRS`. #408 stays open for these.
 
+### #408 update (2026-06-28, completing Opus pass — coverage now FULL)
+
+Read **in full** all six remaining trust-critical modules in one `/audit` run (code, systemic-only): `rcpt_verify.py`, `reconcile_ledger.py`, `render_ledger.py`, `calibrate_tolerance.py`, `grudge_query.py`, `compass.py` (4916L; 5 lenses). The 2026-06-22 deferred boxes — `render_ledger.py`, `grudge_query.py` full read, `compass.py` field-cap surface — are now covered. **27 raw → 16 findings (0F/11S/5M)**, posted as an umbrella checklist on #408 ([issuecomment-4825158506](https://github.com/raddue/crucible/issues/408#issuecomment-4825158506)). Headlines:
+
+- **Trust hole (compounding, untracked):** git-layer output enters the Brier core with zero schema validation (F1); the walkback fails OPEN on an unparseable `merge_time` while the predicate matchers fail CLOSED (F2); the predicate FAIL-flip pass runs over the same unvalidated dicts and escalates to high confidence (F3). The unvalidated/fail-open paths are exactly the untested ones (F16c) — this is the residual of #439/#441 read at the body level.
+- **Silent failure (untracked):** uneven tolerant-read discipline drops corrupt rows with no count outside the 3 central readers (F4); `_git` swallows all errors → a timeout looks like "no fixes merged" (F5).
+- **Duplication (folds into #401):** ISO parsers ×4, JSONL readers ×3-4 with drifted contracts, `_glob_match` verbatim copy (F6/F7/F8).
+- **compass `/tmp` lockdir (untracked security):** predictable world-writable lock path → local DoS/symlink surface (F12).
+- **New test gaps (relate to #441, new functions):** compass parser core, render pipeline, reconcile `main()`+#343 discovery untested (F16a/b/c).
+- **Cleared (no action):** WITNESS grammar, inflation detector, calibrate body — all confirmed adequately tested by the #441/#442 work.
+
+12 single-reproduction instance bugs noted for `/delve` (not cross-checked — run `audit --bugs`). **All #408 boxes now read in full** — #408's read-mandate is satisfied; remaining work is fix-side (the F1-F3+F16c cluster and the #401 fold), maintainer's call on closing the tracker.
+
 ## Provenance
 
 - Lens reports (source): `~/.claude/projects/-home-user-crucible/memory/audit/scratch/2026-06-10T19-29-36/{architecture,blindspots,consistency-a,consistency-b,robustness,testhealth}-findings.md`, `coverage-map.md`, `manifest.md` — machine-local, reclaimable.

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -182,6 +182,61 @@ def _confidence_label(days_delta: float, n_touched: int, cross_cut: bool) -> str
     return "medium"
 
 
+def _valid_repo_path(p) -> bool:
+    """A `touched_files` entry must be a non-empty repo-relative posix path.
+
+    Git `--name-only` only ever emits repo-relative paths; an absolute path or
+    a `..` traversal segment signals corrupted git-layer output (or a `\\x1f`/
+    `\\x1e`-injected commit body that mangled the field split, F1) and must not
+    enter the pure matchers.
+    """
+    if not isinstance(p, str) or not p:
+        return False
+    if p.startswith("/") or os.path.isabs(p):
+        return False
+    return ".." not in p.split("/")
+
+
+def _valid_candidate(cand, *, require_message: bool = False) -> bool:
+    """Schema gate for git-layer candidate dicts at the pure-core boundary (F1).
+
+    The git layer (`discover_*`) is the SOLE producer of the falsification input
+    that flips a Brier `actual`; before this gate its output entered the pure
+    core unvalidated. We reject the LOAD-BEARING corruption modes:
+
+      - `merge_time` that does not parse → dropped (fail-CLOSED, F2). This is
+        the single posture for an unplaceable candidate timestamp across the
+        matchers that consume one — the walkback and the three predicate matchers
+        now agree: a fix we cannot place in time falsifies nothing, rather than
+        the old walkback fail-OPEN that let a garbage `merge_time` falsify an
+        arbitrarily-old verdict it never post-dated. (`compute_brier` never
+        parses a candidate `merge_time`; its own S-1 fail-CLOSED is about an
+        unparseable `now`, an unrelated mechanism.)
+      - `touched_files` present but not a list of repo-relative paths.
+      - `message` missing/non-str when the consumer needs it (`referencing`).
+
+    `commit` is deliberately NOT format-checked: it is decorative provenance
+    (#412), used only in the human-readable `reason`/`falsified_by.commit`
+    string, never in the calibration math — a `\\x1f`-mangled commit field
+    manifests as an unparseable `merge_time` and is dropped on that basis.
+    """
+    if not isinstance(cand, dict):
+        return False
+    if _parse_iso(cand.get("merge_time")) is None:
+        return False
+    tf = cand.get("touched_files")
+    # Whole-dict rejection is intentional: if ANY path element is invalid, the
+    # candidate is partially-corrupt and therefore suspect, so we drop it rather
+    # than salvage the good paths.
+    if tf is not None and (
+        not isinstance(tf, list) or not all(_valid_repo_path(p) for p in tf)
+    ):
+        return False
+    if require_message and not isinstance(cand.get("message"), str):
+        return False
+    return True
+
+
 def reconcile(
     ledger_path: str,
     falsification_path: str,
@@ -270,11 +325,20 @@ def reconcile(
         appended.append(entry)
 
     # --- §3.3/§3.4 algorithm pass ----------------------------------------- #
-    for cand in candidates:
+    # F1: gate git-layer candidates at the boundary; a candidate failing the
+    # schema (unparseable merge_time / non-repo-relative touched_files) is
+    # dropped + counted, not silently fed into the matcher.
+    valid_candidates = [c for c in candidates if _valid_candidate(c)]
+    dropped = len(candidates) - len(valid_candidates)
+    if dropped:
+        _warn(f"reconcile: dropped {dropped} candidate(s) failing schema "
+              f"validation (bad merge_time / touched_files)")
+    for cand in valid_candidates:
         touched = set(cand.get("touched_files") or [])
         if not touched:
             continue
-        merge_dt = _parse_iso(cand.get("merge_time"))
+        # merge_time is validated-parseable for every valid candidate.
+        merge_dt = _parse_iso(cand["merge_time"])
         cross_cut = len(touched) > cross_cut_threshold
 
         # Walkback: earliest UNSEEN ledger entry meeting ALL §3.3 conditions.
@@ -293,8 +357,10 @@ def reconcile(
             gated = set(e.get("gated_files") or [])
             if not (gated & touched):
                 continue
-            # (b) entry timestamp < candidate merge_time
-            if merge_dt is not None and not (ts < merge_dt):
+            # (b) entry timestamp < candidate merge_time (fail-CLOSED: merge_dt
+            # is validated non-None, so an unplaceable fix matches nothing — the
+            # posture now shared with the three predicate matchers).
+            if not (ts < merge_dt):
                 continue
             # run_id/skill are guaranteed valid: identity-less rows were dropped
             # when `indexed` was built (#402).
@@ -312,11 +378,8 @@ def reconcile(
         ts, e, gated, h = match
         seen_hashes.add(h)
 
-        # §3.4 confidence
-        if merge_dt is not None:
-            days_delta = (merge_dt - ts).total_seconds() / 86400.0
-        else:
-            days_delta = float("inf")
+        # §3.4 confidence (merge_dt validated non-None above).
+        days_delta = (merge_dt - ts).total_seconds() / 86400.0
         confidence = _confidence_label(days_delta, len(touched), cross_cut)
         # Phase 7 (design §3a step 3 / plan combination rule): a file-intersection
         # walkback is the COARSER heuristic — it caps at "medium". Only a
@@ -729,8 +792,24 @@ def reconcile_predicates(
     not-`predicate_checkable` predicate is classified `uncheckable` and appends
     nothing.
     """
-    revert_candidates = revert_candidates or []
-    reference_candidates = reference_candidates or []
+    # F1/F3: gate every git-layer candidate population at the boundary BEFORE
+    # the second pass runs over it (this pass escalates a fired predicate to
+    # confidence:"high" and flips a FAIL's Brier actual, so corrupt input here
+    # is maximally costly). Reference candidates additionally require a string
+    # `message` (their matcher scans it); all require a parseable merge_time
+    # (fail-CLOSED — a fix we cannot place in time fires no predicate, F2).
+    raw_total = len(candidates) + len(revert_candidates or []) \
+        + len(reference_candidates or [])
+    candidates = [c for c in candidates if _valid_candidate(c)]
+    revert_candidates = [c for c in (revert_candidates or [])
+                         if _valid_candidate(c)]
+    reference_candidates = [c for c in (reference_candidates or [])
+                            if _valid_candidate(c, require_message=True)]
+    dropped = raw_total - (len(candidates) + len(revert_candidates)
+                           + len(reference_candidates))
+    if dropped:
+        _warn(f"reconcile_predicates: dropped {dropped} candidate(s) failing "
+              f"schema validation (bad merge_time / touched_files / message)")
     classifications: List[dict] = []
     appended: List[dict] = []
     skipped_identityless = 0

--- a/scripts/test_ledger_core.py
+++ b/scripts/test_ledger_core.py
@@ -485,13 +485,14 @@ class ReconcileTest(unittest.TestCase):
                 cross_cut_threshold=20, now="2026-03-01T00:00:00Z")
             self.assertEqual(out, [])   # (b): entry ts must precede merge
 
-    def test_unparseable_merge_time_short_circuits_b_and_still_matches(self):
-        # reconcile_ledger.py:270 guards (b) as
-        #   `merge_dt is not None and not (ts < merge_dt)`.
-        # When merge_time fails to parse (_parse_iso → None), merge_dt is None,
-        # so the timestamp-precedence check is SKIPPED — the candidate can still
-        # match on file-intersection alone. Verified against production: it emits
-        # a walkback falsification at "low" confidence (days_delta → inf → >30d).
+    def test_unparseable_merge_time_fails_closed_no_match(self):
+        # F2 (#408): a candidate whose merge_time does not parse is now DROPPED
+        # at the schema boundary (_valid_candidate) and falsifies NOTHING.
+        # Previously the walkback failed OPEN — `merge_dt is None` skipped the
+        # (b) timestamp-precedence guard, so a garbage merge_time matched on
+        # file-intersection alone and falsified an arbitrarily-old verdict it
+        # never post-dated. The walkback now shares the fail-CLOSED posture of
+        # the predicate matchers and compute_brier (S-1).
         with tempfile.TemporaryDirectory() as d:
             ledger = self._ledger(d, [
                 self._row("r1", "siege", ["auth.py"], "2026-01-01T00:00:00Z"),
@@ -501,11 +502,23 @@ class ReconcileTest(unittest.TestCase):
                 [{"commit": "abc", "touched_files": ["auth.py"],
                   "merge_time": "not-a-real-date"}],
                 cross_cut_threshold=20, now="2026-02-01T00:00:00Z")
-            self.assertEqual(len(out), 1)   # (b) short-circuits → admit
-            self.assertEqual(out[0]["ledger_entry_hash"],
-                             _entry_hash("r1", "siege"))
-            self.assertEqual(out[0]["falsified_by"]["via"], "walkback")
-            self.assertEqual(out[0]["confidence"], "low")
+            self.assertEqual(out, [])   # fail-CLOSED: unplaceable fix, no match
+
+    def test_absolute_path_candidate_dropped(self):
+        # F1: a touched_files entry that is not repo-relative (absolute path /
+        # `..` traversal) signals corrupted git-layer output and is dropped, so
+        # it cannot intersect a verdict's gated_files and mis-falsify.
+        with tempfile.TemporaryDirectory() as d:
+            ledger = self._ledger(d, [
+                self._row("r1", "siege", ["/etc/auth.py"],
+                          "2026-01-01T00:00:00Z"),
+            ])
+            out = rl.reconcile(
+                ledger, os.path.join(d, "f.jsonl"), os.path.join(d, "m.jsonl"),
+                [{"commit": "abc", "touched_files": ["/etc/auth.py"],
+                  "merge_time": "2026-01-10T00:00:00Z"}],
+                cross_cut_threshold=20, now="2026-02-01T00:00:00Z")
+            self.assertEqual(out, [])
 
     def test_walkback_confidence_capped_at_medium(self):
         # design §3a: a file-intersection walkback caps at "medium" even when
@@ -590,6 +603,60 @@ class ReconcileTest(unittest.TestCase):
             # exactly one entry — the manual one; walkback skipped the reserved hash
             self.assertEqual(len(out), 1)
             self.assertEqual(out[0]["falsified_by"]["manual_override"], True)
+
+
+# --------------------------------------------------------------------------- #
+# reconcile_ledger — _valid_candidate / _valid_repo_path (F1/F2 boundary gate) #
+# --------------------------------------------------------------------------- #
+
+class ValidateCandidateTest(unittest.TestCase):
+    """Pure schema gate for git-layer candidate dicts (#408 F1/F2)."""
+
+    GOOD = {"commit": "abc", "touched_files": ["src/auth/token.ts"],
+            "merge_time": "2026-01-10T00:00:00Z"}
+
+    def test_accepts_well_formed_candidate(self):
+        self.assertTrue(rl._valid_candidate(self.GOOD))
+
+    def test_rejects_non_dict(self):
+        for bad in (None, "x", 42, ["a"]):
+            self.assertFalse(rl._valid_candidate(bad), bad)
+
+    def test_rejects_unparseable_merge_time(self):
+        self.assertFalse(rl._valid_candidate(
+            {**self.GOOD, "merge_time": "not-a-date"}))
+        self.assertFalse(rl._valid_candidate(
+            {k: v for k, v in self.GOOD.items() if k != "merge_time"}))
+
+    def test_rejects_non_list_touched_files(self):
+        self.assertFalse(rl._valid_candidate(
+            {**self.GOOD, "touched_files": "src/auth/token.ts"}))
+
+    def test_rejects_absolute_and_traversal_paths(self):
+        for p in ("/etc/passwd", "../../etc/passwd", "a/../../b"):
+            self.assertFalse(rl._valid_candidate(
+                {**self.GOOD, "touched_files": [p]}), p)
+
+    def test_rejects_non_str_path_element(self):
+        self.assertFalse(rl._valid_candidate(
+            {**self.GOOD, "touched_files": [123]}))
+
+    def test_allows_absent_touched_files_for_referencing(self):
+        # referencing candidates carry message, not touched_files.
+        ref = {"commit": "rc1", "message": "closes #341",
+               "merge_time": "2026-01-10T00:00:00Z"}
+        self.assertTrue(rl._valid_candidate(ref, require_message=True))
+
+    def test_require_message_rejects_missing_or_nonstr_message(self):
+        base = {"commit": "rc1", "merge_time": "2026-01-10T00:00:00Z"}
+        self.assertFalse(rl._valid_candidate(base, require_message=True))
+        self.assertFalse(rl._valid_candidate(
+            {**base, "message": 42}, require_message=True))
+
+    def test_repo_path_helper(self):
+        self.assertTrue(rl._valid_repo_path("a/b/c.py"))
+        for bad in ("", "/abs", "a/../b", None, 7):
+            self.assertFalse(rl._valid_repo_path(bad), bad)
 
 
 # --------------------------------------------------------------------------- #
@@ -814,6 +881,22 @@ class ReconcilePredicatesTest(unittest.TestCase):
             self.assertEqual(appended[0]["confidence"], "high")
             # and it really landed on disk.
             self.assertEqual(len(lr.reduce(fals)), 1)
+
+    def test_corrupt_candidate_dropped_no_fire(self):
+        # F1/F3: a candidate that WOULD fire the predicate on file-intersection
+        # but carries an unparseable merge_time is dropped at the boundary, so
+        # the second pass never escalates it to a confidence:"high" FAIL flip.
+        with tempfile.TemporaryDirectory() as d:
+            fals = os.path.join(d, "fals.jsonl")
+            entry = self._code_entry(
+                "r1", "siege", "fix touching src/auth/*.ts within 14d")
+            cand = {"commit": "abc", "touched_files": ["src/auth/token.ts"],
+                    "merge_time": "garbage"}   # unparseable → dropped
+            classifications, appended = rl.reconcile_predicates(
+                [entry], [cand], fals, now=self.NOW)
+            self.assertFalse(classifications[0]["fired"])
+            self.assertEqual(appended, [])
+            self.assertFalse(os.path.exists(fals))
 
     def test_not_fired_out_of_window_classifies_no_append(self):
         with tempfile.TemporaryDirectory() as d:

--- a/scripts/test_reconcile_git.py
+++ b/scripts/test_reconcile_git.py
@@ -13,11 +13,13 @@ squash-style `fix(...)` commit) and run the GIT layer with cwd inside it — the
 same integration style as test_brier_advise.py. Pure stdlib unittest; no central
 store is touched.
 """
+import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
@@ -144,6 +146,116 @@ class FixMergeSubjectTest(unittest.TestCase):
         for s in ("prefix/x", "affix/x", "suffix/y", "feat/x",
                   "Merge branch 'feature'", "", "fix:"):
             self.assertFalse(rl._is_fix_merge_subject(s), s)
+
+
+class DiscoverRevertAndReferenceTest(unittest.TestCase):
+    """#343 git-layer discovery (revert + referencing) was untested (#408 F16c)."""
+
+    def _base(self, repo):
+        _git(repo, "init", "-q", "-b", "main")
+        _git(repo, "config", "user.email", "t@t")
+        _git(repo, "config", "user.name", "t")
+        _write(repo, "a.txt", "1\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "base")
+
+    def test_discover_revert_candidates_finds_canonical_revert(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self._base(repo)
+            _write(repo, "a.txt", "2\n")
+            _git(repo, "add", ".")
+            _git(repo, "commit", "-qm", "feat: a thing")
+            _git(repo, "revert", "--no-edit", "HEAD")   # subject: Revert "feat: a thing"
+            old = os.getcwd()
+            os.chdir(repo)
+            try:
+                cands = rl.discover_revert_candidates(30)
+            finally:
+                os.chdir(old)
+            self.assertTrue(cands, "expected the canonical revert commit")
+            rc = cands[0]
+            self.assertTrue(rc["message"].startswith("Revert"))
+            self.assertIn("a.txt", rc["touched_files"])
+            self.assertTrue(rc["merge_time"])
+
+    def test_discover_reference_commits_matches_token(self):
+        with tempfile.TemporaryDirectory() as repo:
+            self._base(repo)
+            _write(repo, "b.txt")
+            _git(repo, "add", ".")
+            _git(repo, "commit", "-qm", "chore: closes #341 — wrap up")
+            old = os.getcwd()
+            os.chdir(repo)
+            try:
+                cands = rl.discover_reference_commits(["#341"], 30)
+            finally:
+                os.chdir(old)
+            self.assertTrue(cands, "expected the #341-referencing commit")
+            self.assertIn("#341", cands[0]["message"])
+
+    def test_gh_regression_commits_graceful_without_remote(self):
+        # gh absent → FileNotFoundError → graceful [] (not a crash). Patching the
+        # global subprocess.run intercepts the function's `subprocess.run(...)`
+        # call deterministically and offline (no real gh, no network).
+        with mock.patch("subprocess.run", side_effect=FileNotFoundError()):
+            out = rl._git_gh_regression_commits()
+        self.assertEqual(out, [])
+
+
+class MainOrchestrationTest(unittest.TestCase):
+    """End-to-end main() wiring (discover → reconcile → predicate pass → brier
+    write) was untested (#408 F16c). Builds a repo with a squash `fix(...)`
+    commit and a stale ledger PASS whose gated_files intersect it; asserts the
+    walkback falsifies the PASS and brier-rolling.json is written."""
+
+    def test_main_walkback_falsifies_and_writes_brier(self):
+        saved = os.environ.pop("CRUCIBLE_CALIBRATION_DISABLED", None)
+        try:
+            with tempfile.TemporaryDirectory() as repo:
+                _git(repo, "init", "-q", "-b", "main")
+                _git(repo, "config", "user.email", "t@t")
+                _git(repo, "config", "user.name", "t")
+                _write(repo, "auth.py", "1\n")
+                _git(repo, "add", ".")
+                _git(repo, "commit", "-qm", "base")
+                _write(repo, "auth.py", "2\n")
+                _git(repo, "add", ".")
+                _git(repo, "commit", "-qm", "fix(auth): patch hole (#9)")
+
+                ledger = os.path.join(repo, "runs.jsonl")
+                with open(ledger, "w", encoding="utf-8") as f:
+                    f.write(json.dumps({
+                        "run_id": "r1", "skill": "siege", "verdict": "PASS",
+                        "confidence": 0.9, "artifact_type": "code",
+                        "backfilled": False, "gated_files": ["auth.py"],
+                        "timestamp": "2020-01-01T00:00:00Z",   # >30d old
+                    }) + "\n")
+                fals = os.path.join(repo, "fals.jsonl")
+                brier = os.path.join(repo, "brier.json")
+
+                old = os.getcwd()
+                os.chdir(repo)
+                try:
+                    rc = rl.main([
+                        "--ledger", ledger, "--falsification", fals,
+                        "--manual-attribution", os.path.join(repo, "m.jsonl"),
+                        "--brier-out", brier, "--lookback-days", "3650",
+                    ])
+                finally:
+                    os.chdir(old)
+
+                self.assertEqual(rc, 0)
+                self.assertTrue(os.path.exists(fals), "no falsification written")
+                with open(fals, encoding="utf-8") as f:
+                    rows = [json.loads(ln) for ln in f if ln.strip()]
+                self.assertTrue(any(r["falsified_by"]["via"] == "walkback"
+                                    for r in rows), rows)
+                self.assertTrue(os.path.exists(brier), "no brier-rolling written")
+                with open(brier, encoding="utf-8") as f:
+                    self.assertIn("siege", json.load(f))
+        finally:
+            if saved is not None:
+                os.environ["CRUCIBLE_CALIBRATION_DISABLED"] = saved
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## #408 Theme 1 — calibration-corruption trust hole (first slice)

First slice of the staged #408 audit-findings goal. Closes the compounding trust hole the audit flagged in the calibration reconciler.

### Problem (audit findings F1+F2+F3+F16c)
- **F1** — git-layer candidate dicts (`discover_*`) entered the pure Brier core with **zero schema validation**.
- **F2** — the walkback failed **OPEN** on an unparseable `merge_time` (skipped the timestamp-precedence guard → a garbage timestamp falsified an arbitrarily-old verdict it never post-dated), while the three predicate matchers and `compute_brier` fail **CLOSED**.
- **F3** — the predicate FAIL-flip pass (escalates to `confidence:"high"`, flips a FAIL's Brier `actual` 1→0) ran over the same unvalidated dicts.
- **F16c** — those unvalidated / fail-open paths (reconcile `main()` + #343 discovery) were exactly the untested ones.

### Fix
- Pure `_valid_repo_path` + `_valid_candidate` boundary gate: a candidate with an unparseable `merge_time`, a non-list `touched_files`, or an absolute / `..`-traversal path is **dropped and counted** (warn), not silently matched. `commit` stays unvalidated — decorative provenance (#412).
- Gate wired at the top of `reconcile()`'s algorithm pass and over all three candidate populations in `reconcile_predicates()`.
- Walkback temporal guard simplified to unconditional **fail-CLOSED**, unifying the unplaceable-`merge_time` posture and removing the dead `float('inf')` branch.

### Tests (F16c)
- Flipped the old fail-OPEN characterization test to assert fail-CLOSED.
- Added `ValidateCandidateTest`, reconcile/reconcile_predicates drop tests, and git-layer orchestration tests (`discover_revert_candidates`, `discover_reference_commits`, hermetic gh-graceful, end-to-end `main()`).

### Verification
- `bash scripts/run_tests.sh` → **63/63**.
- Self-gated via `/quality-gate`: round 1 **0F/0S/4M**, look-harder confirmed **0F/0S**; Minors quick-fixed (gh-test hermeticity, whole-dict comment, `compute_brier` docstring overclaim). LOCAL marker only — **not** emitted to the central ledger (crucible's own artifact).

Also folds in the #408 coverage-map doc update (the audit's acceptance deliverable).

Remaining advisory (not blocking): `_valid_repo_path` backslash false-accept is inert on the posix git data path; the Theme-3 "5th merge_time caller" note routes to the #401 dedup fold (next slices of this goal).

Refs #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)