### PR TITLE
fix(calibration): #408 Theme 2 — count-and-warn silent drops + git-liveness probe (F4/F5)

### DIFF
--- a/scripts/calibrate_tolerance.py
+++ b/scripts/calibrate_tolerance.py
@@ -114,6 +114,11 @@ def calibrate(
     # per_column_rates[column] -> list of per-run per-fixture pass rates
     per_column_rates: dict[str, list[float]] = {c: [] for c in _LENS_COLUMNS}
 
+    # #408 F4: a fixture whose lens_column is unknown/missing/wrong-typed is
+    # silently dropped from EVERY column's sample, shrinking the empirical sigma
+    # and tightening the tolerance clamp without a trace. Count and warn so a
+    # mis-keyed evals.json (or a stale fixture id) is visible, not invisible.
+    unmapped = 0
     for p in input_paths:
         data = json.loads(p.read_text(encoding="utf-8"))
         for fr in data.get("fixtures", []):
@@ -122,10 +127,19 @@ def calibrate(
             rate = _per_fixture_pass_rate(fr)
             if isinstance(lc, str) and lc in per_column_rates:
                 per_column_rates[lc].append(rate)
-            elif isinstance(lc, list):
+            elif isinstance(lc, list) and any(e in per_column_rates for e in lc):
                 for entry in lc:
                     if entry in per_column_rates:
                         per_column_rates[entry].append(rate)
+            else:
+                unmapped += 1
+    if unmapped:
+        print(
+            f"[calibrate_tolerance WARN] {unmapped} fixture-result(s) had no "
+            f"known lens_column and were excluded from the sigma sample "
+            f"(check evals.json lens_column mappings)",
+            file=sys.stderr,
+        )
 
     sigma_empirical: dict[str, float] = {}
     for col in _LENS_COLUMNS:

--- a/scripts/grudge_query.py
+++ b/scripts/grudge_query.py
@@ -100,6 +100,11 @@ def parse_grudge(path: str) -> Optional[Dict]:
             try:
                 rec[key] = json.loads(val)
             except (ValueError, TypeError):
+                # #408 F4: a malformed files_touched silently empties the
+                # grudge's match scope (it then matches NO path and is a silent
+                # miss, not a loud parse error). Surface it.
+                _qwarn(f"malformed files_touched in {path}; grudge will match "
+                       f"no files")
                 rec[key] = []
         elif key == "anti_pattern_signature":
             try:

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -1205,6 +1205,15 @@ def main(argv: Optional[List[str]] = None) -> int:
     now = _now_iso()
 
     # §3.1 candidate discovery + §3.2 cross-cut threshold (distinct 90d window).
+    # F5 (#408): every git call collapses a timeout / corrupt-repo / git-absent
+    # failure to None, so candidates=0 is indistinguishable from "no fixes
+    # merged" — a falsely-clean reconciliation. Probe git liveness once up front
+    # and warn loudly, so the operator can tell "git couldn't look" from
+    # "git looked and found nothing".
+    if _git(["rev-parse", "--is-inside-work-tree"]) is None:
+        _warn("git is unavailable or this is not a work tree; candidate "
+              "discovery will return 0 with no signal — a reported "
+              "candidates=0 / falsified+=0 is NOT evidence that no fixes merged")
     candidates = discover_candidates(lookback_days=args.lookback_days)
     threshold = cross_cut_threshold_from(fix_branch_sizes(days=90))
 

--- a/scripts/render_ledger.py
+++ b/scripts/render_ledger.py
@@ -699,12 +699,17 @@ def render_week(week: str, entries: list, *, baseline_medians=None,
 
 def _group_by_week(entries: list) -> dict:
     groups = {}
+    skipped = 0  # #408 F4: count dropped bad-timestamp rows, don't degrade silently
     for e in entries:
         try:
             wk = iso_week(e)
         except (ValueError, TypeError):
-            continue  # unparseable timestamp -> skip (tolerant)
+            skipped += 1  # unparseable timestamp -> skip, but surface the count
+            continue
         groups.setdefault(wk, []).append(e)
+    if skipped:
+        _warn(f"_group_by_week: skipped {skipped} entry(ies) with an "
+              f"unparseable timestamp")
     return groups
 
 

--- a/scripts/test_calibrate_tolerance.py
+++ b/scripts/test_calibrate_tolerance.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Unit tests for scripts/calibrate_tolerance.py (#442 G5, #441 calibrate() body)."""
+import contextlib
+import io
 import json
 import os
 import sys
@@ -143,6 +145,40 @@ class TestCalibrate(unittest.TestCase):
         self.assertEqual(sig["DRY"], 0.5)        # ...and here
         self.assertEqual(sig["SRP"], 0.5)        # str routed here
         self.assertEqual(sig["OCP"], 0.0)        # no fixture reached OCP
+
+    def _run_capture(self, runs, lens_map):
+        """Like _run but captures stderr; returns (out, stderr)."""
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            out = self._run(runs, lens_map)
+        return out, buf.getvalue()
+
+    def test_unmapped_fixture_warns_and_excluded(self):
+        # #408 F4: a fixture id absent from evals.json (no lens_column) is dropped
+        # from EVERY column's sample — shrinking sigma and the tolerance clamp.
+        # That exclusion must be counted+warned, not silent.
+        out, err = self._run_capture(
+            [[("f1", ["PASS"]), ("ghost", ["FAIL"])],
+             [("f1", ["FAIL"]), ("ghost", ["PASS"])]],
+            {"f1": "Surgical"},   # "ghost" intentionally unmapped
+        )
+        self.assertIn("no known lens_column", err)
+        self.assertIn("2 fixture-result", err)  # both runs' ghost results excluded
+        # Surgical still got f1's two rates; ghost contributed to nothing.
+        self.assertEqual(out["per_lens_sigma_empirical"]["Surgical"], 0.5)
+
+    def test_unmapped_list_with_no_known_column_warns(self):
+        # A list lens_column whose entries are ALL unknown is also unmapped.
+        out, err = self._run_capture(
+            [[("f1", ["PASS"])], [("f1", ["FAIL"])]],
+            {"f1": ["Bogus", "AlsoBogus"]},
+        )
+        self.assertIn("no known lens_column", err)
+
+    def test_all_mapped_is_silent(self):
+        _, err = self._run_capture(
+            [[("f1", ["PASS"])], [("f1", ["FAIL"])]], {"f1": "Surgical"})
+        self.assertNotIn("no known lens_column", err)
 
     def test_output_shape_invariants(self):
         out = self._run([[("f1", ["PASS"])], [("f1", ["FAIL"])]], {"f1": "Surgical"})

--- a/scripts/test_reconcile_git.py
+++ b/scripts/test_reconcile_git.py
@@ -258,5 +258,45 @@ class MainOrchestrationTest(unittest.TestCase):
                 os.environ["CRUCIBLE_CALIBRATION_DISABLED"] = saved
 
 
+class GitLivenessProbeTest(unittest.TestCase):
+    """#408 F5: a git outage collapses to candidates=0, indistinguishable from
+    'no fixes merged'. main() now probes git liveness and warns when git/the
+    work tree is unreachable, so a falsely-clean reconciliation is visible."""
+
+    def test_main_warns_when_not_in_a_work_tree(self):
+        import contextlib
+        import io
+        saved = os.environ.pop("CRUCIBLE_CALIBRATION_DISABLED", None)
+        try:
+            with tempfile.TemporaryDirectory() as nongit:
+                # A bare temp dir is not a git work tree → rev-parse fails.
+                ledger = os.path.join(nongit, "runs.jsonl")
+                open(ledger, "w").close()
+                brier = os.path.join(nongit, "brier.json")
+                old = os.getcwd()
+                os.chdir(nongit)
+                buf = io.StringIO()
+                try:
+                    # On a host whose TMPDIR resolves inside a checkout,
+                    # rev-parse succeeds and the warn would not fire — skip
+                    # rather than fail spuriously.
+                    if rl._git(["rev-parse", "--is-inside-work-tree"]) is not None:
+                        self.skipTest("temp dir resolves inside a git work tree")
+                    with contextlib.redirect_stderr(buf):
+                        rc = rl.main([
+                            "--ledger", ledger,
+                            "--falsification", os.path.join(nongit, "f.jsonl"),
+                            "--manual-attribution", os.path.join(nongit, "m.jsonl"),
+                            "--brier-out", brier,
+                        ])
+                finally:
+                    os.chdir(old)
+                self.assertEqual(rc, 0)
+                self.assertIn("git is unavailable", buf.getvalue())
+        finally:
+            if saved is not None:
+                os.environ["CRUCIBLE_CALIBRATION_DISABLED"] = saved
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_stores.py
+++ b/scripts/test_stores.py
@@ -205,6 +205,22 @@ class ParseGrudgeTest(unittest.TestCase):
             p = self._write(d, "g.md", "---\nfiles_touched: [\"a.py\"]\n")
             self.assertIsNone(gq.parse_grudge(p))
 
+    def test_malformed_files_touched_warns_and_empties(self):
+        # #408 F4: a malformed files_touched silently empties the grudge's match
+        # scope (it then matches no path) — surface the corruption, don't hide it.
+        with tempfile.TemporaryDirectory() as d:
+            p = self._write(d, "g.md",
+                            '---\n'
+                            'repo_root: /repo\n'
+                            'files_touched: [not valid json\n'
+                            '---\n'
+                            'body\n')
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                g = gq.parse_grudge(p)
+            self.assertEqual(g["files_touched"], [])
+            self.assertIn("malformed files_touched", buf.getvalue())
+
 
 class PathMatchTest(unittest.TestCase):
     def test_exact_equality(self):
@@ -721,6 +737,15 @@ class RenderLedgerIdentitySkipTest(unittest.TestCase):
             out, err = _capture(lambda: rl.load_runs(p))
             self.assertEqual(len(out), 1)
             self.assertIn("skipped 1", err)
+
+    def test_group_by_week_warns_on_unparseable_timestamp(self):
+        # #408 F4: a bad-timestamp row is dropped from the weekly grouping but
+        # the count is now surfaced, not silently swallowed.
+        good = {"run_id": "r1", "skill": "siege", "timestamp": self.OLD}
+        bad = {"run_id": "r2", "skill": "siege", "timestamp": "not-a-date"}
+        groups, err = _capture(lambda: rl._group_by_week([good, bad]))
+        self.assertEqual(sum(len(v) for v in groups.values()), 1)
+        self.assertIn("skipped 1", err)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## #408 Theme 2 — silent failure / uneven error discipline (slice 2)

Second slice of the staged #408 audit-findings goal. Closes the "tolerant read = silently drop" pattern outside the 3 central JSONL readers, and the git-error opacity that makes a clean reconciliation indistinguishable from a git outage.

### F4 — count-and-warn (observability only)
- **`render_ledger._group_by_week`** — count + `_warn` dropped unparseable-timestamp rows (was a silent `continue`).
- **`calibrate_tolerance.calibrate`** — count + warn fixtures with **no known `lens_column`** (unknown/missing id, wrong-typed `lc`, or an all-unknown list). These were silently excluded from the sigma sample, shrinking empirical sigma and tightening the tolerance clamp. The `elif` is tightened to route an all-unknown list to the unmapped branch — **sample-preserving** (verified across all input shapes: only a counter moves, no sigma/tolerance value changes; `test_lens_column_list_routes_into_both` stays green).
- **`grudge_query.parse_grudge`** — `_qwarn` on malformed `files_touched` (was silently `[]`, making the grudge match no path — a silent miss).

### F5 — git-error opacity
- **`reconcile_ledger.main()`** probes `git rev-parse --is-inside-work-tree` once and warns that a `candidates=0 / falsified+=0` result is **not evidence** no fixes merged when git is unreachable. Covers the dominant git-absent / not-a-work-tree class; a mid-run `git` timeout remains a documented residual (the probe is intentionally narrower than full discovery).

### Tests
`_group_by_week` skipped-count warn · calibrate `unmapped` count + all-mapped silence + all-unknown-list · grudge malformed-`files_touched` warn · F5 liveness (run `main()` outside a work tree, guarded against an in-repo `TMPDIR`).

### Verification
- `bash scripts/run_tests.sh` → **63/63**.
- Self-gated via `/quality-gate`: round 1 **0F/0S/4M**, look-harder confirmed **0F/0S** (calibrate elif sample-invariance proven). Minors quick-fixed (tightened count assertion, softened F5 warn wording, hardened TMPDIR test). LOCAL marker only — **not** the central ledger.

All edits are observability-only except the sample-preserving calibrate `elif`.

Refs #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)