### PR TITLE
fix(rcpt): #601 diagnosed group-writable toplevel as world-writable

### DIFF
--- a/scripts/rcpt_verify.py
+++ b/scripts/rcpt_verify.py
@@ -2776,10 +2776,33 @@ def _unresolved_disposition(name, strict, cov, witness_leg=False, refused=None):
     return f"UNVERIFIABLE: {label} (no file under root){_refused_clause(refused)}"
 
 
+def _writability_notes(d):
+    """SIEGE-C1 — name the writability class that actually refused `d` as a probe base.
+
+    `_is_world_writable`'s mask is `0o022`, so a directory that is group-writable (`g+w`,
+    mode bit `0o020`) but not other-writable is refused too — and calling THAT a
+    "world-writable git toplevel" is a double misdiagnosis: not only is the directory not
+    world-writable, the remedy it states ("make it non-world-writable") is already
+    satisfied, so an operator who follows the text changes nothing and never reaches the
+    real cause (`g+w`). Each refused directory is reported against its own mode instead.
+    `0o002` is the superset threat, so an other-writable directory takes the world label.
+    An unstattable directory falls back to the world label — `_is_world_writable` already
+    treated that as writable (fail closed), and the superset claim can only overstate."""
+    try:
+        m = d.stat().st_mode
+    except OSError:
+        m = 0o002
+    if m & 0o002:
+        return ("world-writable (o+w)", "any local uid can plant a marker there",
+                "make it non-world-writable (chmod o-w)")
+    return ("group-writable (g+w)", "any uid in the directory's group can plant a marker there",
+            "make it non-group-writable (chmod g-w, or -D on a shared parent)")
+
+
 def _refused_clause(refused):
     """SIEGE-C1 — the suffix naming a probe base that was DROPPED rather than absent.
 
-    A world-writable git toplevel is refused as a probe base, so a repo-relative name
+    A writable git toplevel is refused as a probe base, so a repo-relative name
     resolves nowhere and (path-shaped, under the mandated --strict) hard-FAILs. Without
     this the operator is told the artifact is "absent under all bases" for a file that is
     present and readable, with nothing on stderr mentioning permissions — so a checkout in
@@ -2787,7 +2810,11 @@ def _refused_clause(refused):
     umask-000 container clones) blocks every receipt citing such a name, with a false
     diagnosis. Blocks, precisely: a PATH-SHAPED name hard-FAILs under --strict; a bare
     basename stays UNVERIFIABLE at exit 0. The clause is appended on both dispositions,
-    since the operator needs the reason either way.
+    since the operator needs the reason either way. Each refused directory is diagnosed
+    against the write bit that actually fired (`_writability_notes`): `world-writable (o+w)`
+    for `0o002`, `group-writable (g+w)` for a `g+w`-only directory — the pre-#601 wording
+    called both world-writable and so pointed a group-writable checkout at a remedy that
+    was already satisfied.
 
     It reaches BOTH cited-name shapes because the refusal is recorded in `_allowed_bases`:
     a relative name loses `repo / name` as a candidate, and an absolute name inside the
@@ -2805,9 +2832,11 @@ def _refused_clause(refused):
     What was wrong was the silence, not the refusal."""
     if not refused:
         return ""
-    homes = ", ".join(sorted(_show_path(d) for d in refused))
-    return (f" [refused as probe base: world-writable git toplevel {homes} — "
-            f"any local uid can plant a marker there; make it non-world-writable]")
+    parts = []
+    for d in sorted(refused, key=str):
+        label, threat, remedy = _writability_notes(d)
+        parts.append(f"{label} git toplevel {_show_path(d)} — {threat}; {remedy}")
+    return " [refused as probe base: " + "; ".join(parts) + "]"
 
 
 # SIEGE-R2BA-2 — the ceiling on how many bytes ONE Tier-2 leg will materialise from

--- a/scripts/rcpt_verify.py
+++ b/scripts/rcpt_verify.py
@@ -2509,6 +2509,20 @@ def _is_git_marker(g: pathlib.Path) -> bool:
     return False
 
 
+class _RefusedBase(typing.NamedTuple):
+    """A probe base SIEGE-C1 dropped, carried WITH the mode that dropped it.
+
+    #615 — the refusal decision and the human-readable diagnosis used to `stat()` the
+    directory independently, so they could disagree about the same path: a first stat that
+    failed (`_writable_mode`'s fail-closed arm) followed by a second that succeeded made a
+    0755 directory print "group-writable (g+w) … chmod g-w", a remedy already satisfied —
+    the exact confusing-diagnosis class #601 was about — and a mode change between the two
+    stats could label an `o+w` directory as merely `g+w`, understating the threat. One
+    stat, carried to the message, cannot disagree with itself."""
+    path: pathlib.Path
+    mode: int
+
+
 def _git_toplevel(start: pathlib.Path, refused=None):
     d = start if start.is_dir() else start.parent
     for cur in [d, *d.parents]:
