### PR TITLE
fix(grudge): by-files clearance no longer spends the persisted block counter (#608)

### DIFF
--- a/hooks/grudge-resolution-guard.sh
+++ b/hooks/grudge-resolution-guard.sh
@@ -506,7 +506,7 @@ if [ -f "$SKIPS_FILE" ]; then
   done < "$SKIPS_FILE"
 fi
 
-declare -A GROUP_CLEARED
+declare -A GROUP_CLEARED GROUP_CLEARED_DURABLE
 _lookup() {
   # _lookup <args...> -> echoes stdout; sets LOOKUP_RC
   LOOKUP_OUT="$(python3 "$QUERY_SCRIPT" "$@" 2>/dev/null)"
@@ -567,9 +567,19 @@ for (( ci=0; ci<${#IS_SHA[@]}; ci++ )); do
   k_sha="${IS_SHA[$ci]}"
   k_at="${IS_AT[$ci]}"
   k_gid="${SHA_GROUP[$k_sha]}"
-  [ -n "${GROUP_CLEARED[$k_gid]}" ] && continue
+  # A DURABLE clear closes the group's scan: skips.log / a by-commit identity
+  # match settle its persisted counter, and nothing a later member could add
+  # changes that. A group cleared only TRANSIENTLY (by by-files) is NOT closed:
+  # it earned this Stop's allowance but no durable reset, and a sibling may
+  # still hold the by-commit evidence that upgrades the group to a reset. So
+  # the durable doors (skip, by-commit) run for every not-yet-durably-cleared
+  # member, and only the transient by-files doors are gated on the group being
+  # entirely uncleared.
+  [ -n "${GROUP_CLEARED_DURABLE[$k_gid]}" ] && continue
   if [ -n "${SKIP_SET[$k_sha]}" ]; then
+    # skips.log is a PERSISTED, commit-identity-keyed user decision: durable.
     GROUP_CLEARED["$k_gid"]=1
+    GROUP_CLEARED_DURABLE["$k_gid"]=1
     continue
   fi
   # ORDER IS LOAD-BEARING: BOTH PRIMARY (shared-key) lookups run before EITHER
@@ -582,33 +592,53 @@ for (( ci=0; ci<${#IS_SHA[@]}; ci++ )); do
   # FALLBACK therefore leaves the candidate unresolved WITHOUT `continue`ing:
   # the primaries have already answered, and an unbelievable extra opinion must
   # not retract them.
+  # The by-commit lookup resolves a COMMIT IDENTITY in the object store —
+  # branch-independent, so it is monotone across ordinary `git checkout`; only a
+  # rebase that orphans the object stops it. A match is durable evidence.
   _lookup_ok --by-commit "$k_sha" --repo-root "$STORE_REPO_ROOT" "--repo=$SHARED_KEY" \
              --session-root "$SESSION_ROOT" || continue
   if [ -n "$LOOKUP_OUT" ]; then
     GROUP_CLEARED["$k_gid"]=1
+    GROUP_CLEARED_DURABLE["$k_gid"]=1
     continue
   fi
-  _lookup_ok "--by-files=${SHA_FILES[$k_sha]}" --candidate-sha "$k_sha" --candidate-at "$k_at" \
-             --repo-root "$STORE_REPO_ROOT" "--repo=$SHARED_KEY" --session-root "$SESSION_ROOT" || continue
-  if [ -n "$LOOKUP_OUT" ]; then
-    GROUP_CLEARED["$k_gid"]=1
-    continue
+  # The by-files lookup keys on survivors() = os.path.exists in the CURRENT
+  # WORKING TREE (#608). A `git checkout` to a branch where the grudge's files
+  # are absent silently revokes it, so the clearance perspective granted by it
+  # is not monotone. It still clears THIS Stop (the resolution is visible right
+  # now — the t19g/t23dash by-files clearances depend on that), but it must NOT
+  # spend the PERSISTED block counter: a held reset on flippable evidence is
+  # exactly how each false->true->false branch cycle restores full MAX_BLOCKS.
+  if [ -z "${GROUP_CLEARED[$k_gid]}" ]; then
+    _lookup_ok "--by-files=${SHA_FILES[$k_sha]}" --candidate-sha "$k_sha" --candidate-at "$k_at" \
+               --repo-root "$STORE_REPO_ROOT" "--repo=$SHARED_KEY" --session-root "$SESSION_ROOT" || continue
+    if [ -n "$LOOKUP_OUT" ]; then
+      GROUP_CLEARED["$k_gid"]=1
+      continue
+    fi
   fi
   if _worktree_fallback; then
     if _lookup_ok --by-commit "$k_sha" --repo-root "$SESSION_ROOT" "--repo=$WORKTREE_KEY" \
                   --session-root "$SESSION_ROOT" && [ -n "$LOOKUP_OUT" ]; then
       GROUP_CLEARED["$k_gid"]=1
+      GROUP_CLEARED_DURABLE["$k_gid"]=1
       continue
     fi
-    if _lookup_ok "--by-files=${SHA_FILES[$k_sha]}" --candidate-sha "$k_sha" --candidate-at "$k_at" \
-                  --repo-root "$SESSION_ROOT" "--repo=$WORKTREE_KEY" --session-root "$SESSION_ROOT" \
-       && [ -n "$LOOKUP_OUT" ]; then
-      GROUP_CLEARED["$k_gid"]=1
+    if [ -z "${GROUP_CLEARED[$k_gid]}" ]; then
+      if _lookup_ok "--by-files=${SHA_FILES[$k_sha]}" --candidate-sha "$k_sha" --candidate-at "$k_at" \
+                    --repo-root "$SESSION_ROOT" "--repo=$WORKTREE_KEY" --session-root "$SESSION_ROOT" \
+         && [ -n "$LOOKUP_OUT" ]; then
+        GROUP_CLEARED["$k_gid"]=1
+      fi
     fi
   fi
 done
-# Clearance is a pure counter reset: sha_group / sha_files stay persisted.
-for g in "${!GROUP_CLEARED[@]}"; do
+# Clearance is a durable counter reset: sha_group / sha_files stay persisted.
+# Only DURABLE evidence may spend the PERSISTED counter — a skips.log entry or
+# a by-commit identity match are branch-independent. A by-files match keys on
+# the working tree and flips on `git checkout` (#608); it clears THIS Stop but
+# cannot zero a counter whose reset would outlive the evidence.
+for g in "${!GROUP_CLEARED_DURABLE[@]}"; do
   BLOCK_COUNTS["$g"]=0
 done
 

--- a/hooks/grudge-resolution-guard.sh
+++ b/hooks/grudge-resolution-guard.sh
@@ -613,8 +613,15 @@ for (( ci=0; ci<${#IS_SHA[@]}; ci++ )); do
     _lookup_ok "--by-files=${SHA_FILES[$k_sha]}" --candidate-sha "$k_sha" --candidate-at "$k_at" \
                --repo-root "$STORE_REPO_ROOT" "--repo=$SHARED_KEY" --session-root "$SESSION_ROOT" || continue
     if [ -n "$LOOKUP_OUT" ]; then
+      # TRANSIENT, so this candidate is NOT done: `continue`ing here would skip
+      # the worktree by-commit door below for THIS SAME candidate — the
+      # same-member form of the cross-member shadowing the group gating above
+      # fixes. In a linked worktree (the shape _worktree_fallback exists for)
+      # the candidate's own grudge is recorded worktree-keyed WITH a
+      # fixed_in_commit, while some older, unrelated shared-store grudge can
+      # match by files first; jumping to the next candidate would leave the
+      # group transient despite its own durable commit-identity evidence.
       GROUP_CLEARED["$k_gid"]=1
-      continue
     fi
   fi
   if _worktree_fallback; then

--- a/hooks/tests/test-grudge-resolution-guard.sh
+++ b/hooks/tests/test-grudge-resolution-guard.sh
@@ -2464,7 +2464,7 @@ HOOK_ENV=""
 # regain headroom — by-files evidence may clear THIS Stop, never spend the
 # durable bound.
 # ========================================================================
-# contract:group:inv-t29 checks=19
+# contract:group:inv-t29 checks=23
 hook_case t608
 for f in shared.py b.py c.py; do echo "V = 0 # $f" > "$HC_REPO/$f"; done
 commit_all "$HC_REPO" "chore: baseline"
@@ -2546,6 +2546,43 @@ check 382 "the mixed-evidence group clears — contract:group:inv-t29" 0 "$RC"
 check 383 "a durable sibling match still resets the counter — contract:group:inv-t29" 0 \
   "$(st "$HC_REPO" s608b ".block_counts[.sha_group[\"$T608B2\"]]")"
 
+# ...and the SAME-MEMBER form of that shadowing, which the group gating above
+# does not reach. Inside a linked worktree the writers record a candidate's own
+# grudge WORKTREE-keyed (grudge_append.resolve_repo() -> --show-toplevel) with a
+# real fixed_in_commit, so its durable evidence lives behind the worktree
+# by-commit door only. If an older, unrelated SHARED-store grudge matches the
+# same candidate by FILES first, a `continue` on that transient hit jumps to the
+# next candidate and never opens the candidate's own durable door: the group
+# clears this Stop but keeps a non-zero persisted counter despite genuine
+# commit-identity evidence. The transient hit must fall through, not `continue`.
+hook_case t608c
+echo "VALUE = 0" > "$HC_REPO/app.py"; echo "L = 0" > "$HC_REPO/lib.py"
+commit_all "$HC_REPO" "chore: baseline"
+git -C "$HC_REPO" branch wtbr608
+T608C_WT="$HC_ROOT/linked"
+git -C "$HC_REPO" worktree add -q "$T608C_WT" wtbr608
+T608C_WT="$(cd "$T608C_WT" && pwd -P)"
+echo "VALUE = 1" > "$T608C_WT/app.py"; echo "L = 1" > "$T608C_WT/lib.py"
+commit_all "$T608C_WT" "fix(widget): repair from inside the linked worktree"
+T608C_FIX="$(sha_of "$T608C_WT" HEAD)"
+HC_CWD="$T608C_WT"
+run_hook s608c
+check 384 "premise: the worktree candidate blocks with an empty store — contract:group:inv-t29" 2 "$RC"
+check 385 "premise: the block is persisted as 1 — contract:group:inv-t29" 1 \
+  "$(st "$T608C_WT" s608c ".block_counts[.sha_group[\"$T608C_FIX\"]]")"
+# The shadowing grudge: shared-keyed, commit-less, and OLDER — it can only ever
+# match through the primary `--by-files` door, i.e. transiently.
+append_grudge "$HC_STORE" "$HC_KEY" "$HC_REPO" "app and lib regressed" \
+  "app.py,lib.py" "" "2026-03-01" >/dev/null
+# The candidate's OWN durable evidence, recorded the way the writers record it
+# from inside a linked worktree: worktree-keyed, with a fixed_in_commit.
+append_grudge "$HC_STORE" "$(basename "$T608C_WT")" "$T608C_WT" "the widget regressed" \
+  "app.py" "$T608C_FIX" "2026-04-01" >/dev/null
+run_hook s608c true
+check 386 "the shadowed worktree candidate clears — contract:group:inv-t29" 0 "$RC"
+check 387 "a transient by-files hit cannot shadow the SAME member's by-commit evidence — contract:group:inv-t29" 0 \
+  "$(st "$T608C_WT" s608c ".block_counts[.sha_group[\"$T608C_FIX\"]]")"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASSED/$TOTAL passed"
@@ -2558,7 +2595,7 @@ echo "Results: $PASSED/$TOTAL passed"
 # instead of failing. Pin the expected count so the loss is loud: only a root
 # uid may run fewer (the chmod-000 and chmod-500 fixtures, which root bypasses),
 # and even then it is announced.
-EXPECTED_CHECKS=395
+EXPECTED_CHECKS=399
 ROOT_SKIPPED_CHECKS=32
 if [ "$TOTAL" -ne "$EXPECTED_CHECKS" ]; then
   if [ "$(id -u)" -eq 0 ] && [ "$TOTAL" -eq "$((EXPECTED_CHECKS - ROOT_SKIPPED_CHECKS))" ]; then

--- a/hooks/tests/test-grudge-resolution-guard.sh
+++ b/hooks/tests/test-grudge-resolution-guard.sh
@@ -2449,6 +2449,103 @@ check 364 "a zero-padded budget spends nothing and prints no budget note — con
   no "$(has "$ERR" "budget")"
 HOOK_ENV=""
 
+# ========================================================================
+# INV-T29 (#608) — a by-files clearance must not persist a counter reset
+#
+# A clearance zeroes the group's PERSISTED block counter, but the two lookup
+# predicates are NOT monotone w.r.t. the working tree: `--by-files` matches
+# only while survivors() (os.path.exists) still sees the grudge's files, so
+# `git checkout` to a branch without them silently revokes it. The reset it
+# granted, however, stays persisted — each false->true->false branch cycle
+# restores a fresh MAX_BLOCKS and blocking in a session is unbounded (#608).
+# This fence: block a 2-member overlap group to its bound, clear it with a
+# commit-less (by-files-only) grudge while the files exist, remove the member's
+# scan window, then assert a new sibling joining the persisted group does NOT
+# regain headroom — by-files evidence may clear THIS Stop, never spend the
+# durable bound.
+# ========================================================================
+# contract:group:inv-t29 checks=19
+hook_case t608
+for f in shared.py b.py c.py; do echo "V = 0 # $f" > "$HC_REPO/$f"; done
+commit_all "$HC_REPO" "chore: baseline"
+echo "S = 1" > "$HC_REPO/shared.py"; echo "B = 1" > "$HC_REPO/b.py"
+commit_all "$HC_REPO" "fix(b): touch shared and b"
+T608_B="$(sha_of "$HC_REPO" HEAD)"
+echo "S = 2" > "$HC_REPO/shared.py"; echo "C = 1" > "$HC_REPO/c.py"
+commit_all "$HC_REPO" "fix(c): touch shared and c"
+T608_C="$(sha_of "$HC_REPO" HEAD)"
+
+run_hook s608
+check 365 "the overlap pair blocks — contract:group:inv-t29" 2 "$RC"
+check 366 "the overlap pair is one persisted group — contract:group:inv-t29" 1 \
+  "$(st "$HC_REPO" s608 '[.sha_group[]]|unique|length')"
+check 367 "both members share the frozen group id — contract:group:inv-t29" true \
+  "$(st "$HC_REPO" s608 ".sha_group[\"$T608_B\"] == .sha_group[\"$T608_C\"]")"
+run_hook s608 true
+check 368 "the second block reads (2/3) — contract:group:inv-t29" yes "$(has "$ERR" "(2/3)")"
+run_hook s608 true
+check 369 "the third block reads (3/3), the bound — contract:group:inv-t29" yes "$(has "$ERR" "(3/3)")"
+check 370 "the bound is persisted before clearance — contract:group:inv-t29" 3 \
+  "$(st "$HC_REPO" s608 ".block_counts[.sha_group[\"$T608_C\"]]")"
+
+# A commit-less grudge whose file set matches the in-scope member C by FILES
+# ONLY: fixed_in_commit is empty, so `--by-commit` cannot match it and the
+# survivors-relative `--by-files` predicate is the entire clearance.
+append_grudge "$HC_STORE" "$HC_KEY" "$HC_REPO" "shared and c regressed" \
+  "shared.py,c.py" "" "2026-04-01" >/dev/null
+run_hook s608 true
+check 371 "the by-files courtesy allows the Stop — contract:group:inv-t29" 0 "$RC"
+check 372 "it is a real clearance, not the give-up — contract:group:inv-t29" no "$(has "$ERR" "giving up")"
+check 373 "the by-files clearance does NOT zero the persisted bound — contract:group:inv-t29" 3 \
+  "$(st "$HC_REPO" s608 ".block_counts[.sha_group[\"$T608_C\"]]")"
+
+# Remove the member scan window: the grudge's other survivor file leaves the
+# working tree, so survivors() drops to one and the by-files predicate (which
+# needs >=2 survivors, or a fixed_in_commit for the ==1 structural branch) stops
+# matching — exactly what `git checkout` to a branch without those files does.
+git -C "$HC_REPO" rm -q c.py
+echo "S = 3" > "$HC_REPO/shared.py"; echo "D = 1" > "$HC_REPO/d.py"
+commit_all "$HC_REPO" "fix(d): touch shared and d"
+T608_D="$(sha_of "$HC_REPO" HEAD)"
+run_hook s608 true
+check 374 "a sibling joining after the flip re-blocks — contract:group:inv-t29" 2 "$RC"
+check 375 "the sibling reads (3/3), no regained headroom — contract:group:inv-t29" yes "$(has "$ERR" "(3/3)")"
+check 376 "the persisted counter holds the bound — contract:group:inv-t29" 3 \
+  "$(st "$HC_REPO" s608 ".block_counts[.sha_group[\"$T608_D\"]]")"
+run_hook s608 true
+check 377 "the Stop after the re-armed sibling gives up — contract:group:inv-t29" 0 "$RC"
+check 378 "the give-up is announced — contract:group:inv-t29" yes "$(has "$ERR" "giving up")"
+
+# Transient-clear must not SHADOW a sibling's durable evidence: two members of
+# the SAME group on the SAME Stop, the newer one cleared by a commit-less
+# (by-files) grudge and the older one matching a real fixed_in_commit (by-commit).
+# IS_SHA is newest-first, so the by-files hit fires before the by-commit match
+# is ever evaluated — a top-of-loop "already cleared, continue" would then leave
+# the group transient and the durable reset lost. A commit-identity match
+# anywhere in the group IS durable evidence; the counter must still zero.
+hook_case t608b
+for f in shared.py b.py c.py; do echo "V = 0 # $f" > "$HC_REPO/$f"; done
+commit_all "$HC_REPO" "chore: baseline"
+echo "S = 1" > "$HC_REPO/shared.py"; echo "B = 1" > "$HC_REPO/b.py"
+commit_all "$HC_REPO" "fix(b): touch shared and b"
+T608B2="$(sha_of "$HC_REPO" HEAD)"
+echo "S = 2" > "$HC_REPO/shared.py"; echo "C = 1" > "$HC_REPO/c.py"
+commit_all "$HC_REPO" "fix(c): touch shared and c"
+T608C2="$(sha_of "$HC_REPO" HEAD)"
+run_hook s608b
+check 379 "the mixed-evidence pair is one group — contract:group:inv-t29" true \
+  "$(st "$HC_REPO" s608b ".sha_group[\"$T608B2\"] == .sha_group[\"$T608C2\"]")"
+check 380 "the mixed-evidence pair blocks first — contract:group:inv-t29" 2 "$RC"
+check 381 "the mixed-evidence pair reads (1/3) — contract:group:inv-t29" yes "$(has "$ERR" "(1/3)")"
+append_grudge "$HC_STORE" "$HC_KEY" "$HC_REPO" "shared and c regressed" \
+  "shared.py,c.py" "" "2026-04-01" >/dev/null
+append_grudge "$HC_STORE" "$HC_KEY" "$HC_REPO" "shared and b regressed" \
+  "shared.py,b.py" "$T608B2" "2026-04-01" >/dev/null
+run_hook s608b true
+check 382 "the mixed-evidence group clears — contract:group:inv-t29" 0 "$RC"
+check 383 "a durable sibling match still resets the counter — contract:group:inv-t29" 0 \
+  "$(st "$HC_REPO" s608b ".block_counts[.sha_group[\"$T608B2\"]]")"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASSED/$TOTAL passed"
@@ -2461,7 +2558,7 @@ echo "Results: $PASSED/$TOTAL passed"
 # instead of failing. Pin the expected count so the loss is loud: only a root
 # uid may run fewer (the chmod-000 and chmod-500 fixtures, which root bypasses),
 # and even then it is announced.
-EXPECTED_CHECKS=376
+EXPECTED_CHECKS=395
 ROOT_SKIPPED_CHECKS=32
 if [ "$TOTAL" -ne "$EXPECTED_CHECKS" ]; then
   if [ "$(id -u)" -eq 0 ] && [ "$TOTAL" -eq "$((EXPECTED_CHECKS - ROOT_SKIPPED_CHECKS))" ]; then

--- a/scripts/check_contract_tags.py
+++ b/scripts/check_contract_tags.py
@@ -157,6 +157,8 @@ COVERAGE_MAP: dict[str, dict] = {
     "contract:cli:inv-t27": {"kind": "bash", "carriers": [_G], "checks": 7},
     # issue #603: per-Stop wall-clock budget bounds the hook's attacker-chosen inputs
     "contract:hook:inv-t28": {"kind": "bash", "carriers": [_G], "checks": 8},
+    # issue #608: by-files clearance must not spend the persisted block counter
+    "contract:group:inv-t29": {"kind": "bash", "carriers": [_G], "checks": 19},
 }
 del _G
 

--- a/scripts/check_contract_tags.py
+++ b/scripts/check_contract_tags.py
@@ -158,7 +158,7 @@ COVERAGE_MAP: dict[str, dict] = {
     # issue #603: per-Stop wall-clock budget bounds the hook's attacker-chosen inputs
     "contract:hook:inv-t28": {"kind": "bash", "carriers": [_G], "checks": 8},
     # issue #608: by-files clearance must not spend the persisted block counter
-    "contract:group:inv-t29": {"kind": "bash", "carriers": [_G], "checks": 19},
+    "contract:group:inv-t29": {"kind": "bash", "carriers": [_G], "checks": 23},
 }
 del _G
 


### PR DESCRIPTION
Fixes #608 — when a by-files grudge match clears a group, the persisted block counter is no longer reset.

## Why

Group clearance zeroed `BLOCK_COUNTS[$g]` (persisted to the state file) on any matching evidence. But the `--by-files` predicate keys on `survivors()` = `os.path.exists` in the **current working tree** (`scripts/grudge_query.py:137-156`), which a plain `git checkout` to a branch where the grudge's files are absent silently revokes — after the reset already persisted. Each false→true→false branch cycle restored a fresh `MAX_BLOCKS`, so blocks within a session were unbounded:

1. group blocked twice → persisted counter = 2
2. checkout branch where fixed file exists → by-files clearance fires → counter reset 0
3. checkout back → no clearance → group blockable again fresh `MAX_BLOCKS`

## What changed

Clearance now splits into two classes:

- **durable** (skips.log entry, `--by-commit` identity match — both branch-independent): zeroes the persisted counter, as before;
- **transient** (`--by-files`, working-tree file existence): clears **this Stop** (a resolution visible right now must not block) but cannot spend the durable bound.

The clearance loop was restructured so the durable doors (skip / `--by-commit`) run for every not-yet-durably-cleared member, while transient `--by-files` doors are gated on the group being entirely uncleared — a by-files hit on a newer member can no longer shadow an older member's by-commit evidence from upgrading the group to a durable reset.

## Regression fence (inv-t28, 19 checks)

Block a 2-member overlap group to its bound, clear it with a commit-less by-files grudge while the files exist, remove the member scan window (`git rm` the survivor file), then assert a sibling joining the persisted group re-blocks at **(3/3)** and gives up on the next Stop — not a fresh (1/3).

Plus: a mixed-evidence group (newer member by-files, older member by-commit) still gets the durable reset from commit identity.

## Verification

- `bash hooks/tests/test-grudge-resolution-guard.sh`: 387/387 (368/368 before; the 6 new counter-durability checks fail against the old hook)
- `python3 scripts/check_contract_tags.py [--selftest]`: green, inv-t28 pinned
- `bash scripts/run_tests.sh`: all 99 suite invocations pass