### PR TITLE
fix(security): #604 — close tracked app-config exec surface (siege S-1)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ These settings are specific to Claude Code. Other platforms have equivalent conf
 
 ## Session Activity Index (hooks)
 
-Crucible includes PostToolUse hooks (`hooks/session-index.sh`, `hooks/session-summary.sh`) that log session events for compaction recovery and the `/recall` skill. To enable, add to your `.claude/settings.json`:
+Crucible includes PostToolUse hooks (`hooks/session-index.sh`, `hooks/session-summary.sh`) that log session events for compaction recovery and the `/recall` skill. To enable, add to your **untracked** `.claude/settings.local.json` (or user-global `~/.claude/settings.json`):
 
 ```json
 {
@@ -31,7 +31,7 @@ See `hooks/README.md` for details on storage layout, the outbox pattern, and hoo
 
 ## Build Routing Advisor (hooks)
 
-Optional PreToolUse hook (`hooks/build-routing-advisor.sh`) that warns — without blocking — when a raw-agent dispatch looks like it should have gone through `/build`, `/spec`, `/debugging`, or `/migrate`. Warn-only and tier-aware (matches Claude Code's skill-trigger vocabulary). Enable via `.claude/settings.json` with a `PreToolUse` matcher on `Agent`. The post-merge reconciler (`hooks/tests/tools/build-routing-reconcile.sh`) provides a read-only audit of dispatches in recent session index data.
+Optional PreToolUse hook (`hooks/build-routing-advisor.sh`) that warns — without blocking — when a raw-agent dispatch looks like it should have gone through `/build`, `/spec`, `/debugging`, or `/migrate`. Warn-only and tier-aware (matches Claude Code's skill-trigger vocabulary). Enable via **untracked** `.claude/settings.local.json` or user-global `~/.claude/settings.json` with a `PreToolUse` matcher on `Agent`. The post-merge reconciler (`hooks/tests/tools/build-routing-reconcile.sh`) provides a read-only audit of dispatches in recent session index data. Per GH-604 (`hooks/README.md` → Hook Registration Surface), never commit a `.claude/settings.json` that registers hooks — it turns every branch checkout into an execution surface.
 
 ## External Model Review (MCP)
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -373,3 +373,33 @@ bash hooks/tests/test-rcpt-verify-hook.sh
 
 `jq` and `python3` — both absent-tolerant (the hook exits 0 silently when either is
 missing). No `git` dependency beyond the optional repo-root resolution (absent → exit 0).
+
+## Hook Registration Surface (#604)
+
+Repo-owned hooks (`hooks/*.sh`) are registered in **per-machine, untracked config** —
+never in a committed `.claude/settings.json`. A committed `settings.json` that
+registers an executable hook turns every PR checkout into an arbitrary-code
+execution surface on the reviewer's machine (GH-604, siege S-1): Claude Code's
+directory trust is per-directory, so checking out a branch inside an
+already-`/trust`ed repo does not re-prompt, and a reviewer's `gh pr checkout N`
+runs the branch's hook (and whatever `scripts/` helper it names) with the
+reviewer's full privileges on the next Stop.
+
+The two legal registration points are `.claude/settings.local.json`
+(machine-local, untracked — the whole `.claude/` directory is git-ignored, and
+`scripts/check_settings_surface.py` fails the gate if any of it is re-tracked)
+and user-global `~/.claude/settings.json` (the `gate-ledger-guard` /
+`build-routing-advisor` convention). Both make the hook's execution surface
+opt-in per machine rather than automatic per clone. A registration command must
+reference the hook by its **absolute installed path** (or `$CLAUDE_PROJECT_DIR`);
+the machine that installed it is the machine that accepts the surfaced code.
+
+Review rule: every PR touching a `hooks/` or `scripts/` diff gets full review
+before merge — those files execute with the maintainer's privileges.
+
+### Testing
+
+```bash
+python3 scripts/check_settings_surface.py --selftest
+python3 scripts/check_settings_surface.py
+```

--- a/scripts/check_settings_surface.py
+++ b/scripts/check_settings_surface.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Structural check: no tracked app-config may register executable hooks (#604).
+
+Invocation (from repo root):
+    python3 scripts/check_settings_surface.py            # gate the real repo
+    python3 scripts/check_settings_surface.py --selftest # fixture-driven logic test
+
+GH-604 (siege S-1): a committed `.claude/settings.json` that registers a hook by
+path turns every PR checkout into an arbitrary-code execution surface on the
+reviewer's machine. `.claude/settings.json:6` was force-added past `.gitignore`
+(#559), registering a blocking Stop hook whose body (`hooks/grudge-resolution-guard.sh`)
+and helper (`scripts/grudge_query.py`) live in the SAME tracked tree — so a
+contributor touching any of those files runs their code with the maintainer's
+full privileges the moment the maintainer runs `gh pr checkout N` and ends a
+turn. Claude Code's directory-trust prompt does not help: it is per-directory,
+so checking out a branch inside an already-`/trust`ed repo does not re-prompt.
+Verified: a contributor-modified helper created a marker file in `$HOME` from the
+hook's argv on an ordinary Stop. The `/.claude/` git-ignore being blanket means
+the ONLY legal registration points for a repo-owned hook are per-machine and
+untracked: `.claude/settings.local.json` or user-global `~/.claude/settings.json`
+(the `gate-ledger-guard` / `build-routing-advisor` convention). This check pins
+the surface closed:
+
+  1. `.claude/settings.json` (and any other tracked file under `.claude/`) is
+     NOT git-tracked — `git ls-files` must list nothing under `.claude/`.
+  2. `.gitignore` carries the blanket `.claude/` ignore and no `!`-negation that
+     re-includes any part of `.claude/` (the #559 prologue added exactly such a
+     negation to re-track the settings file; both must be absent).
+  3. `hooks/README.md` carries the "Hook Registration Surface" contract — the
+     two per-machine registration points, the prohibition on registering
+     executable hooks in committed config, and the hooks/scripts diff review
+     rule.
+
+Style mirrors `scripts/check_handoff_stop_contract.py`: ROOT-from-`__file__`,
+error accumulation, `sys.exit(main())`, stdlib only, no argparse. The selftest
+drives the SAME check functions against throwaway fixtures (real `git init`ed
+trees for the tracking assertions) covering the PASS and FAIL shape of every
+assertion — including the git-unavailable fail-closed branch — so an enforcement
+branch cannot be mutated into a no-op without the suite noticing. Selftest
+failures raise; they are never returned.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SETTINGS_REL = ".claude/settings.json"
+
+# Contract the Hook Registration Surface section of hooks/README.md must carry.
+README_CONTRACT: dict[str, str] = {
+    "machine-local registration point": "settings.local.json",
+    "user-global registration point": "~/.claude/settings.json",
+    "committed-config prohibition": "never in a committed `.claude/settings.json`",
+    "hooks/scripts diff review rule": "a `hooks/` or `scripts/` diff",
+}
+
+_SECTION_RE = re.compile(
+    r"^## Hook Registration Surface\b.*?(?=^## |\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def extract_surface_section(text: str) -> str:
+    matches = _SECTION_RE.findall(text)
+    return matches[-1] if matches else ""
+
+
+def tracked_under_claude(root: pathlib.Path) -> list[str] | None:
+    """Tracked paths under `.claude/` at any depth (or None if unverifiable)."""
+    # Two pathspecs: root `.claude/` and any-depth `**/.claude/**` — the blanket
+    # gitignore rule matches at every depth, so the tracking assertion must too.
+    pathspecs = [".claude/", ":(glob)**/.claude/**"]
+    tracked: set[str] = set()
+    for ps in pathspecs:
+        try:
+            out = subprocess.run(
+                ["git", "-C", str(root), "ls-files", "--", ps],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return None
+        if out.returncode != 0:
+            return None
+        tracked.update(p.strip() for p in out.stdout.splitlines() if p.strip())
+    return sorted(tracked)
+
+
+def check_tracking(root: pathlib.Path) -> list[str]:
+    tracked = tracked_under_claude(root)
+    if tracked is None:
+        return [
+            "could not verify git tracking of `.claude/` (git ls-files failed) — "
+            "gate cannot confirm no tracked app-config; treat as FAILED"
+        ]
+    if not tracked:
+        return []
+    critical = [p for p in tracked if p == SETTINGS_REL]
+    lines = []
+    if critical:
+        lines.append(
+            f"execution surface: `{SETTINGS_REL}` is git-TRACKED; a committed "
+            "app-config registering hooks runs contributor code on the reviewer's "
+            "machine at Stop (GH-604). Register hooks in untracked "
+            "settings.local.json / ~/.claude/settings.json, and git rm this file."
+        )
+    rest = [p for p in tracked if p != SETTINGS_REL]
+    if rest:
+        lines.append(
+            "tracked file(s) under `.claude/` (machine-local session state, "
+            "public repo): " + ", ".join(f"`{p}`" for p in rest)
+        )
+    return lines
+
+
+def check_gitignore(root: pathlib.Path) -> list[str]:
+    gi = root / ".gitignore"
+    if not gi.is_file():
+        return ["`.gitignore` missing"]
+    lines = gi.read_text(encoding="utf-8").splitlines()
+    errors = []
+    if not any(l.strip() == ".claude/" for l in lines):
+        errors.append("`.gitignore` lacks the blanket `.claude/` ignore line")
+    for l in lines:
+        s = l.strip()
+        body = s[1:] if s.startswith("!") else ""
+        body = body.lstrip("/")
+        if body == ".claude" or body.startswith(".claude/") or body.startswith("**/.claude"):
+            errors.append(
+                f"`.gitignore` carries a `!`-negation re-including `.claude/` "
+                f"(`{l}`) — that is how #559 re-tracked the settings file; remove it"
+            )
+    return errors
+
+
+def check_readme_contract(root: pathlib.Path) -> list[str]:
+    readme = root / "hooks/README.md"
+    if not readme.is_file():
+        return ["`hooks/README.md` missing"]
+    section = extract_surface_section(readme.read_text(encoding="utf-8"))
+    if not section:
+        return ["no `## Hook Registration Surface` section in hooks/README.md"]
+    return [
+        f"missing {label} in Hook Registration Surface section: `{sub}`"
+        for label, sub in README_CONTRACT.items()
+        if sub not in section
+    ]
+
+
+# --------------------------------------------------------------------------
+# selftest — throwaway fixtures, never the real repo
+# --------------------------------------------------------------------------
+def _git_init(path: pathlib.Path) -> None:
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "selftest@example.invalid"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "selftest"],
+        check=True,
+    )
+
+
+def _write_gitignore(path: pathlib.Path, content: str) -> None:
+    (path / ".gitignore").write_text(content, encoding="utf-8")
+
+
+def selftest() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = pathlib.Path(td)
+
+        # -- tracking assertions (real git trees) -------------------------
+        good = tmp / "good"
+        good.mkdir()
+        _git_init(good)
+        _write_gitignore(good, ".claude/\nnode_modules/\n")
+        (good / "x.txt").write_text("hi", encoding="utf-8")
+        subprocess.run(["git", "-C", str(good), "add", "-A"], check=True)
+        subprocess.run(
+            ["git", "-C", str(good), "commit", "-qm", "init"], check=True
+        )
+        assert check_tracking(good) == [], f"clean tree should pass, got: {check_tracking(good)}"
+
+        evil = tmp / "evil"
+        evil.mkdir()
+        _git_init(evil)
+        _write_gitignore(evil, ".claude/\n")
+        settings = evil / SETTINGS_REL
+        settings.parent.mkdir()
+        settings.write_text(
+            '{"hooks":{"Stop":[{"hooks":[{"type":"command",'
+            '"command":"bash $CLAUDE_PROJECT_DIR/hooks/x.sh"}]}]}}',
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "-C", str(evil), "add", "-f", SETTINGS_REL], check=True)
+        subprocess.run(
+            ["git", "-C", str(evil), "commit", "-qm", "tracked settings"], check=True
+        )
+        errs = check_tracking(evil)
+        assert any(SETTINGS_REL in e for e in errs), (
+            f"tracked settings.json must be flagged, got: {errs}")
+
+        nested = tmp / "nested"
+        nested.mkdir()
+        _git_init(nested)
+        _write_gitignore(nested, ".claude/\n")
+        (nested / ".claude").mkdir()
+        (nested / ".claude/scratch.log").write_text("x", encoding="utf-8")
+        subprocess.run(["git", "-C", str(nested), "add", "-f", ".claude/scratch.log"], check=True)
+        subprocess.run(
+            ["git", "-C", str(nested), "commit", "-qm", "nested"], check=True
+        )
+        errs = check_tracking(nested)
+        assert any("scratch.log" in e for e in errs), (
+            f"tracked non-settings .claude file must be flagged, got: {errs}")
+
+        deep = tmp / "deep"
+        deep.mkdir()
+        _git_init(deep)
+        _write_gitignore(deep, ".claude/\n")
+        deep_settings = deep / "skills/foo/.claude/settings.json"
+        deep_settings.parent.mkdir(parents=True)
+        deep_settings.write_text('{"hooks":{}}', encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(deep), "add", "-f", "skills/foo/.claude/settings.json"],
+            check=True)
+        subprocess.run(
+            ["git", "-C", str(deep), "commit", "-qm", "deep"], check=True
+        )
+        errs = check_tracking(deep)
+        assert any("settings.json" in e for e in errs), (
+            f"any-depth tracked .claude/settings.json must be flagged, got: {errs}")
+
+        nogit = tmp / "nogit"
+        nogit.mkdir()
+        (nogit / ".claude").mkdir(parents=True)
+        (nogit / SETTINGS_REL).write_text('{"hooks":{}}', encoding="utf-8")
+        errs = check_tracking(nogit)
+        assert any("could not verify" in e for e in errs), (
+            f"git-unavailable tree must fail closed, got: {errs}")
+
+        # -- gitignore assertions -----------------------------------------
+        assert check_gitignore(good) == [], f"good gitignore should pass, got: {check_gitignore(good)}"
+        no_ignore = tmp / "no_ignore"
+        no_ignore.mkdir()
+        (no_ignore / ".gitignore").write_text("node_modules/\n", encoding="utf-8")
+        errs = check_gitignore(no_ignore)
+        assert any(".claude/" in e for e in errs), f"missing .claude/ ignore must flag, got: {errs}"
+
+        reinclude = tmp / "reinclude"
+        reinclude.mkdir()
+        (reinclude / ".gitignore").write_text(
+            ".claude/*\n!.claude/settings.json\n", encoding="utf-8"
+        )
+        errs = check_gitignore(reinclude)
+        assert any("!" in e for e in errs), f"re-inclusion negation must flag, got: {errs}"
+
+        # -- README contract assertions -----------------------------------
+        good_readme = (
+            "## Hook Registration Surface\n\n"
+            "Repo hooks register in per-machine config, never in a committed "
+            "`.claude/settings.json`: `.claude/settings.local.json` "
+            "(untracked) or user-global `~/.claude/settings.json`. Every PR "
+            "touching a `hooks/` or `scripts/` diff gets full review.\n\n"
+            "## Other\n"
+        )
+        # exercise against a fake hooks/README.md file
+        fake_root = tmp / "fake"
+        fake_root.mkdir()
+        (fake_root / "hooks").mkdir(parents=True)
+        (fake_root / "hooks/README.md").write_text(good_readme, encoding="utf-8")
+        assert check_readme_contract(fake_root) == [], (
+            f"contract-complete README should pass, got: {check_readme_contract(fake_root)}")
+
+        for label, sub in README_CONTRACT.items():
+            bad = good_readme.replace(sub, "‹removed›")
+            (fake_root / "hooks/README.md").write_text(bad, encoding="utf-8")
+            errs = check_readme_contract(fake_root)
+            assert any(label in e for e in errs), (
+                f"removing {label!r} (`{sub}`) should flag it, got: {errs}")
+            (fake_root / "hooks/README.md").write_text(good_readme, encoding="utf-8")
+
+        missing_section = "# Only One Heading\n\nno surface section\n"
+        (fake_root / "hooks/README.md").write_text(missing_section, encoding="utf-8")
+        errs = check_readme_contract(fake_root)
+        assert any("section" in e for e in errs), (
+            f"missing section heading should flag it, got: {errs}")
+
+    print("selftest OK — tracking (root + any-depth tracked `.claude/` incl. settings.json, "
+          "nested `.claude/` file, git-unavailable fail-closed), gitignore (missing ignore, "
+          "re-inclusion negation), and README contract (per-token RED + section-missing) all "
+          "covered with PASS and FAIL fixtures.")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--selftest":
+        return selftest()
+
+    errs: list[str] = []
+    errs += ["[tracking] " + e for e in check_tracking(ROOT)]
+    errs += ["[gitignore] " + e for e in check_gitignore(ROOT)]
+    errs += ["[readme] " + e for e in check_readme_contract(ROOT)]
+
+    if errs:
+        print("SETTINGS EXECUTION SURFACE CHECK FAILED (#604):")
+        for e in errs:
+            print(f"  - {e}")
+        return 1
+    print("OK — no tracked `.claude/` app-config; .gitignore and hooks/README carry "
+          "the per-machine registration contract.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -104,6 +104,10 @@ run python3 scripts/check_dispatch_graphify_consult.py
 run python3 scripts/check_handoff_stop_contract.py --selftest
 run python3 scripts/check_handoff_stop_contract.py
 
+# --- tracked-app-config execution surface (#604, siege S-1) ---
+run python3 scripts/check_settings_surface.py --selftest
+run python3 scripts/check_settings_surface.py
+
 # --- warden structural checks (#464) ---
 run python3 scripts/check_warden_structure.py --selftest
 run python3 scripts/check_warden_structure.py


### PR DESCRIPTION
## What

Closes #604. A committed `.claude/settings.json` registering a Stop hook by path (introduced on the #559 branch) made every checked-out branch an arbitrary-code execution surface on the reviewer's machine. Verified in #604: a contributor-modified `grudge_query.py` in a reconstructed checkout created a file in $HOME carrying the hook's argv on an ordinary Stop — no paste, no backtick, no attacker-named file. Claude Code's per-directory trust does not re-prompt for a branch checked out inside an already-trusted repo, so `gh pr checkout N` runs the contributor's hook with the maintainer's privileges.

## Fix

Hook registration moves to per-machine untracked config; the surface is pinned closed structurally:

- **`scripts/check_settings_surface.py`** (new, stdlib-only, mirrors repo check pattern): fails the gate if
  1. any path under `.claude/` is git-tracked (root `.claude/` and any-depth `**/.claude/**`), especially `.claude/settings.json`,
  2. `.gitignore` loses the blanket `.claude/` ignore or carries a `!`-negation re-including `.claude/` (the #559 prologue did exactly this to re-track the file),
  3. `hooks/README.md` lacks the registration-surface contract (per-machine registration points + committed-config prohibition + hooks/scripts review rule).
  Selftest covers PASS/FAIL for every assertion against real git-init'd trees, including the git-unavailable **fail-closed** branch.
- **`hooks/README.md`**: new "Hook Registration Surface (#604)" section — the only legal registration points are untracked `.claude/settings.local.json` or user-global `~/.claude/settings.json` (the existing gate-ledger-guard/build-routing-advisor convention); commits to `.claude/settings.json` are prohibited; every PR touching a `hooks/` or `scripts/` diff gets full review.
- **`docs/configuration.md`**: aligned the hook-enable guidance that seeded #559 (it pointed at `.claude/settings.json`).
- **`scripts/run_tests.sh`**: wired check (selftest + real gate) into the canonical suite — CI and local run it atomically.

## Verification

- `bash scripts/run_tests.sh` — all 97 suite invocations pass.
- Check selftest + real gate pass; RED confirmed first (missing README contract) per TDD.

## Note for #559

When the grudge-resolution-guard hook lands (#559), its `.claude/settings.json` must be dropped and `scripts/check_claude_settings.py` inverted to assert NOT-tracked; the guard registers via `.claude/settings.local.json` / user-global per this contract. This branch's gate makes the old tracked-registration approach CI-red.