@@ -2540,7 +2554,10 @@ def _git_toplevel(start: pathlib.Path, refused=None):
         # is a design change to the probe set (quality-gate/SKILL.md:30 defines it as
         # "each supplied root plus that root's git toplevel") and not a linter-local fix.
         if _is_git_marker(cur / ".git"):
-            if not _is_world_writable(cur):
+            # #615 — ONE stat, whose mode both decides the refusal here and words the
+            # diagnosis in `_writability_notes`. See `_RefusedBase`.
+            mode = _writable_mode(cur)
+            if not mode & 0o022:
                 return cur
             # `refused` is an optional out-param (the same idiom as found/cov/probe/
             # meter/bodies): the refusal must be REPORTABLE, not merely silent. Dropping
@@ -2549,8 +2566,8 @@ def _git_toplevel(start: pathlib.Path, refused=None):
             # so in a world-writable checkout the refusal blocks every receipt of the run
             # while stderr says only "absent under all bases", of a file that is present
             # and readable. The disposition appends the real reason instead.
-            if refused is not None and cur not in refused:
-                refused.append(cur)
+            if refused is not None and not any(r.path == cur for r in refused):
+                refused.append(_RefusedBase(cur, mode))
             # siege S-3 — and STOP. This used to KEEP WALKING, on the reasoning that "a
             # legitimate repo further up still wins". Measured, that reasoning INVERTED
             # the containment guarantee: the ancestor toplevel a continued walk finds is
@@ -2572,12 +2589,19 @@ def _git_toplevel(start: pathlib.Path, refused=None):
     return None   # stdlib-only: walk for .git rather than shelling out to git
 
 
-def _is_world_writable(d: pathlib.Path) -> bool:
-    """SIEGE-C1 — writable by someone other than its owner, on the directory that HOLDS
+def _writable_mode(d: pathlib.Path) -> int:
+    """SIEGE-C1 — the mode deciding whether `d` is writable by someone other than its
+    owner, on the directory that HOLDS
     the `.git` marker, i.e. "a uid that is not this one could have created this marker".
     Raw mode bits rather than an `import stat` for two bits; the sticky bit is irrelevant
-    here (it restrains deletion, not creation). An unstattable directory is treated as
-    writable — fail closed.
+    here (it restrains deletion, not creation). An unstattable directory returns the
+    sentinel `0o002` and is therefore treated as writable — fail closed, and it takes the
+    superset (world) label in `_writability_notes`, which can only overstate.
+
+    #615 — this returns the MODE rather than a bool so that `_git_toplevel` can carry the
+    very mode it refused on into the diagnosis (`_RefusedBase`) instead of the message
+    re-`stat()`ing the path and possibly disagreeing. The mask (`0o022`) is applied by the
+    caller; everything below is about that mask.
 
     siege S-3 — the mask was `0o002` (other) ALONE while this function's callers, and
     `quality-gate/SKILL.md` § "Dispatch-root and findings-root layout (#486)" pin (b)
