### PR TITLE
fix(grudge): #605 env-allowlist for resolve_repo git shell-out

### DIFF
--- a/scripts/grudge_append.py
+++ b/scripts/grudge_append.py
@@ -61,9 +61,17 @@ def resolve_repo(start_dir: Optional[str] = None) -> Tuple[str, str]:
     base = start_dir or os.getcwd()
     try:
         import subprocess
+        # #605 (siege S-3): run git under an ALLOWLIST env, never the inherited
+        # one. Hooks export GIT_DIR/GIT_WORK_TREE; with no env= those leak in
+        # and steer which repo git reports — the store dir, the repo_root
+        # isolation key, and the privacy-guard check all follow the WRONG repo.
+        # A denylist can't work (GIT_CONFIG_KEY_n is indexed, no finite set), so
+        # keep only what git needs: PATH (find git) + HOME (read ~/.gitconfig).
+        keep = ("PATH", "HOME")
+        env = {k: os.environ[k] for k in keep if k in os.environ}
         proc = subprocess.run(
             ["git", "-C", base, "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, timeout=5, env=env,
         )
         top = proc.stdout.strip()
         if proc.returncode == 0 and top:

--- a/scripts/grudge_append.py
+++ b/scripts/grudge_append.py
@@ -54,9 +54,24 @@ def grudges_dir(repo: str, base_dir: Optional[str] = None) -> str:
     return os.path.join(base, repo, "grudges")
 
 
+def _walk_up_git_root(base: str) -> Optional[str]:
+    """Env-free repo-root detector: walk up from `base` looking for a `.git`
+    entry (a dir in a normal clone, a file in a worktree/submodule). Returns the
+    realpath of the containing dir, or None when no `.git` is found."""
+    cur = os.path.realpath(os.path.abspath(base))
+    while True:
+        if os.path.exists(os.path.join(cur, ".git")):
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return None
+        cur = parent
+
+
 def resolve_repo(start_dir: Optional[str] = None) -> Tuple[str, str]:
     """(repo_basename, repo_root_realpath) for the repo the cwd is in. Shells to
-    git; falls back to the realpath of start_dir/cwd when not in a git repo.
+    git; if that fails, walks up for a `.git` entry; falls back to the realpath
+    of start_dir/cwd only when neither finds a repo.
     Never raises. CLI-only (git side effect)."""
     base = start_dir or os.getcwd()
     try:
@@ -79,6 +94,22 @@ def resolve_repo(start_dir: Optional[str] = None) -> Tuple[str, str]:
             return (os.path.basename(root.rstrip("/")) or root, root)
     except Exception:  # noqa: BLE001 — best-effort, never fatal
         pass
+    # #605 (follow-up): the allowlist above makes the git call newly FAILABLE in
+    # legitimate setups (config reachable only via GIT_CONFIG_GLOBAL/XDG_CONFIG_HOME,
+    # a Windows box needing SystemRoot/PATHEXT, git off PATH). Falling straight
+    # through to cwd would report a SUBDIR as the repo root — and then the
+    # privacy guard in append() compares the store dir against that too-narrow
+    # root and happily writes the private store INTO the repo tree, which is the
+    # exact leak #605 closed, reached via a silent git failure instead. So try an
+    # env-free walk-up first; bare cwd is only for a genuine non-repo dir.
+    walked = _walk_up_git_root(base)
+    if walked is not None:
+        _warn(
+            f"git rev-parse failed under the allowlist env (PATH+HOME) but {base} is "
+            f"inside a git repo; using the walked-up root {walked}. Grudge dedupe keys "
+            f"and the privacy guard depend on this root being the real toplevel."
+        )
+        return (os.path.basename(walked.rstrip("/")) or walked, walked)
     root = os.path.realpath(os.path.abspath(base))
     return (os.path.basename(root) or "unknown", root)
 

--- a/scripts/test_stores.py
+++ b/scripts/test_stores.py
@@ -100,8 +100,15 @@ class GrudgeResolveRepoEnvTest(unittest.TestCase):
         os.environ.update(self.saved)
 
     def _gitinit(self, d):
+        # Run the fixture's own git under the SAME allowlist the code under test
+        # uses. These tests deliberately poison the ambient env (GIT_DIR /
+        # GIT_WORK_TREE, and PATH in the walk-up test); inheriting that here
+        # would steer or break `git init` itself, so the fixture would stop
+        # building what the assertions claim to exercise.
         subprocess.run(["git", "init", "-q", d], check=True,
-                       capture_output=True, text=True)
+                       capture_output=True, text=True,
+                       env={k: os.environ[k] for k in ("PATH", "HOME")
+                            if k in os.environ})
 
     def test_inherited_git_dir_does_not_steer_repo_resolution(self):
         with tempfile.TemporaryDirectory() as out:
