### PR TITLE
fix(agents): #548 add explicit SendMessage delivery instruction to teammate-dispatched agent defs

### DIFF
--- a/agents/crucible-qg-fix.md
+++ b/agents/crucible-qg-fix.md
@@ -10,6 +10,15 @@ return-format instructions. The dispatch file is the single source of truth for
 your task, your inputs, and the exact structure of your return; do not infer a
 task or a return format from this system prompt.
 
+If you were dispatched as a named teammate — your first user message is wrapped
+in `<teammate-message teammate_id="...">` — you MUST deliver your result via
+`SendMessage` before finishing, including when reporting an abort. `SendMessage`
+is a deferred tool: first call `ToolSearch({query: "select:SendMessage"})` to
+load its schema, then call `SendMessage` addressed to the team lead with your
+return (your Evidence Receipt, or an abort report per the dispatch convention's
+Failure Handling procedure). Do not rely on your final message being returned
+automatically — it is not.
+
 This definition exists only to pin your model (Sonnet) and route you.
 Rationale and the sites the re-review bound does not cover: see
 `shared/harness-adapter.md` Mapping 1b (#537). It does not prescribe what you

--- a/agents/crucible-qg-judge.md
+++ b/agents/crucible-qg-judge.md
@@ -10,5 +10,14 @@ return-format instructions. The dispatch file is the single source of truth for
 your task, your inputs, and the exact structure of your return; do not infer a
 task or a return format from this system prompt.
 
+If you were dispatched as a named teammate — your first user message is wrapped
+in `<teammate-message teammate_id="...">` — you MUST deliver your result via
+`SendMessage` before finishing, including when reporting an abort. `SendMessage`
+is a deferred tool: first call `ToolSearch({query: "select:SendMessage"})` to
+load its schema, then call `SendMessage` addressed to the team lead with your
+return (your Evidence Receipt, or an abort report per the dispatch convention's
+Failure Handling procedure). Do not rely on your final message being returned
+automatically — it is not.
+
 This definition exists only to pin your model (Sonnet) and route you. It does not
 prescribe what you produce — the dispatch file does.

--- a/agents/crucible-qg-verifier.md
+++ b/agents/crucible-qg-verifier.md
@@ -10,6 +10,15 @@ return-format instructions. The dispatch file is the single source of truth for
 your task, your inputs, and the exact structure of your return; do not infer a
 task or a return format from this system prompt.
 
+If you were dispatched as a named teammate — your first user message is wrapped
+in `<teammate-message teammate_id="...">` — you MUST deliver your result via
+`SendMessage` before finishing, including when reporting an abort. `SendMessage`
+is a deferred tool: first call `ToolSearch({query: "select:SendMessage"})` to
+load its schema, then call `SendMessage` addressed to the team lead with your
+return (your Evidence Receipt, or an abort report per the dispatch convention's
+Failure Handling procedure). Do not rely on your final message being returned
+automatically — it is not.
+
 This definition exists only to pin your model (Sonnet) and route you. It does not
 prescribe what you produce — the dispatch file does. Different dispatch files give
 this role different return contracts (e.g. an Evidence Receipt for fix

--- a/agents/crucible-red-team.md
+++ b/agents/crucible-red-team.md
@@ -11,5 +11,14 @@ return-format instructions. The dispatch file is the single source of truth for
 your task, your inputs, and the exact structure of your return; do not infer a
 task or a return format from this system prompt.
 
+If you were dispatched as a named teammate — your first user message is wrapped
+in `<teammate-message teammate_id="...">` — you MUST deliver your result via
+`SendMessage` before finishing, including when reporting an abort. `SendMessage`
+is a deferred tool: first call `ToolSearch({query: "select:SendMessage"})` to
+load its schema, then call `SendMessage` addressed to the team lead with your
+return (your Evidence Receipt, or an abort report per the dispatch convention's
+Failure Handling procedure). Do not rely on your final message being returned
+automatically — it is not.
+
 This definition exists only to pin your model (Opus) and route you. It does not
 prescribe what you produce — the dispatch file does.


### PR DESCRIPTION
## Summary
- Adds an explicit instruction to the four pinned Crucible agent defs (`crucible-red-team`, `crucible-qg-fix`, `crucible-qg-judge`, `crucible-qg-verifier`): when dispatched as a named `in_process_teammate`, load `SendMessage`'s schema via `ToolSearch` and call it to deliver your result — including on abort — before finishing.
- This is a defensive mitigation for #548, not a confirmed root-cause fix — see the linked comment on #548 for the full investigation (6-round quality-gate hypothesis gate; five successive causal theories proposed and falsified; the exact triggering mechanism for silent non-delivery is still unconfirmed). It directly targets the observed failure mode (a named-teammate dispatch finishing without its result ever reaching the orchestrator) regardless of the precise trigger.
- Related to #542 — same `name:`-teammate topology; recommend keeping both open together rather than treating either as a duplicate.

## Test plan
- [x] Diff is exactly the four `agents/crucible-*.md` files, one added paragraph each — no other lines touched
- [x] Frontmatter (YAML) on all four files re-parsed and confirmed intact
- [x] `bash scripts/run_tests.sh` — 79/79 suite invocations pass

🤖 Change drafted via the private `ai-rack` driver repo (maintainer-confirmed), independently reviewed and verified locally before this PR.

https://github.com/raddue/crucible/issues/548