@@ -2593,9 +2617,9 @@ def _is_world_writable(d: pathlib.Path) -> bool:
     has no portable reader, and this module is stdlib-only — so an ACL-writable directory
     with owner-only mode bits still contributes its toplevel."""
     try:
-        return bool(d.stat().st_mode & 0o022)
+        return d.stat().st_mode
     except OSError:
-        return True
+        return 0o002
 
 
 # SIEGE-C2 — the ONE renderer for a filesystem path interpolated into stderr.
@@ -2776,23 +2800,23 @@ def _unresolved_disposition(name, strict, cov, witness_leg=False, refused=None):
     return f"UNVERIFIABLE: {label} (no file under root){_refused_clause(refused)}"
 
 
-def _writability_notes(d):
-    """SIEGE-C1 — name the writability class that actually refused `d` as a probe base.
+def _writability_notes(mode):
+    """SIEGE-C1 — name the writability class that actually refused a probe base.
 
-    `_is_world_writable`'s mask is `0o022`, so a directory that is group-writable (`g+w`,
+    The refusal mask is `0o022`, so a directory that is group-writable (`g+w`,
     mode bit `0o020`) but not other-writable is refused too — and calling THAT a
     "world-writable git toplevel" is a double misdiagnosis: not only is the directory not
     world-writable, the remedy it states ("make it non-world-writable") is already
     satisfied, so an operator who follows the text changes nothing and never reaches the
     real cause (`g+w`). Each refused directory is reported against its own mode instead.
     `0o002` is the superset threat, so an other-writable directory takes the world label.
-    An unstattable directory falls back to the world label — `_is_world_writable` already
-    treated that as writable (fail closed), and the superset claim can only overstate."""
-    try:
-        m = d.stat().st_mode
-    except OSError:
-        m = 0o002
-    if m & 0o002:
+    An unstattable directory falls back to the world label — `_writable_mode` already
+    treated that as writable (fail closed), and the superset claim can only overstate.
+
+    #615 — `mode` is the mode `_git_toplevel` ACTUALLY REFUSED ON, handed over in
+    `_RefusedBase`, not one this function re-derives from the path. Re-stat'ing here made
+    the message able to contradict the decision that produced it: see `_RefusedBase`."""
+    if mode & 0o002:
         return ("world-writable (o+w)", "any local uid can plant a marker there",
                 "make it non-world-writable (chmod o-w)")
     return ("group-writable (g+w)", "any uid in the directory's group can plant a marker there",
@@ -2833,10 +2857,13 @@ def _refused_clause(refused):
     if not refused:
         return ""
     parts = []
-    for d in sorted(refused, key=str):
-        label, threat, remedy = _writability_notes(d)
-        parts.append(f"{label} git toplevel {_show_path(d)} — {threat}; {remedy}")
-    return " [refused as probe base: " + "; ".join(parts) + "]"
+    for r in sorted(refused, key=lambda e: str(e.path)):
+        label, threat, remedy = _writability_notes(r.mode)
+        parts.append(f"{label} git toplevel {_show_path(r.path)} — {threat}; {remedy}")
+    # #615 — entries are joined with " | ", not "; ": "; " is ALREADY the separator
+    # INSIDE one entry (threat from remedy), so two refused directories rendered as four
+    # semicolon-separated clauses with nothing marking where one directory ended.
+    return " [refused as probe base: " + " | ".join(parts) + "]"
 
 
 # SIEGE-R2BA-2 — the ceiling on how many bytes ONE Tier-2 leg will materialise from

--- a/scripts/test_rcpt_verify.py
+++ b/scripts/test_rcpt_verify.py
@@ -6388,6 +6388,50 @@ class TestARefusedProbeBaseIsDiagnosable(_InqBase):
         self.assertNotIn("world-writable", out.stderr)
         self.assertIn("non-group-writable", out.stderr)
 
+    def test_the_diagnosis_uses_the_mode_the_refusal_used(self):
+        """#615 — the refusal (`_git_toplevel`) and the wording (`_writability_notes`)
+        used to `stat()` the directory INDEPENDENTLY, so a mode change between the two
+        made the message contradict the decision that produced it: an `o+w` directory
+        could be reported as merely `g+w` (understating the threat), and a first stat that
+        failed closed followed by a second that succeeded could point a 0755 directory at
+        `chmod g-w` — a remedy already satisfied, the #601 class over again. One stat,
+        carried in `_RefusedBase`, cannot disagree with itself."""
+        rv = _import_rv()
+        d = self.base / "toctou"; d.mkdir()
+        _plant_git_dir(d)
+        os.chmod(d, 0o777)
+        self.addCleanup(os.chmod, d, 0o755)
+        if not (d.stat().st_mode & 0o002):
+            self.skipTest("filesystem does not honour chmod; cannot set o+w")
+        refused = []
+        self.assertIsNone(rv._git_toplevel(d, refused))
+        os.chmod(d, 0o755)                 # the race: mode moves after the decision
+        clause = rv._refused_clause(refused)
+        self.assertIn("world-writable (o+w) git toplevel", clause)
+        self.assertNotIn("group-writable", clause)
+
+    def test_two_refused_directories_are_separable(self):
+        """#615 — `; ` was both the intra-entry separator (threat from remedy) and the
+        inter-entry one, so two refused directories rendered as four semicolon-separated
+        clauses with nothing marking where one directory ended."""
+        rv = _import_rv()
+        dirs = []
+        for nm in ("a", "b"):
+            d = self.base / nm; d.mkdir()
+            _plant_git_dir(d)
+            os.chmod(d, 0o777)
+            self.addCleanup(os.chmod, d, 0o755)
+            if not (d.stat().st_mode & 0o002):
+                self.skipTest("filesystem does not honour chmod; cannot set o+w")
+            dirs.append(d)
+        refused = []
+        for d in dirs:
+            self.assertIsNone(rv._git_toplevel(d, refused))
+        clause = rv._refused_clause(refused)
+        self.assertEqual(len(clause.split(" | ")), 2, clause)
+        for d in dirs:
+            self.assertIn(str(d), clause)
+
     def test_an_absolute_cited_name_is_diagnosed_too(self):
         """The shape a refusal blocks through the CONTAINMENT UNION rather than through
         the candidate list. An absolute name keeps its own candidate, but the refused
@@ -6888,7 +6932,7 @@ class TestTheWorldWritableRefusalIsMonotone(_InqBase):
         self.assertIn("refused as probe base", hostile.stderr)
 
     def test_a_group_writable_toplevel_is_refused_too(self):
