### PR TITLE
fix(hooks): #591 register gate-ledger-guard via plugin manifest + restore #614-truncated plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,5 +21,19 @@
     "adversarial-testing",
     "eval-tested"
   ],
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-ledger-guard.sh\"",
+            "timeout": 500
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -79,7 +79,9 @@ External enforcement hook for the build pipeline's gate ledger. Blocks unauthori
 
 ### Setup
 
-Add the following to your `.claude/settings.json` (project-level) or `~/.claude/settings.json` (user-level):
+**Installed automatically** when the crucible plugin is enabled — `.claude-plugin/plugin.json` registers this hook on the `PreToolUse` event (matcher `Write|Edit`) via `${CLAUDE_PLUGIN_ROOT}`, so no manual configuration is needed. See the MIN-5-R6 Parity Note below for details.
+
+For a non-plugin install (running this hook standalone), add the following to your `.claude/settings.local.json` (machine-local, untracked) or `~/.claude/settings.json` (user-level) — never a committed `.claude/settings.json` (see Hook Registration Surface below):
 
 ```json
 {
@@ -88,7 +90,7 @@ Add the following to your `.claude/settings.json` (project-level) or `~/.claude/
       {
         "matcher": "*",
         "hooks": [
-          { "type": "command", "command": "bash hooks/gate-ledger-guard.sh", "timeout": 500 }
+          { "type": "command", "command": "bash /absolute/path/to/crucible/hooks/gate-ledger-guard.sh", "timeout": 500 }
         ]
       }
     ]
@@ -96,7 +98,7 @@ Add the following to your `.claude/settings.json` (project-level) or `~/.claude/
 }
 ```
 
