### PR TITLE
fix(grudge): #607 preserve backslash in normalize_path on POSIX

### DIFF
--- a/scripts/grudge_append.py
+++ b/scripts/grudge_append.py
@@ -78,10 +78,18 @@ def resolve_repo(start_dir: Optional[str] = None) -> Tuple[str, str]:
 def normalize_path(p: str, repo_root: str) -> str:
     """Normalize a path to repo-relative POSIX form (fix #1): forward-slashes,
     made relative to repo_root when absolute, no leading './', no trailing '/'."""
-    p = p.replace("\\", "/").strip()
+    # #607 (siege S-8): only Windows treats backslash as a path separator. On
+    # POSIX it is a legal filename byte — git stores it verbatim (diff-tree -z),
+    # so rewriting it to '/' stores a DIFFERENT non-existent path, voiding the
+    # grudge; --cull then permanently deletes it. Rewrite only on Windows.
+    _windows = os.name == "nt"
+    p = p.replace("\\", "/") if _windows else p
+    p = p.strip()
     if os.path.isabs(p) or p.startswith(repo_root):
         try:
-            p = os.path.relpath(p, repo_root).replace("\\", "/")
+            p = os.path.relpath(p, repo_root)
+            if _windows:
+                p = p.replace("\\", "/")
         except ValueError:  # different drive on Windows — leave as-is
             pass
     while p.startswith("./"):

--- a/scripts/test_stores.py
+++ b/scripts/test_stores.py
@@ -46,8 +46,15 @@ from scripts import atomic_write as aw  # noqa: E402
 # --------------------------------------------------------------------------- #
 
 class GrudgeNormalizeTest(unittest.TestCase):
-    def test_backslashes_to_posix(self):
-        self.assertEqual(ga.normalize_path("a\\b\\c.py", "/repo"), "a/b/c.py")
+    def test_backslash_handling_is_os_aware(self):
+        if os.name == "nt":
+            # On Windows (separator) backslash must still normalize to '/'.
+            self.assertEqual(ga.normalize_path("a\\b\\c.py", "/repo"), "a/b/c.py")
+        else:
+            # #607 (siege S-8): POSIX backslash is a legal filename byte — git
+            # stores it verbatim. Rewriting it to '/' stores a DIFFERENT path,
+            # voiding the grudge; --cull then deletes it. Must round-trip.
+            self.assertEqual(ga.normalize_path("a\\b\\c.py", "/repo"), "a\\b\\c.py")
 
     def test_absolute_made_repo_relative(self):
         self.assertEqual(ga.normalize_path("/repo/src/a.py", "/repo"), "src/a.py")
@@ -322,6 +329,37 @@ class CullTest(unittest.TestCase):
             self._write(gdir, "g.md", repo_root, ["a.py"])
             self.assertEqual(gq.cull("myrepo", repo_root, base), [])
             self.assertTrue(os.path.exists(os.path.join(gdir, "g.md")))
+
+
+class GrudgeBackslashRoundTripTest(unittest.TestCase):
+    """#607 (siege S-8): a filename containing a backslash (legal on POSIX, git
+    stores it verbatim) must survive append -> query -> cull. normalize_path
+    rewriting `\\` to `/` stored a DIFFERENT, non-existent path -> survivors()
+    went [], the grudge never matched, and --cull permanently DELETED it.
+    Windows-only behavior is covered by the caller-side unit test above."""
+
+    def test_backslash_file_survives_append_query_cull(self):
+        if os.name == "nt":
+            self.skipTest("backslash is the path separator on Windows — n/a")
+        with tempfile.TemporaryDirectory() as repo, \
+                tempfile.TemporaryDirectory() as base:
+            weird = os.path.join(repo, "weird\\name.py")  # one filename, literal backslash
+            open(weird, "w").close()
+            path = ga.append(
+                symptom="retry-logic regression on weird names",
+                files_touched=[weird],  # absolute, as git's diff-tree would give it
+                repo="myrepo", repo_root=repo, base_dir=base,
+            )
+            self.assertIsNotNone(path)
+            self.assertTrue(os.path.exists(path))
+            # pre-flight must match the grudge against the same in-scope file
+            matched, stats = gq.query([weird], "myrepo", repo, base_dir=base)
+            self.assertEqual(stats["matched"], 1,
+                             "grudge failed to match its own backslash-named file")
+            self.assertEqual(stats["skipped_stale"], 0)
+            # cull must not treat the still-existing file as gone
+            self.assertEqual(gq.cull("myrepo", repo, base), [])
+            self.assertTrue(os.path.exists(path))
 
 
 class RenderBlockTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #607 (siege S-8).

## Mechanism
`scripts/grudge_append.py:78` — `normalize_path` unconditionally rewrote `\` to `/`. On POSIX a backslash is a **legal filename byte** that git stores verbatim (`diff-tree -z`), so the rewrite stored a DIFFERENT, non-existent path.

## Consequence chain
1. grudge stored path does not exist on disk.
2. `survivors()` (`grudge_query.py:137`) returns `[]` forever — grudge matches nothing.
3. candidate never clears → pre-flight reports `matched=0 skipped_stale=1`.
4. documented `--cull` housekeeping **permanently deletes** the record.

Attacker-chosen, permanent destruction of the regression oracle.

## Fix
Make the `\`→`/` rewrite OS-aware: rewrite only on Windows, where backslash IS the path separator; preserve backslashes verbatim on POSIX. Both write-side (`append`) and read-side (`query`) call the same `normalize_path`, so normalization stays consistent.

## Tests
- Unit: `test_backslash_handling_is_os_aware` — platform-conditional backslash expectation (replaces the old unconditional-rewrite test that encoded the buggy behavior).
- Integration: `GrudgeBackslashRoundTripTest` — end-to-end append → query → cull round-trip with a real file literally named with a backslash; asserts it matches (`matched=1`) and is never culled.

`bash scripts/run_tests.sh` — all 95 suite invocations passed.