-        """`_is_world_writable` tested `0o002` alone while its callers, and
+        """The writability check tested `0o002` alone while its callers, and
         quality-gate/SKILL.md:41, both claim "any local uid could have planted" — 0775 and
         0770 are exactly that claim's case and were accepted."""
         rv = _import_rv()

--- a/scripts/test_rcpt_verify.py
+++ b/scripts/test_rcpt_verify.py
@@ -6367,8 +6367,26 @@ class TestARefusedProbeBaseIsDiagnosable(_InqBase):
         os.chmod(repo, 0o777)
         out = self.cli("--tier2", "--strict", "--root", str(repo / "work"), str(r))
         self.assertEqual(out.returncode, 1, out.stderr)
-        self.assertIn("world-writable git toplevel", out.stderr)
+        self.assertIn("world-writable (o+w) git toplevel", out.stderr)
         self.assertIn(str(repo), out.stderr)
+
+    def test_a_group_writable_toplevel_is_diagnosed_group_writable(self):
+        """#601 — a `g+w`-only git toplevel (the `drwxrwsr-x` worktree shape, 0o2775) is
+        still REFUSED, but the diagnosis must name the bit that actually fired. The old
+        wording called it "world-writable" and told the operator to "make it
+        non-world-writable" — a remedy already in place for `g+w`-only, so nothing
+        changed and the real cause stayed invisible."""
+        repo, r = self._repo()
+        os.chmod(repo, 0o2775)                       # setgid group-writable, no o+w
+        self.addCleanup(os.chmod, repo, 0o755)
+        if not (repo.stat().st_mode & 0o020):
+            self.skipTest("filesystem does not honour chmod; cannot set g+w")
+        out = self.cli("--tier2", "--strict", "--root", str(repo / "work"), str(r))
+        self.assertEqual(out.returncode, 1, out.stderr)
+        self.assertIn("group-writable (g+w) git toplevel", out.stderr)
+        self.assertIn(str(repo), out.stderr)
+        self.assertNotIn("world-writable", out.stderr)
+        self.assertIn("non-group-writable", out.stderr)
 
     def test_an_absolute_cited_name_is_diagnosed_too(self):
         """The shape a refusal blocks through the CONTAINMENT UNION rather than through
@@ -6394,7 +6412,7 @@ class TestARefusedProbeBaseIsDiagnosable(_InqBase):
         os.chmod(repo, 0o777)
         out = self.cli("--tier2", "--strict", "--root", str(repo / "work"), str(p))
         self.assertEqual(out.returncode, 1, out.stderr)
-        self.assertIn("world-writable git toplevel", out.stderr)
+        self.assertIn("world-writable (o+w) git toplevel", out.stderr)
         # Non-vacuity: the ABSOLUTE name is the one being diagnosed.
         self.assertIn(absname, out.stderr)
 


### PR DESCRIPTION
Fixes #601

## Problem

While running #585's quality gate, a group-writable git toplevel owned by the invoking uid (`drwxrwsr-x`, 0o3775/0o2775 worktree shape) was refused as a probe base — the refusal itself is correct — but diagnosed as `world-writable git toplevel` with the advice "make it non-world-writable". Three things wrong with that message for the `g+w`-only case:

- the directory is *not* world-writable;
- "any local uid can plant a marker there" overstates (only group members can);
- "make it non-world-writable" instructs a fix already in place, so the operator changes nothing and never reaches the actual cause.

Consequence: repo-relative path-shaped citations from a group-writable worktree hard-FAIL the mandated `--strict` run with a diagnosis that actively points away from the cause.

## Fix

Diagnosis now reports the write bit that actually fired, per refused directory (`_writability_notes`):

- `world-writable (o+w) git toplevel <path> — any local uid can plant a marker there; make it non-world-writable (chmod o-w)` (mode bit 0o002)
- `group-writable (g+w) git toplevel <path> — any uid in the directory's group can plant a marker there; make it non-group-writable (chmod g-w, or -D on a shared parent)` (`g+w`-only)

The refusal *behaviour* is deliberately unchanged — the mask stays `0o022`, the exit code does not move, and the containment guarantee is untouched. Only the diagnosis was wrong. The two-root relaxation question from the issue (third root for repo-resident artifacts vs. narrowing the toplevel refusal) remains an open design call and is out of scope here.

## Tests

- New regression test `test_a_group_writable_toplevel_is_diagnosed_group_writable`: 0o2775 repo → still exit 1, diagnosed `group-writable (g+w)`, `non-group-writable` remedy, and `world-writable` absent from stderr.
- Updated the two existing 0o777 assertions to the new `world-writable (o+w)` wording.
- Full gate: `bash scripts/run_tests.sh` — all 95 suite invocations pass.