### PR TITLE
fix(warden): anchor slashless escalator globs to **/ (cold-reader SKIP defect)

### DIFF
--- a/skills/warden/SKILL.md
+++ b/skills/warden/SKILL.md
@@ -77,8 +77,10 @@ Evaluated on the entry diff, in order (escalators dominate; strictly additive):
    → **run inquisitor**.
 4. **Else → skip inquisitor.**
 
-**INTERFACE/API/SCHEMA glob set:** `**/api/**`, `*.proto`, `openapi*`,
-`**/schema*`, `**/migrations/**`, `**/index.*`, `**/__init__.py`, `*.graphql`.
+**INTERFACE/API/SCHEMA glob set** (each matched at any depth, gitignore-style —
+every entry is `**/`-anchored, so a nested `internal/rpc/x.proto` matches exactly as
+a root-level `x.proto` does): `**/api/**`, `**/*.proto`, `**/openapi*`,
+`**/schema*`, `**/migrations/**`, `**/index.*`, `**/__init__.py`, `**/*.graphql`.
 
 **DEPENDENCY/lockfile glob set:** `**/package.json`, `**/*.lock`,
 `**/requirements*.txt`, `**/Cargo.toml`, `**/go.mod`, `**/pyproject.toml`.
@@ -99,7 +101,7 @@ inquisitor under the old clause now skips it.
 
 **Residual risk.** (a) *Escalator over-match:* several escalator globs swallow common
 docs paths — `**/api/**` catches `docs/api/x.md`, `**/index.*` catches `index.md`,
-`**/schema*` catches `schema.md`, `openapi*` catches `openapi.md`. Because escalators
+`**/schema*` catches `schema.md`, `**/openapi*` catches `openapi.md`. Because escalators
 are evaluated **first and dominate**, the pure-doc skip fires on a **narrower** slice
 than the headline "all-docs → skip" implies. The direction is **safe**
 (over-inclusive → more inquisitor runs, never fewer); for `openapi.md`/`schema.md`

--- a/skills/warden/evals/fixtures/tw3-doc-only-multifile/provenance.md
+++ b/skills/warden/evals/fixtures/tw3-doc-only-multifile/provenance.md
@@ -6,7 +6,7 @@ predicate* subsection); not recorded from a live run.
 - **`reviewer_set` = temper, delve, red-team — inquisitor SKIPPED via block 2.** Block 1
   (escalators): none of `README.md`, `guide.md`, `changelog.md` match the
   INTERFACE/API/SCHEMA or DEPENDENCY/lockfile glob sets (the names deliberately avoid the
-  `index.*`/`schema*`/`openapi*`/`api/**` over-match cases), no binary path → miss. Block 2
+  `**/index.*`/`**/schema*`/`**/openapi*`/`**/api/**` over-match cases), no binary path → miss. Block 2
   (pure-doc bounded subtraction): EVERY changed path is a pure-doc `.md` file → **skip
   inquisitor**. This is the token win — an all-docs sweep does not pay for the Opus 5-dim
   fan-out. siege absent (non-security).

--- a/skills/warden/evals/fixtures/tw3-openapi-md/provenance.md
+++ b/skills/warden/evals/fixtures/tw3-openapi-md/provenance.md
@@ -4,7 +4,7 @@ Hand-derived from `skills/warden/SKILL.md` (the *Standalone inquisitor-inclusion
 predicate* subsection); not recorded from a live run.
 
 - **`reviewer_set` includes inquisitor — via block 1.** Block 1 (escalators) is evaluated
-  FIRST: the single changed path `openapi.md` matches `openapi*` in the
+  FIRST: the single changed path `openapi.md` matches `**/openapi*` in the
   INTERFACE/API/SCHEMA glob set → **run inquisitor**. Block 2 (pure-doc) is never reached,
   so the `.md` extension does NOT earn a skip here. This is intended, and stated verbatim
   in SKILL.md's residual-risk note: "for `openapi.md`/`schema.md` the run is intended — an


### PR DESCRIPTION
Fixes #468.

## Problem
The standalone inquisitor-inclusion predicate (#466) escalator glob set mixed `**/`-anchored and slashless entries:
- anchored: `**/api/**`, `**/schema*`, `**/migrations/**`, `**/index.*`, `**/__init__.py`
- slashless: `*.proto`, `openapi*`, `*.graphql`

The predicate is orchestrator-followed prose (never executed in CI). A live `/warden` cold-reader validation (3 naive agents, no intended-answer hint) split **2 RUN / 1 SKIP** on a nested `internal/rpc/service.proto` diff — one reader read slashless `*.proto` as root-only (contrast with its `**/`-anchored siblings) → block-4 SKIP. That is the **unsafe** direction: it under-runs inquisitor, contradicting the predicate's fail-safe-toward-running intent. CI's present-only structural check cannot catch this ambiguity.

## Fix
Anchor all three slashless escalator globs to `**/*.proto`, `**/openapi*`, `**/*.graphql` (all 8 interface globs now uniformly `**/`-prefixed) + an explicit any-depth annotation naming `internal/rpc/x.proto` as a matching example. Two fixture-provenance spelling updates (cosmetic).

**Monotonic-safe:** only widens the escalator set (nested interface files move SKIP→RUN; none move RUN→SKIP). Preserves INV-P2/P6/P10.

## Verification
- **Cold-reader re-test on anchored text** (definitive — QG reviewers are primed by design and structurally cannot prove interpretation-convergence): `internal/rpc/service.proto` → **3/3 RUN**, nested `internal/gql/user.graphql` → **3/3 RUN**. Zero variance vs pre-fix 2R/1S.
- /quality-gate PASS (red-team 0F/0S + look-harder tightened-rubric 0F/0S).
- `check_warden_structure.py` exit 0; warden evals 20/20; full suite 75/75.