@@ -143,6 +150,34 @@ class GrudgeResolveRepoEnvTest(unittest.TestCase):
             self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
             self.assertFalse(os.path.exists(os.path.join(store, "real_repo")))
             self.assertFalse(os.path.exists(os.path.join(store, "hidden_repo")))
+
+    def test_git_failure_in_subdir_still_finds_the_real_repo_root(self):
+        # The allowlist made the git call failable in legitimate setups. If a
+        # failure fell through to realpath(cwd), a cwd one level down would be
+        # reported as the repo root — and append()'s privacy guard, comparing
+        # the store dir against that too-narrow root, would then permit a write
+        # INTO the repo tree. Same leak as #605, reached by a silent git
+        # failure. Here git is genuinely unreachable (PATH holds no git), which
+        # is a real failure, not a mock.
+        with tempfile.TemporaryDirectory() as out:
+            repo = os.path.join(out, "real_repo")
+            self._gitinit(repo)
+            sub = os.path.join(repo, "src", "deep")
+            os.makedirs(sub)
+            os.environ["PATH"] = os.path.join(out, "empty_bin")
+            os.makedirs(os.environ["PATH"])
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                repo_name, root = ga.resolve_repo(start_dir=sub)
+                # ...and the guard that depends on it still refuses an in-tree store.
+                refused = ga.append(
+                    symptom="private bug", files_touched=["src/secret.py"],
+                    repo=repo_name, repo_root=root,
+                    base_dir=os.path.join(repo, ".claude", "grudge"))
+            self.assertEqual(root, os.path.realpath(repo))   # NOT the subdir
+            self.assertEqual(repo_name, "real_repo")
+            self.assertIsNone(refused)
+            self.assertFalse(os.path.exists(os.path.join(repo, ".claude")))
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/test_stores.py
+++ b/scripts/test_stores.py
@@ -23,6 +23,7 @@ import json
 import os
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 import threading
@@ -78,6 +79,70 @@ class GrudgeIsInsideTest(unittest.TestCase):
     def test_parent_equals_child_is_inside(self):
         with tempfile.TemporaryDirectory() as d:
             self.assertTrue(ga._is_inside(d, d))