-> **Note:** `"matcher": "*"` — the hook intercepts all PreToolUse events and filters internally for Write and Edit tool calls. This ensures both tools are gated. (You may narrow to `"matcher": "Write|Edit"` to let Claude Code filter upstream; the hook's internal target-path check makes either choice safe.) The maintainer's actual user-global registration uses `Write|Edit` (see the MIN-5-R6 Parity Note below); the `*` shown here is simply the simplest illustrative form.
+> **Note:** `"matcher": "*"` — the hook intercepts all PreToolUse events and filters internally for Write and Edit tool calls. This ensures both tools are gated. (You may narrow to `"matcher": "Write|Edit"` to let Claude Code filter upstream; the hook's internal target-path check makes either choice safe.) For the manual path, use an absolute path (S1/CHAIN-N5: a repo-relative path is cwd-dependent).
 
 ### Verification
 
@@ -126,7 +128,9 @@ Run the test suite:
 bash hooks/tests/test-gate-ledger-guard.sh
 ```
 
-17 test cases covering: non-ledger writes, non-PASS writes, valid markers, missing markers, PipelineID mismatch, missing jq, missing directories, malformed JSON, COMPLETE writes, wrong-phase markers, Phase 3 PASS blocking, first-run bypass, INFERRED-to-PASS promotion, Edit tool PASS introduction, trailing-space PASS, missing PipelineID, and PipelineID change detection.
+26 test cases covering: non-ledger writes, non-PASS writes, valid markers, missing markers, PipelineID mismatch, missing jq, missing directories, malformed JSON, COMPLETE writes, wrong-phase markers, Phase 3 PASS blocking, first-run bypass, INFERRED-to-PASS promotion, Edit tool PASS introduction, trailing-space PASS, missing PipelineID, PipelineID change detection, legacy `.tool`/`.input` fallback (Write and Edit paths), indented old_string, backslash old_string, and double-space phase headers.
+
+`bash hooks/tests/test-plugin-manifest-hooks.sh` separately checks that `.claude-plugin/plugin.json` actually declares the `PreToolUse` registration described above (matcher, `type: command`, `${CLAUDE_PLUGIN_ROOT}` path) — a wiring check, not a runtime liveness check (#591 item 3).
 
 ### Dependencies
 
@@ -134,7 +138,7 @@ bash hooks/tests/test-gate-ledger-guard.sh
 
 ### MIN-5-R6 Parity Note
 
-Registered in user-global `~/.claude/settings.json`. Matcher: `Write|Edit` (verified by reading `~/.claude/settings.json` on 2026-04-15). Because a concrete matcher is set, Claude Code filters upstream and only Write/Edit PreToolUse events reach the hook — no internal filtering is needed for other tool families. The hook still internally filters by target path (`build-gate-ledger.md`) and exits 0 for every other file. By contrast, `build-routing-advisor` registers `matcher: "Agent"` (canonical per T1; legacy alias `"Task"` also honored) in the SAME user-global `~/.claude/settings.json`. Both hooks share scope (user-global, not `.claude/settings.json` at the repo root) and are documented side-by-side so the matcher choices are explicit for parity.
+Registered via the plugin, not via manual settings.json (#591). This section previously claimed the hook was "Registered in user-global `~/.claude/settings.json`. Matcher: `Write|Edit` (verified ... on 2026-04-15)" — that was never true; no settings.json ever installed this hook, which is why it sat inert. The durable fact is that `.claude-plugin/plugin.json` declares a `PreToolUse` hook for this script (matcher `Write|Edit`, command `bash "${CLAUDE_PLUGIN_ROOT}/hooks/gate-ledger-guard.sh"`) (#591 item 3), so enabling the plugin installs it automatically. The manual `~/.claude/settings.json` / `.claude/settings.local.json` registration shown in the Setup section above is a fallback for non-plugin installs — redundant, not required, once the plugin is enabled. Whether a given reader's own settings.json additionally declares a redundant `PreToolUse` entry for this script is machine-local and can drift between developers — check your own files rather than trusting a hook inventory recorded here. `build-routing-advisor` (below) remains in the state this hook used to be in: it is NOT registered via the plugin, and its Setup section is a manual-registration instruction, not a description of an existing registration.
 
 ## Build Routing Advisor
 
@@ -385,17 +389,27 @@ already-`/trust`ed repo does not re-prompt, and a reviewer's `gh pr checkout N`
 runs the branch's hook (and whatever `scripts/` helper it names) with the
 reviewer's full privileges on the next Stop.
 
-The two legal registration points are `.claude/settings.local.json`
+The per-machine settings registration points are `.claude/settings.local.json`
 (machine-local, untracked — the whole `.claude/` directory is git-ignored, and
 `scripts/check_settings_surface.py` fails the gate if any of it is re-tracked)
-and user-global `~/.claude/settings.json` (the `gate-ledger-guard` /
-`build-routing-advisor` convention). Both make the hook's execution surface
-opt-in per machine rather than automatic per clone. A registration command must
-reference the hook by its **absolute installed path** (or `$CLAUDE_PROJECT_DIR`);
-the machine that installed it is the machine that accepts the surfaced code.
+and user-global `~/.claude/settings.json` (the `build-routing-advisor`
+convention). Both make the hook's execution surface opt-in per machine rather
+than automatic per clone. A registration command must reference the hook by its
+**absolute installed path** (or `$CLAUDE_PROJECT_DIR`); the machine that
+installed it is the machine that accepts the surfaced code.
 
-Review rule: every PR touching a `hooks/` or `scripts/` diff gets full review
-before merge — those files execute with the maintainer's privileges.
+A third, distinct mechanism is the plugin manifest: `.claude-plugin/plugin.json`
+may declare a `hooks.PreToolUse` entry (as `gate-ledger-guard` now does, #591),
+which fires only after the user explicitly enables the crucible plugin on their
+machine. This is per-machine opt-in exactly like the settings points — enabling
+a plugin is an affirmative execute-code grant, not a checkout side-effect — so
+it does not create the GH-604 surface. The prohibition above targets committed
+`.claude/settings.json`, which auto-loads on checkout without fresh consent.
+
+Review rule: every PR touching a `hooks/` or `scripts/` diff (or
+`.claude-plugin/plugin.json`, which carries hook-execution config — command,
+matcher, timeout) gets full review before merge — those files execute with the
+maintainer's privileges.
 
 ### Testing
 

--- a/hooks/gate-ledger-guard.sh
+++ b/hooks/gate-ledger-guard.sh
@@ -6,8 +6,11 @@
 # (legacy .tool/.input fallback accepted — see build-routing-advisor.sh's T1 finding)
 # Exit 0 = allow, non-zero = block (reason on stderr).
 #
-# Configured in ~/.claude/settings.json with an ABSOLUTE path (S1/CHAIN-N5, PR
-# #583 warden gate: a relative path here is cwd-dependent):
+# Registered via .claude-plugin/plugin.json's "hooks" key (#591 item 3) — this
+# installs the hook automatically when the crucible plugin is enabled;
+# ${CLAUDE_PLUGIN_ROOT} keeps the invoked path absolute regardless of cwd.
+# For non-plugin installs, see hooks/README.md — register per-machine
+# (S1/CHAIN-N5, PR #583 warden gate: use an ABSOLUTE path, never repo-relative):
 #   "hooks": { "PreToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "bash /absolute/path/to/crucible/hooks/gate-ledger-guard.sh", "timeout": 500 }] }] }
 
 # Disable errexit — this hook must never fail fatally

--- a/hooks/tests/test-gate-ledger-guard.sh
+++ b/hooks/tests/test-gate-ledger-guard.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # hooks/tests/test-gate-ledger-guard.sh
 # Test suite for the gate-ledger-guard.sh PreToolUse hook.
-# Runs 17 test cases validating allow/block behavior.
+# Runs 26 test cases validating allow/block behavior.
 
 set -euo pipefail
 
@@ -10,7 +10,7 @@ HOOK="$SCRIPT_DIR/../gate-ledger-guard.sh"
 
 PASSED=0
 FAILED=0
-TOTAL=25
+TOTAL=26
 
 # ── Setup temp directory ────────────────────────────────────────────────
 TMPDIR_BASE="$(mktemp -d)"
@@ -105,6 +105,15 @@ make_legacy_json() {
   local file_path="$1"
   local content="$2"
   jq -nc --arg fp "$file_path" --arg c "$content" '{"tool":"Write","input":{"file_path":$fp,"content":$c}}'
+}
+
+# ── Helper: build LEGACY-shape Edit JSON (.tool/.input) ─────────────────
+make_legacy_edit_json() {
+  local file_path="$1"
+  local old_string="$2"
+  local new_string="$3"
+  jq -nc --arg fp "$file_path" --arg os "$old_string" --arg ns "$new_string" \
+    '{"tool":"Edit","input":{"file_path":$fp,"old_string":$os,"new_string":$ns}}'
 }
 
 # ── Helper: create verdict marker ──────────────────────────────────────
@@ -587,10 +596,32 @@ JSON="$(make_json "$LEDGER_PATH" "$DOUBLE_SPACE_CONTENT")"
 set +e; run_hook "$JSON" 2>/dev/null; RC=$?; set -e
 check 25 "R2BA-3: double-space phase header PASS-introducing write blocked" 2 "$RC"
 
+# ========================================================================
+# Test 26: LEGACY-shape (.tool/.input) Edit introducing a PASS, no verdict
+# marker — blocked (exit 2). Exercises the Edit-path legacy fallback
+# (EDIT_OLD/EDIT_NEW via .tool_input.old_string // .input.old_string and
+# .tool_input.new_string // .input.new_string), which test 22 (Write-path
+# legacy fallback only) does not cover. Genuine discriminating power: with
+# the .input fallback removed, a legacy-shape Edit payload resolves
+# EDIT_NEW empty, the hook takes the "exit 0" early-return, and this test
+# fails.
+# ========================================================================
+reset_state
+EXISTING="$(make_ledger "build-test-026" "IN_PROGRESS" "NOT_STARTED" "NOT_STARTED" "NOT_STARTED")"
+echo "$EXISTING" > "$LEDGER_PATH"
+mkdir -p "$VERDICT_DIR"
+JSON="$(make_legacy_edit_json "$LEDGER_PATH" "Status: IN_PROGRESS" "Status: PASS")"
+set +e; run_hook "$JSON" 2>/dev/null; RC=$?; set -e
+check 26 "Legacy .tool/.input Edit PASS introduction blocked" 2 "$RC"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASSED/$TOTAL passed"
 
+if [ "$((PASSED + FAILED))" -ne "$TOTAL" ]; then
+  echo "FATAL: $((PASSED + FAILED)) tests recorded a result (PASSED=$PASSED, FAILED=$FAILED) but TOTAL=$TOTAL — a test silently did not run." >&2
+  exit 1
+fi
 if [ "$FAILED" -gt 0 ]; then
   exit 1
 fi

--- a/hooks/tests/test-plugin-manifest-hooks.sh
+++ b/hooks/tests/test-plugin-manifest-hooks.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# hooks/tests/test-plugin-manifest-hooks.sh
+# Structural check (#591 item 3): .claude-plugin/plugin.json actually declares
+# a PreToolUse registration for gate-ledger-guard.sh, so the plugin install
+# path is real rather than just documented. This is a WIRING check — it does
+# NOT assert the hook fires at runtime (that's #591 item 4 / #585's scope).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MANIFEST="$REPO_ROOT/.claude-plugin/plugin.json"
+
+PASSED=0
+FAILED=0
+TOTAL=5
+
+check() {
+  local test_num="$1" test_name="$2" expected="$3" actual="$4"
+  if [ "$actual" = "$expected" ]; then
+    echo "Test $test_num: $test_name... PASS"
+    PASSED=$((PASSED + 1))
+  else
+    echo "Test $test_num: $test_name... FAIL (expected '$expected', got '$actual')"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# Test 1: manifest is valid JSON with a hooks.PreToolUse array
+VALID_JSON="$(jq -re '.hooks.PreToolUse | type' "$MANIFEST" 2>/dev/null || echo "invalid")"
+check 1 "plugin.json has hooks.PreToolUse array" "array" "$VALID_JSON"
+
+# Test 2: some PreToolUse entry's command references gate-ledger-guard.sh
+HAS_GUARD_ENTRY="$(jq -e '[.hooks.PreToolUse[].hooks[]?.command // empty | select(contains("gate-ledger-guard.sh"))] | length > 0' "$MANIFEST" 2>/dev/null || echo "false")"
+check 2 "a PreToolUse entry references gate-ledger-guard.sh" "true" "$HAS_GUARD_ENTRY"
+
+# Test 3: that entry's command uses CLAUDE_PLUGIN_ROOT (absolute, not repo-relative)
+USES_PLUGIN_ROOT="$(jq -e '[.hooks.PreToolUse[].hooks[]?.command // empty | select(contains("gate-ledger-guard.sh"))] | all(contains("CLAUDE_PLUGIN_ROOT"))' "$MANIFEST" 2>/dev/null || echo "false")"
+check 3 "gate-ledger-guard.sh command uses \${CLAUDE_PLUGIN_ROOT}" "true" "$USES_PLUGIN_ROOT"
+
+# Test 4: the entry's type is "command" (a bare {command:...} silently no-ops per hooks/README.md)
+GUARD_TYPE="$(jq -r '[.hooks.PreToolUse[] | select(.hooks[]?.command // "" | contains("gate-ledger-guard.sh"))][0].hooks[0].type // "missing"' "$MANIFEST" 2>/dev/null || echo "missing")"
+check 4 "gate-ledger-guard.sh hook entry has type=command" "command" "$GUARD_TYPE"
+
+# Test 5: matcher covers both Write and Edit (either "*" or a pattern naming both)
+GUARD_MATCHER="$(jq -r '[.hooks.PreToolUse[] | select(.hooks[]?.command // "" | contains("gate-ledger-guard.sh"))][0].matcher // ""' "$MANIFEST" 2>/dev/null || echo "")"
+MATCHER_OK="false"
+if [ "$GUARD_MATCHER" = "*" ] || { echo "$GUARD_MATCHER" | grep -q "Write" && echo "$GUARD_MATCHER" | grep -q "Edit"; }; then
+  MATCHER_OK="true"
+fi
+check 5 "matcher covers Write and Edit" "true" "$MATCHER_OK"
+
+echo ""
+echo "Results: $PASSED/$TOTAL passed"
+
+if [ "$FAILED" -gt 0 ] || [ "$((PASSED + FAILED))" -ne "$TOTAL" ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/check_settings_surface.py
+++ b/scripts/check_settings_surface.py
@@ -16,10 +16,12 @@ turn. Claude Code's directory-trust prompt does not help: it is per-directory,
 so checking out a branch inside an already-`/trust`ed repo does not re-prompt.
 Verified: a contributor-modified helper created a marker file in `$HOME` from the
 hook's argv on an ordinary Stop. The `/.claude/` git-ignore being blanket means
-the ONLY legal registration points for a repo-owned hook are per-machine and
-untracked: `.claude/settings.local.json` or user-global `~/.claude/settings.json`
-(the `gate-ledger-guard` / `build-routing-advisor` convention). This check pins
-the surface closed:
+the ONLY legal settings registration points for a repo-owned hook are per-machine
+and untracked: `.claude/settings.local.json` or user-global `~/.claude/settings.json`
+(the `build-routing-advisor` convention). A plugin manifest may separately
+declare hooks (see `.claude-plugin/plugin.json`, #591), which fire on explicit
+per-machine plugin enable — not a checkout side-effect. This check pins the
+settings surface closed:
 
   1. `.claude/settings.json` (and any other tracked file under `.claude/`) is
      NOT git-tracked — `git ls-files` must list nothing under `.claude/`.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -239,6 +239,7 @@ run python3 scripts/test_catalog.py
 # --- Build-routing advisor + reconcile hooks ---
 run bash hooks/tests/test-build-routing-advisor.sh
 run bash hooks/tests/test-gate-ledger-guard.sh
+run bash hooks/tests/test-plugin-manifest-hooks.sh
 run bash hooks/tests/tools/test-build-routing-reconcile.sh
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

Fixes the remaining half of #591: `hooks/gate-ledger-guard.sh` was inert not only from the dead payload shape (fixed by #594) but because **nothing ever registered it**. This PR now installs the hook via the plugin manifest, corrects the stale README registration claims, and restores `plugin.json` after #614 left it truncated to invalid JSON.

## What changed

**Item 3 — plugin install path** (the actual "inert" fix)
- `.claude-plugin/plugin.json`: add `hooks.PreToolUse` (matcher `Write|Edit`, command `bash "${CLAUDE_PLUGIN_ROOT}/hooks/gate-ledger-guard.sh"`). Enabling the crucible plugin now auto-registers the guard; `${CLAUDE_PLUGIN_ROOT}` keeps the path absolute regardless of cwd.
- New `hooks/tests/test-plugin-manifest-hooks.sh` (5 wiring checks) — structural only, explicitly **not** a runtime liveness check (that is #591 item 4, owned by #585).

**Item 5 — correct the stale README claims**
- Rewrote the `MIN-5-R6 Parity Note` that falsely claimed the hook was "Registered in user-global `~/.claude/settings.json` (verified 2026-04-15)". It never was; no settings.json ever installed it, which is precisely why it sat inert.
- `Setup` now documents plugin auto-install plus the per-machine settings fallback.

**#614 invalid-JSON restoration**
- `.claude-plugin/plugin.json` was truncated to 4 lines by `44a14eb` / `f0a036b` (lost `author`/`homepage`/`repository`/`license`/`keywords`/`skills` path **and** the closing brace). Restored the full valid structure; description bump `50 -> 51` (orchestrator skill) retained.

**Test hardening on main's post-#594 suite (TOTAL 25 → 26)**
- Ported the legacy `.tool/.input` Edit-path fallback test (26), which #594 never exercised.
- Added TOTAL-gating (`PASSED+FAILED != TOTAL` → hard fail) so a silently-skipped test cannot pass CI.

Hook body is byte-identical to `main` (already carries the #594 payload-shape fix plus CHAIN-N1/R2BA-1 and R2BA-3).

## Relationship to #594 / #604

- **#594 supersedes** this branch's original items 1+2 (payload-shape fix + anti-regression tests). This PR keeps `main`'s hook/test versions and layers items 3+5 on top — no mechanical re-merge of two test suites.
- **#604 reconciliation:** #604's "Hook Registration Surface" contract records the plugin manifest as a **third** registration mechanism — opt-in per-machine plugin enable (an affirmative execute-code grant), not a committed-`.claude/settings.json` checkout side-effect — so it does not re-open the siege S-1 surface. Review rule extended to cover `.claude-plugin/plugin.json`.

## Open follow-ups (not in this PR)

- **#623** — `hooks/session-index.sh` has the same dead `.tool`/`.input` payload shape (filed separately, standalone).
- **#591 item 4** (positive runtime liveness signal) remains open, owned by the #585 auth-boundary design.

## Testing

`bash scripts/run_tests.sh` — **98/98 suite invocations pass** (26/26 gate-ledger-guard, 5/5 plugin-manifest, plus catalog + settings-surface checks).