### PR TITLE
fix(compass): #408 F12 — move lock out of world-writable /tmp (beside-data)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules/
 docs/plans/
 docs/prds/
 docs/compass.md
+# Transient compass lockdir (#408 F12: lock-beside-data); only present mid-write,
+# but a crashed process can leave one — never commit it.
+.lock-compass/
 docs/handoffs/
 # Local research scratch (dated audit/eval working dirs). Committed research
 # records live in docs/research/ directly; only the dated scratch is ignored.

--- a/scripts/compass.py
+++ b/scripts/compass.py
@@ -7,7 +7,6 @@ script wins. Stdlib only.
 import argparse
 import datetime as _dt
 import errno
-import hashlib
 import os
 import re
 import sys
@@ -73,8 +72,20 @@ def _test_sleep():
 
 # ── Lock ──────────────────────────────────────────────────────────────────────
 def _lockdir_for(repo_root):
-    h = hashlib.sha1(str(Path(repo_root).resolve()).encode()).hexdigest()[:8]
-    return f"/tmp/.lock-compass-{h}"
+    """Lock dir for a repo's compass.md — BESIDE THE DATA, in the user-owned repo
+    tree (#408 F12).
+
+    The lock used to live at `/tmp/.lock-compass-<sha1(repo_root)>` — a
+    predictable name in a world-writable directory. A hostile co-tenant could
+    pre-create the lockdir (→ `compass update` hangs the full 30s then
+    TimeoutErrors) or plant a `holder` file naming a live foreign PID (→ the
+    stale-recovery path evicts/races on it). Placing the lock inside the
+    resolved repo_root inherits the repo's ownership and permissions — the same
+    lock-beside-data posture `ledger_append` uses under `~/.claude`. `.resolve()`
+    keeps the lock identity dir-scoped, so symlinked / relative spellings of the
+    same root collapse to one lock.
+    """
+    return str(Path(repo_root).resolve() / ".lock-compass")
 
 
 def _holder_alive(pid):

--- a/scripts/test_locks.py
+++ b/scripts/test_locks.py
@@ -28,8 +28,10 @@ not silently fixed):
     the current derivation rule.
 
 Pure stdlib `unittest`. All locks live under tmp dirs (ledger lock is beside the
-tmp ledger_path; compass lock is `/tmp/.lock-compass-<sha1>` keyed off a tmp
-repo_root we create and clean up). The machine-local central store is never
+tmp ledger_path; the compass lock is `<repo_root>/.lock-compass` beside the data
+in the user-owned repo tree — #408 F12 moved it off the world-writable
+`/tmp/.lock-compass-<sha1>` — keyed off a tmp repo_root we create and clean up).
+The machine-local central store is never
 touched.
 """
 import json
@@ -334,10 +336,24 @@ class CompassStaleRecoveryTest(unittest.TestCase):
 
 class CompassAcquireReleaseTest(unittest.TestCase):
     def setUp(self):
-        # A tmp repo_root → a deterministic /tmp/.lock-compass-<sha1> we clean up.
+        # A tmp repo_root → a deterministic <repo_root>/.lock-compass we clean up
+        # (#408 F12: beside the data, not in shared /tmp).
         self.repo_root = tempfile.mkdtemp()
         self.lockdir = cm._lockdir_for(self.repo_root)
         self._cleanup_lock()
+
+    def test_f12_lock_lives_inside_repo_not_shared_tmp(self):
+        # #408 F12: the lockdir must sit inside the user-owned resolved repo_root
+        # (inheriting its permissions), NOT at the predictable, world-writable
+        # `/tmp/.lock-compass-<sha1>` a co-tenant could pre-create.
+        from pathlib import Path
+        root = str(Path(self.repo_root).resolve())
+        # Pin the exact location: beside the data, inside the resolved repo tree.
+        self.assertEqual(self.lockdir, os.path.join(root, ".lock-compass"))
+        # And it is NOT the old hole: a predictable name directly under the
+        # shared, world-writable /tmp root a co-tenant could pre-create.
+        self.assertFalse(self.lockdir.startswith("/tmp/.lock-compass"),
+                         "lock must not sit in the world-writable /tmp namespace")
 
     def tearDown(self):
         self._cleanup_lock()
@@ -436,10 +452,10 @@ class CompassLockIdentityTest(unittest.TestCase):
 
     def test_sibling_subdir_compasses_do_NOT_share_lock_BUG_406(self):
         # CHARACTERIZATION of deferred #406 (compass.py:689): the lock identity
-        # is dir-scoped (sha1 of the resolved repo_root), NOT keyed off the
-        # compass file's realpath. Two compass files under different sub-dirs of
-        # the same project therefore get DIFFERENT locks — concurrent writers to
-        # them do not serialize against each other. Pin the current behavior;
+        # is dir-scoped (one `.lock-compass` per resolved repo_root), NOT keyed
+        # off the compass file's realpath. Two compass files under different
+        # sub-dirs of the same project therefore get DIFFERENT locks — concurrent
+        # writers to them do not serialize against each other. Pin current behavior;
         # #406 may revisit the lock-identity derivation.
         with tempfile.TemporaryDirectory() as root:
             a_root = os.path.dirname(os.path.abspath(


### PR DESCRIPTION
## #408 F12 — compass lock out of world-writable /tmp (slice 4, Significant/security)

The compass concurrency lock lived at `/tmp/.lock-compass-<sha1(repo_root)>` — a **predictable name in a world-writable directory**. Attack surface:
- A hostile co-tenant pre-creates the lockdir → victim's `compass update` hangs the full 30s then `TimeoutError`.
- Or plants a `holder` file naming a **live foreign PID** → the stale-recovery path evicts / races on it (PID-reuse hazard).

`ledger_append` already locks beside its data under the user-owned `~/.claude`; compass was the outlier (the audit's F12).

### Fix
`_lockdir_for` now returns `<resolve(repo_root)>/.lock-compass` — inside the **user-owned repo tree, beside the data**, inheriting the repo's ownership/permissions. `.resolve()` keeps the lock **dir-scoped** (symlinked/relative spellings collapse to one lock), so mutual exclusion is preserved — and strictly improved (the literal path has none of sha1's theoretical collisions). `import hashlib` dropped (only used here). `.gitignore` gains `.lock-compass/` so a crashed-process lock leftover can't be committed.

### Verification
- `bash scripts/run_tests.sh` → **64/64**.
- Self-gated via `/quality-gate` with an **attacker lens**: round 1 **0F/0S/3M** — all three Fatal-class attacks (lock still attacker-writable / mutual-exclusion broken / normal-path crash) rejected with concrete reproduction; look-harder confirmed **0F/0S**. gitignore depth coverage verified via `git check-ignore`. Minors quick-fixed (exact-equality test assertion, comment wrap). LOCAL marker only — **not** the central ledger.
- New `test_f12_lock_lives_inside_repo_not_shared_tmp` pins the beside-data location and the not-in-`/tmp` property. Grudge recorded against the `/tmp/.lock-compass` anti-pattern.

Mutual exclusion preserved; `_acquire_lock`/`_release_lock`/`_try_recover_stale`/`_holder_alive` unchanged.

Refs #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)