+
+
+# --------------------------------------------------------------------------- #
+# grudge_append — resolve_repo() env allowlist (siege S-3, #605)               #
+# --------------------------------------------------------------------------- #
+
+class GrudgeResolveRepoEnvTest(unittest.TestCase):
+    """#605 — resolve_repo() shells out to git with the FULL inherited env.
+    Git hooks export GIT_DIR/GIT_WORK_TREE; with no `env=` those leak in and
+    steer which repo git reports, which decides the store dir, the repo_root
+    isolation key, AND the privacy-guard check. git must run under an
+    allowlist env (PATH + HOME), never the inherited one."""
+
+    def setUp(self):
+        self.saved = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.saved)
+
+    def _gitinit(self, d):
+        subprocess.run(["git", "init", "-q", d], check=True,
+                       capture_output=True, text=True)
+
+    def test_inherited_git_dir_does_not_steer_repo_resolution(self):
+        with tempfile.TemporaryDirectory() as out:
+            real = os.path.join(out, "real_repo")
+            hidden = os.path.join(out, "hidden_repo")
+            for d in (real, hidden):
+                self._gitinit(d)
+            # Recreate a git hook's exported environment: GIT_DIR/WORK_TREE
+            # point at the WRONG repo (this is exactly what hooks export).
+            os.environ["GIT_DIR"] = os.path.join(hidden, ".git")
+            os.environ["GIT_WORK_TREE"] = hidden
+            repo, root = ga.resolve_repo(start_dir=real)
+            # Must resolve to the repo the cwd is in, not the GIT_DIR-steered one.
+            self.assertEqual(repo, "real_repo")
+            self.assertEqual(root, os.path.realpath(real))
+
+    def test_append_cli_refuses_store_into_repo_tree_under_poisoned_env(self):
+        # #605 end-to-end (the siege-verified leak): the whole append() chain key
+        # on the repo resolve_repo() reports. With GIT_DIR inherited, it reports
+        # the steered repo, the privacy guard compares against the WRONG
+        # repo_root, and the private store gets written INTO the real repo tree.
+        # With the fix the guard still refuses on the REAL cwd repo (rc=1, and
+        # no grudges under the store path inside the repo tree).
+        with tempfile.TemporaryDirectory() as out:
+            real = os.path.join(out, "real_repo")
+            hidden = os.path.join(out, "hidden_repo")
+            for d in (real, hidden):
+                self._gitinit(d)
+            store = os.path.join(real, ".claude", "grudge")
+            env = dict(os.environ)
+            env["GIT_DIR"] = os.path.join(hidden, ".git")
+            env["GIT_WORK_TREE"] = hidden
+            env["CRUCIBLE_GRUDGE_DIR"] = store
+            script = os.path.join(HERE, "grudge_append.py")
+            r = subprocess.run(
+                [sys.executable, script, "--symptom", "private bug",
+                 "--files", "src/secret.py", "--root-cause", "regression"],
+                cwd=real, env=env, capture_output=True, text=True)
+            self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+            self.assertFalse(os.path.exists(os.path.join(store, "real_repo")))
+            self.assertFalse(os.path.exists(os.path.join(store, "hidden_repo")))
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
Fixes #605 (siege S-3, P1 security). `resolve_repo()` in `scripts/grudge_append.py` shelled out to git with the **full inherited environment**. Git hooks export `GIT_DIR`/`GIT_WORK_TREE`; inherited, they steer which repo git reports — corrupting all three things `resolve_repo()` decides at once:

1. **store dir** — grudges written under the wrong `<repo>` basename
2. **repo_root isolation key** — read-side isolation + dedupe hash key
3. **privacy-guard check** — compared against the WRONG repo_root, so the private store (private file paths; crucible is a PUBLIC repo) gets written **into the repo tree**

## Fix
Run git under an **allowlist env** (`PATH` + `HOME` only), the discipline the issue notes the hardened siblings used (`env -i PATH HOME git`). A denylist cannot work (`GIT_CONFIG_KEY_n` is indexed). `HOME` stays so `~/.gitconfig` still applies; bare `GIT_DIR`/`GIT_WORK_TREE`/`GIT_CONFIG_*` are the exact vectors this kills.

## Tests (TDD, red→green verified)
- `test_inherited_git_dir_does_not_steer_repo_resolution` — unit: poisoned `GIT_DIR`/`GIT_WORK_TREE` must not steer `resolve_repo()` (failed RED: returned `hidden_repo`).
- `test_append_cli_refuses_store_into_repo_tree_under_poisoned_env` — e2e: `grudge_append.py` CLI under poisoned env returns rc=1 and writes nothing into the repo tree (failed RED: leaked store to `real_repo/.claude/grudge/hidden_repo/grudges/<hash>.md`).

`bash scripts/run_tests.sh`: all 95 invocations pass.

## Out of scope (noted, not fixed)
`ledger_append.default_repo()` shares the same pattern — but the ledger subsystem's blast radius is provenance *labeling* only (ledger store location is fixed at `~/.claude/crucible/ledger`, no privacy-guard bypass). #605 is scoped to the grudge privacy guard; flagging for a follow-up if desired.