### PR TITLE
refactor(scripts): #401 — consolidate the ledger/grudge seam (+ #408 F9)

### DIFF
--- a/scripts/grudge_query.py
+++ b/scripts/grudge_query.py
@@ -14,7 +14,6 @@ Design fixes baked in (from the design adversarial gate):
 - #5 per-path staleness: match against surviving files only; cull iff none survive.
 - #7 signature compiled defensively (re.error -> literal substring); file read size-capped.
 """
-import fnmatch
 import glob as _glob
 import json
 import os
@@ -22,12 +21,18 @@ import re as _re
 import sys
 from typing import Dict, List, Optional, Tuple
 
+# #401: root the package at the repo (`scripts.X`), matching reconcile_ledger /
+# render_ledger / brier_advisory / backfill-ledger — was the lone sibling using
+# `sys.path.insert(0, HERE)` + bare `from grudge_append import …`, which forced
+# every caller to keep BOTH roots on sys.path for the grudge path to resolve.
 HERE = os.path.dirname(os.path.abspath(__file__))
-if HERE not in sys.path:
-    sys.path.insert(0, HERE)
-from grudge_append import (  # noqa: E402
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+from scripts.grudge_append import (  # noqa: E402
     default_base_dir, grudges_dir, normalize_path, resolve_repo,
 )
+from scripts.pathmatch import glob_match as _glob_match  # noqa: E402
 
 SIG_READ_CAP_BYTES = 256 * 1024  # fix #7: bound signature-match file reads
 SIG_MATCH_TIMEOUT_S = 2.0  # wall-clock guard so a pathological signature regex can never hang a pre-flight
@@ -41,18 +46,6 @@ def _qwarn(msg: str) -> None:
 
 class _SigTimeout(Exception):
     """Raised by the SIGALRM handler when a signature match overruns its budget."""
-
-
-def _glob_match(path: str, pattern: str) -> bool:
-    """Path-aware glob: `*` matches within ONE segment, never crosses `/`
-    (reused discipline from reconcile_ledger._glob_match, PR #340). fnmatchcase
-    keeps it case-sensitive + cross-host deterministic. Glob-free patterns fall
-    out as segment-wise equality."""
-    p_seg = path.split("/")
-    pat_seg = pattern.split("/")
-    if len(p_seg) != len(pat_seg):
-        return False
-    return all(fnmatch.fnmatchcase(a, b) for a, b in zip(p_seg, pat_seg))
 
 
 def _path_match(scope_norm: str, stored: str) -> bool:

--- a/scripts/ledger_append.py
+++ b/scripts/ledger_append.py
@@ -80,10 +80,19 @@ def default_repo(start_dir: Optional[str] = None) -> str:
         )
         top = proc.stdout.strip()
         if proc.returncode == 0 and top:
-            return os.path.basename(top.rstrip("/")) or top
+            # #401: realpath for parity with grudge_append.resolve_repo. On the
+            # git path this is effectively a no-op — `git rev-parse --show-toplevel`
+            # already returns a canonicalized path — but it keeps the two
+            # resolvers textually aligned. The non-git fallback below is where the
+            # symlink-resolution drift actually mattered.
+            root = os.path.realpath(top)
+            return os.path.basename(root.rstrip("/")) or root
     except Exception:  # noqa: BLE001 — provenance is best-effort, never fatal
         pass
-    return os.path.basename(os.path.abspath(base)) or "unknown"
+    # #401: realpath the fallback base so a non-git dir reached via a symlinked
+    # parent yields the SAME basename label the grudge store derives. The return
+    # SHAPE stays a bare basename (callers want a label, not the root tuple).
+    return os.path.basename(os.path.realpath(os.path.abspath(base))) or "unknown"
 
 
 def _warn(msg: str) -> None:
@@ -95,6 +104,14 @@ def _valid_identity(value) -> bool:
     for either half of the (run_id, skill) ledger join key (#402). A missing,
     empty, whitespace-only, or non-string value has no stable identity."""
     return isinstance(value, str) and value.strip() != ""
+
+
+def valid_ledger_identity(entry: dict) -> bool:
+    """True iff a ledger `entry` carries a valid (run_id, skill) join identity
+    (#402). Factors the `_valid_identity(run_id) AND _valid_identity(skill)`
+    guard that was inlined verbatim ×5 across reconcile_ledger / render_ledger
+    (#408 F9) into one source, so the #402 read-side contract cannot drift."""
+    return _valid_identity(entry.get("run_id")) and _valid_identity(entry.get("skill"))
 
 
 def _truncate_payload(entry: dict, max_gated_files: int,

--- a/scripts/pathmatch.py
+++ b/scripts/pathmatch.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Path-aware glob matching — the single source of truth (#401).
+
+Extracted from the verbatim-duplicated `_glob_match` that lived in BOTH
+`reconcile_ledger.py` and `grudge_query.py` (PR #340). Both copies feed the
+central calibration ledger / grudge store, and reconcile's copy carries the
+warning that wrong semantics silently flip a Brier `actual` value — so a fix
+landing in one copy while the other drifted was a correctness hazard. There is
+now one implementation; `test_pathmatch.py` pins its contract.
+
+Pure stdlib. No third-party deps.
+"""
+import fnmatch
+
+
+def glob_match(path: str, pattern: str) -> bool:
+    """A `*` matches within ONE path segment and does NOT cross `/`
+    (shell/git non-recursive semantics).
+
+    `fnmatch` alone treats `/` as an ordinary character, so `src/auth/*` would
+    over-match `src/auth/sub/deep/x.ts` and credit a verdict for an unrelated
+    deep-tree fix — silently corrupting calibration (a fired predicate flips a
+    FAIL's Brier `actual` 1->0). We require equal segment counts and fnmatch each
+    segment pairwise, so `src/auth/*` matches `src/auth/token.ts` but not
+    `src/auth/sub/x.ts`. Exact (glob-free) paths fall out as segment-wise equality.
+
+    fnmatchcase (NOT fnmatch): case-SENSITIVE regardless of host OS. git paths
+    are case-sensitive posix; plain fnmatch case-folds on macOS/Windows, which
+    would make calibration non-reproducible across machines feeding one ledger.
+    """
+    p_seg = path.split("/")
+    pat_seg = pattern.split("/")
+    if len(p_seg) != len(pat_seg):
+        return False
+    return all(fnmatch.fnmatchcase(a, b) for a, b in zip(p_seg, pat_seg))

--- a/scripts/reconcile_ledger.py
+++ b/scripts/reconcile_ledger.py
@@ -43,9 +43,13 @@ from scripts.ledger_append import (  # noqa: E402
     append as _ledger_append,
     default_ledger_dir,
     default_ledger_path,
-    _valid_identity,
+    valid_ledger_identity,
 )
 from scripts.atomic_write import atomic_write_text  # noqa: E402
+# #401: path-aware glob is the single source of truth (scripts/pathmatch.py);
+# was verbatim-duplicated here and in grudge_query.py. Alias to the prior
+# private name so the calibration call sites are untouched.
+from scripts.pathmatch import glob_match as _glob_match  # noqa: E402
 
 # 30-day grace period: a verdict must be older than this before it can be
 # falsified by a fix (so it has had a chance to be falsified) and before it is
@@ -272,7 +276,7 @@ def reconcile(
         ts = _parse_iso(e.get("timestamp"))
         if ts is None:
             continue
-        if not (_valid_identity(e.get("run_id")) and _valid_identity(e.get("skill"))):
+        if not valid_ledger_identity(e):
             skipped_identityless += 1
             continue
         indexed.append((ts, e))
@@ -465,7 +469,7 @@ def compute_brier(
         # "unknown" skill's Brier with unrelated runs. Skip + count it instead.
         run_id = e.get("run_id")
         skill = e.get("skill")
-        if not (_valid_identity(run_id) and _valid_identity(skill)):
+        if not valid_ledger_identity(e):
             skipped_identityless += 1
             continue
         # Hoist the falsification lookup ABOVE the artifact_type gate so the
@@ -618,28 +622,6 @@ def parse_predicate(text) -> Optional[dict]:
                 "token": m.group(2), "within_days": n}
 
     return None
-
-
-def _glob_match(path: str, pattern: str) -> bool:
-    """Path-aware glob: a `*` matches within ONE path segment and does NOT cross
-    `/` (shell/git non-recursive semantics).
-
-    `fnmatch` alone treats `/` as an ordinary character, so `src/auth/*` would
-    over-match `src/auth/sub/deep/x.ts` and credit a verdict for an unrelated
-    deep-tree fix — silently corrupting calibration (a fired predicate flips a
-    FAIL's Brier `actual` 1->0). We require equal segment counts and fnmatch each
-    segment pairwise, so `src/auth/*` matches `src/auth/token.ts` but not
-    `src/auth/sub/x.ts`. Exact (glob-free) paths fall out as segment-wise equality.
-    """
-    import fnmatch
-    p_seg = path.split("/")
-    pat_seg = pattern.split("/")
-    if len(p_seg) != len(pat_seg):
-        return False
-    # fnmatchcase (NOT fnmatch): case-SENSITIVE regardless of host OS. git paths
-    # are case-sensitive posix; plain fnmatch case-folds on macOS/Windows, which
-    # would make calibration non-reproducible across machines feeding one ledger.
-    return all(fnmatch.fnmatchcase(a, b) for a, b in zip(p_seg, pat_seg))
 
 
 def _predicate_fired(parsed: dict, entry_dt, candidates: List[dict]):
@@ -822,7 +804,7 @@ def reconcile_predicates(
         # into the shared "unknown:unknown" bucket.
         run_id = e.get("run_id")
         skill = e.get("skill")
-        if not (_valid_identity(run_id) and _valid_identity(skill)):
+        if not valid_ledger_identity(e):
             skipped_identityless += 1
             continue
         h = ledger_entry_hash(run_id, skill)

--- a/scripts/render_ledger.py
+++ b/scripts/render_ledger.py
@@ -28,7 +28,7 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from scripts.ledger_reduce import reduce as _falsification_reduce  # noqa: E402
-from scripts.ledger_append import default_ledger_dir, _valid_identity  # noqa: E402
+from scripts.ledger_append import default_ledger_dir, valid_ledger_identity  # noqa: E402
 from scripts.atomic_write import atomic_write_text  # noqa: E402
 from scripts.reconcile_ledger import (  # noqa: E402
     parse_predicate,
@@ -185,7 +185,7 @@ def week_summary(entries: list) -> dict:
         # #402 read-side: a row lacking a valid (run_id, skill) join key would
         # merge into a single "unknown" skill bucket, conflating unrelated runs
         # in the severity table. Skip + count it instead.
-        if not (_valid_identity(e.get("run_id")) and _valid_identity(e.get("skill"))):
+        if not valid_ledger_identity(e):
             skipped_identityless += 1
             continue
         skill = e["skill"]
@@ -377,7 +377,7 @@ def predicate_rates(entries: list, falsification_reduced: dict, *, now) -> dict:
             continue
         # #402 read-side: an identity-less row has no stable join key into the
         # falsification map — skip + count rather than bucket it under "unknown".
-        if not (_valid_identity(e.get("run_id")) and _valid_identity(e.get("skill"))):
+        if not valid_ledger_identity(e):
             skipped_identityless += 1
             continue
         skill = e["skill"]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -58,6 +58,9 @@ run python3 scripts/test_ledger_core.py
 # --- Ledger GIT layer: falsification discovery (#439 / #441) ---
 run python3 scripts/test_reconcile_git.py
 
+# --- Path-aware glob single-source-of-truth (#401) ---
+run python3 scripts/test_pathmatch.py
+
 # --- Lock state machines + crash recovery (#398 Phase 2) ---
 run python3 scripts/test_locks.py
 

--- a/scripts/test_ledger_core.py
+++ b/scripts/test_ledger_core.py
@@ -286,6 +286,44 @@ class AppendTest(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------- #
+# ledger_append.valid_ledger_identity (#408 F9) + default_repo realpath (#401) #
+# --------------------------------------------------------------------------- #
+
+class ValidLedgerIdentityTest(unittest.TestCase):
+    """The (run_id, skill) join-identity guard, factored out of the ×5 inlined
+    copies in reconcile_ledger / render_ledger (#408 F9)."""
+
+    def test_both_present_is_valid(self):
+        self.assertTrue(la.valid_ledger_identity(
+            {"run_id": "r1", "skill": "siege"}))
+
+    def test_missing_or_empty_or_nonstring_is_invalid(self):
+        for e in (
+            {"skill": "siege"},                       # no run_id
+            {"run_id": "r1"},                         # no skill
+            {"run_id": "", "skill": "siege"},         # empty run_id
+            {"run_id": "r1", "skill": "   "},         # whitespace skill
+            {"run_id": 123, "skill": "siege"},        # non-string run_id
+            {},                                       # neither
+        ):
+            self.assertFalse(la.valid_ledger_identity(e), e)
+
+
+class DefaultRepoRealpathTest(unittest.TestCase):
+    """#401: default_repo realpaths before taking the basename, so a repo reached
+    via a symlink yields the same label the grudge store derives."""
+
+    def test_symlinked_dir_resolves_to_real_basename(self):
+        with tempfile.TemporaryDirectory() as d:
+            real = os.path.join(d, "realrepo")
+            os.mkdir(real)
+            link = os.path.join(d, "linked")
+            os.symlink(real, link)
+            # Not a git repo → falls back to realpath(abspath(base)) basename.
+            self.assertEqual(la.default_repo(start_dir=link), "realrepo")
+
+
+# --------------------------------------------------------------------------- #
 # ledger_reduce.reduce — L-9 latest-wins + tolerant read                      #
 # --------------------------------------------------------------------------- #
 

--- a/scripts/test_pathmatch.py
+++ b/scripts/test_pathmatch.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Tests for scripts/pathmatch.py — the single source of truth for path-aware
+glob, extracted from the verbatim `_glob_match` duplication (#401).
+
+Pins both the matching contract AND the no-drift guarantee: reconcile_ledger
+and grudge_query must reference the SAME function object, so a future edit to
+one cannot silently diverge the other (the exact hazard #401 flagged — wrong
+glob semantics silently flip a Brier `actual`)."""
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from scripts.pathmatch import glob_match  # noqa: E402
+
+
+class GlobMatchContractTest(unittest.TestCase):
+    def test_exact_match(self):
+        self.assertTrue(glob_match("src/auth/token.ts", "src/auth/token.ts"))
+
+    def test_star_matches_within_one_segment(self):
+        self.assertTrue(glob_match("src/auth/token.ts", "src/auth/*"))
+        self.assertTrue(glob_match("src/auth/token.ts", "src/auth/*.ts"))
+
+    def test_star_does_not_cross_slash(self):
+        # the load-bearing property: `*` must NOT match a deeper subtree.
+        self.assertFalse(glob_match("src/auth/sub/x.ts", "src/auth/*"))
+
+    def test_segment_count_mismatch_fails(self):
+        self.assertFalse(glob_match("src/auth", "src/auth/token.ts"))
+        self.assertFalse(glob_match("a/b/c", "a/b"))
+
+    def test_case_sensitive_cross_host(self):
+        # fnmatchcase: `Auth` != `auth` regardless of host OS.
+        self.assertFalse(glob_match("src/Auth/token.ts", "src/auth/*"))
+
+    def test_question_and_class_metachars_within_segment(self):
+        self.assertTrue(glob_match("a/b1.py", "a/b?.py"))
+        self.assertTrue(glob_match("a/b1.py", "a/b[0-9].py"))
+        self.assertFalse(glob_match("a/bx.py", "a/b[0-9].py"))
+
+
+class NoDriftIdentityTest(unittest.TestCase):
+    """#401 anti-drift: the two former copies are now the SAME object."""
+
+    def test_reconcile_and_grudge_share_one_implementation(self):
+        from scripts import reconcile_ledger as rl
+        from scripts import grudge_query as gq
+        self.assertIs(rl._glob_match, glob_match)
+        self.assertIs(gq._glob_match, glob_match)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #401 — consolidate the ledger/grudge seam (slice 3 of the #408 goal)

Closes #401. The audit's DRY question resolves to a **narrow** yes — three concrete defects at the ledger↔grudge seam (the checker skeleton is explicitly kept as-is per #401).

1. **`_glob_match` de-duplication (= F8).** The verbatim-identical path-aware glob in `reconcile_ledger.py` and `grudge_query.py` → single source **`scripts/pathmatch.py:glob_match`**; both import it. This was correctness-critical drift — wrong glob semantics silently flip a Brier `actual`. New `test_pathmatch.py` pins the contract **and** the no-drift guarantee (`assertIs` — both modules reference one function object; a future re-copy fails the test).
2. **Import-rooting.** `grudge_query.py` was the lone sibling using `sys.path.insert(0, HERE)` + bare `from grudge_append import …`, forcing callers to keep **both** roots on `sys.path`. Switched to the `scripts.X` convention matching reconcile_ledger / render_ledger / brier_advisory / backfill-ledger.
3. **Repo-resolver drift.** `ledger_append.default_repo` now realpaths before the basename, for parity with `grudge_append.resolve_repo`. The divergent return **shape** (bare str vs tuple) is intentional and kept; only the symlink-resolution drift (in the non-git fallback) is removed. (`git rev-parse --show-toplevel` already canonicalizes, so the git path is a no-op — kept for textual parity.)

### Plus #408 F9
The `_valid_identity(run_id) and _valid_identity(skill)` join-key guard, inlined verbatim ×5 across reconcile_ledger/render_ledger, factored into `ledger_append.valid_ledger_identity(entry)` so the #402 read-side contract can't drift.

### Verification
- `bash scripts/run_tests.sh` → **63 → 64** (registers `test_pathmatch.py`).
- Self-gated via `/quality-gate`: round 1 **0F/0S/3M**, look-harder confirmed **0F/0S** — all four equivalences verified (glob byte-identity, import-rooting incl. standalone CLI + no circular import, default_repo git-path realpath no-op, F9 ×5 sites). Quick-fixed the one useful Minor (narrowed a `default_repo` comment). LOCAL marker only — **not** the central ledger.

Behavior-preserving refactor.

Closes #401
Refs #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)